### PR TITLE
Add permissions for Actions workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,8 @@ name: Update Docs
 permissions:
   contents: read
   pages: write
+  checks: write
+  statuses: write
 
 on:
   workflow_dispatch:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,8 @@ name: Rust CI
 
 permissions:
   contents: read
+  checks: write
+  statuses: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This adds permissions for workflow actions, currently [failing](https://github.com/DataDog/substrait-explain/actions/runs/15907037162/job/44865248203) due to low permissions. 