### PR TITLE
Add id-token permission

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ permissions:
   pages: write
   checks: write
   statuses: write
+  id-token: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Description

This PR adds the missing `id-token: write` permission to the docs workflow to fix OIDC authentication errors with the [`actions/deploy-pages@v4`](https://github.com/actions/deploy-pages/tree/v4/) action. The workflow was failing with the error `"Ensure GITHUB_TOKEN has permission 'id-token: write'"` during deployment.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Example update
- [ ] Other (please describe)

## Testing

- [ ] Added tests for new functionality
- [x] All existing tests pass
- [ ] Ran examples to verify behavior

## Checklist

- [x] Code follows Rust conventions
- [ ] Documentation updated if needed
- [x] No breaking changes (or breaking changes documented)
- [x] Pre-commit hooks pass

## Related Issues

Fixes deployment authentication error in GitHub Pages workflow

## Changes made:

- Added `id-token: write` permission to `.github/workflows/docs.yml`
- This enables OIDC authentication required by [`actions/deploy-pages@v4`](https://github.com/actions/deploy-pages/tree/v4/)
- Should resolves the `"Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable"` [error](https://github.com/DataDog/substrait-explain/actions/runs/15914077033/job/44888102107)
