### PR TITLE
chore: update CODEOWNERS to use @Datadog/substrait team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # Limit ownership to those directly working in this area. Others are welcome to
 # provide PRs.
 
-* @Datadog/query-semantics @wackywendell
+* @Datadog/substrait @wackywendell


### PR DESCRIPTION
## Description

This PR updates the `CODEOWNERS` file to point to a publicly visible team.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Example update
- [x] Other (please describe): Chore (ownership metadata update)
