### PR TITLE
Add support for float, boolean, and date/time literals

### DIFF
--- a/tests/literal_roundtrip.rs
+++ b/tests/literal_roundtrip.rs
@@ -47,3 +47,36 @@ Root[result]
 "#;
     roundtrip_plan(plan);
 }
+
+#[test]
+fn test_date_literal_roundtrip() {
+    let plan = r#"
+=== Plan
+Root[result]
+  Project['2023-12-25':date]
+    Read[data => a:i64]
+"#;
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_time_literal_roundtrip() {
+    let plan = r#"
+=== Plan
+Root[result]
+  Project['14:30:45':time]
+    Read[data => a:i64]
+"#;
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_timestamp_literal_roundtrip() {
+    let plan = r#"
+=== Plan
+Root[result]
+  Project['2023-01-01T12:00:00':timestamp]
+    Read[data => a:i64]
+"#;
+    roundtrip_plan(plan);
+}


### PR DESCRIPTION
## Summary

This PR implements comprehensive support for additional literal types in the Substrait text format parser and textifier:

- **Date literals**: Parse and format date values (e.g., `'2023-01-01':date`)
- **Time literals**: Parse and format time values (e.g., `'14:30:45':time`)
- **Timestamp literals**: Parse and format timestamp values (e.g., `'2023-01-01T12:00:00':timestamp`)

### Testing
- Added comprehensive roundtrip tests for all new literal types
- Refactored common test utilities to eliminate code duplication
- All tests pass including full roundtrip functionality

## Test Plan
- [x] All existing tests continue to pass
- [x] New roundtrip tests verify parsing and formatting work correctly
- [x] Unit tests cover edge cases and error conditions
- [x] Pre-commit hooks pass (formatting and linting)

Closes #22