### PR TITLE
Split out CI jobs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,17 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Cache cargo dependencies / build outputs. See
-      # https://github.com/actions/cache/blob/main/examples.md#rust---cargo
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-docs-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # 2.8.1
 
       - name: Build docs
         id: build_docs

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,19 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          # Cache based on OS and cargo.lock
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          # Cache fallback to just OS
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+        # Uses rust cache action, stnadard in Rust community.
+        # Added to allowlist here:
+        # https://github.com/DataDog/substrait-explain/settings/actions
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # 2.8.1
       - name: Lint with Clippy
         run: cargo clippy --features protoc -- -D warnings
       - name: Lint with Clippy (All features)
@@ -52,17 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # 2.8.1
 
       - name: Run tests
         run: cargo test --all-features --verbose


### PR DESCRIPTION
The current setup has one big job with all the steps in it. If formatting fails, so do all the rest.

Let's put this in multiple jobs so they can happen in parallel, and tests can run even if formatting or linting fails.

Addresses #48 .