### PR TITLE
Use Swatinem rust-cache in GitHub Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,17 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Cache cargo dependencies / build outputs. See
-      # https://github.com/actions/cache/blob/main/examples.md#rust---cargo
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-docs-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # 2.8.1
 
       - name: Build docs
         id: build_docs

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,19 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          # Cache based on OS and cargo.lock
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          # Cache fallback to just OS
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+        # Uses rust cache action, stnadard in Rust community.
+        # Added to allowlist here:
+        # https://github.com/DataDog/substrait-explain/settings/actions
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # 2.8.1
       - name: Lint with Clippy
         run: cargo clippy --features protoc -- -D warnings
       - name: Lint with Clippy (All features)
@@ -52,17 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # 2.8.1
 
       - name: Run tests
         run: cargo test --all-features --verbose


### PR DESCRIPTION
### Motivation
- Standardize Rust caching to the community-maintained action and pin the same release used in Datadog CI by replacing `actions/cache@v4` with `Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # 2.8.1`.

### Description
- Replaced the explicit `actions/cache@v4` cache steps with `Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # 2.8.1` in ` .github/workflows/rust.yml` (lint and test jobs) and ` .github/workflows/docs.yml` (build_docs job).

### Testing
- No automated tests were run because this is a CI workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698377fbe39c8331b981af9e589795b5)