### PR TITLE
feat: support VirtualTable Read with inline and verbose text formats

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -527,6 +527,91 @@ Root[result2]
 # assert_eq!(plan.relations.len(), 2);
 ```
 
+### VirtualTable Read Relation
+
+A VirtualTable read embeds inline data directly in the plan, similar to SQL's `VALUES` clause. Instead of referencing a catalog table, the data rows are specified as part of the relation.
+
+The `Read:Virtual` relation uses the same `ReadRel` protobuf message with `ReadType::VirtualTable`, where each row is a `nested::Struct` containing expressions.
+
+#### Syntax
+
+There are two forms: **inline** (rows as arguments) and **verbose** (`+ Row` addenda).
+
+**Inline form:**
+
+`"Read:Virtual" "[" (virtual_row ("," virtual_row)*)? "=>" named_column_list "]"`
+
+Where `virtual_row := "(" expression ("," expression)* ")"` — a parenthesized tuple of expressions forming one row.
+
+**Verbose form:**
+
+```text
+"Read:Virtual" "[" "_" "=>" named_column_list "]"
+  ("+ Row" "[" expression ("," expression)* "]")*
+```
+
+The `+ Row` lines are addenda attached to the `Read:Virtual` relation (same structural role as `+ Enh:` / `+ Opt:` lines). They must appear before any child relations.
+
+Both forms are always accepted by the parser. The textifier uses inline form when `rows * columns <= 8`, and verbose form otherwise.
+
+**Mixed form (accepted, not recommended):** If a `Read:Virtual` has both inline rows and `+ Row` addenda, the inline rows come first, followed by the addendum rows. The textifier will never produce mixed form.
+
+#### Components
+
+- `virtual_row` - parenthesized tuple of expressions, one per row
+- `expression` - any expression (literal, field reference, function call)
+- `named_column_list` - output column names with type annotations
+- `_` - empty marker (no inline rows; rows provided via `+ Row` addenda)
+
+#### Examples
+
+Inline form with two rows:
+
+```rust
+# use substrait_explain::parser::Parser;
+#
+# let plan_text = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[(1, 'alice'), (2, 'bob') => id:i64, name:string]
+# "#;
+#
+# let plan = Parser::parse(plan_text).unwrap();
+# assert_eq!(plan.relations.len(), 1);
+```
+
+Verbose form with `+ Row` addenda:
+
+```rust
+# use substrait_explain::parser::Parser;
+#
+# let plan_text = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[_ => id:i64, name:string]
+    + Row[1, 'alice']
+    + Row[2, 'bob']
+# "#;
+#
+# let plan = Parser::parse(plan_text).unwrap();
+# assert_eq!(plan.relations.len(), 1);
+```
+
+Empty virtual table (no rows):
+
+```rust
+# use substrait_explain::parser::Parser;
+#
+# let plan_text = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[_ => id:i64, name:string]
+# "#;
+#
+# let plan = Parser::parse(plan_text).unwrap();
+# assert_eq!(plan.relations.len(), 1);
+```
+
 ### Filter Relation
 
 #### Syntax

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -53,8 +53,8 @@ pub enum ParseError {
     #[error("Unknown extension relation type: {0}")]
     UnknownExtensionRelationType(String),
 
-    #[error("Validation error: {0}")]
-    ValidationError(String),
+    #[error("Invalid input at line {0}: {1}")]
+    ValidationError(ParseContext, String),
 
     #[error("Error parsing section header on line {0}: {1}")]
     Initial(ParseContext, #[source] MessageParseError),

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -212,6 +212,9 @@ named_column      = { name ~ ":" ~ type }
 named_column_list = { (named_column ~ ("," ~ sp ~ named_column)*)? }
 
 planNode = {
+    // virtual_read_relation must precede read_relation: both start with "Read",
+    // and PEG tries alternatives in order — the longer "Read:Virtual" prefix
+    // must be attempted first.
     virtual_read_relation
   | read_relation
   | filter_relation

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -212,7 +212,8 @@ named_column      = { name ~ ":" ~ type }
 named_column_list = { (named_column ~ ("," ~ sp ~ named_column)*)? }
 
 planNode = {
-    read_relation
+    virtual_read_relation
+  | read_relation
   | filter_relation
   | project_relation
   | aggregate_relation
@@ -220,6 +221,7 @@ planNode = {
   | fetch_relation
   | join_relation
   | extension_relation
+  | row_addendum
   | adv_extension
 }
 
@@ -233,6 +235,16 @@ root_relation  = { "Root" ~ "[" ~ root_name_list ~ "]" }
 root_name_list = { (name ~ (sp ~ "," ~ sp ~ name)*)? }
 
 read_relation = { "Read" ~ "[" ~ table_name ~ sp ~ "=>" ~ sp ~ named_column_list ~ "]" }
+
+// VirtualTable read: Read:Virtual[rows => columns] or Read:Virtual[_ => columns]
+// Inline rows are parenthesized tuples; verbose rows use + Row addenda.
+virtual_read_relation = { "Read:Virtual" ~ "[" ~ virtual_read_args ~ sp ~ "=>" ~ sp ~ named_column_list ~ "]" }
+virtual_read_args     = { virtual_row_list | empty }
+virtual_row_list      = { virtual_row ~ (sp ~ "," ~ sp ~ virtual_row)* }
+virtual_row           = { "(" ~ sp ~ expression_list ~ sp ~ ")" }
+
+// Row addendum for verbose VirtualTable reads: + Row[expr, expr, ...]
+row_addendum = { "+" ~ sp ~ "Row" ~ "[" ~ expression_list ~ "]" }
 
 filter_relation = { "Filter" ~ "[" ~ expression ~ sp ~ "=>" ~ sp ~ reference_list ~ "]" }
 reference_list  = { (reference ~ (sp ~ "," ~ sp ~ reference)*)? }

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -15,9 +15,7 @@ use substrait::proto::{
     RelCommon, SortField, SortRel, Type, aggregate_rel, join_rel, read_rel, r#type,
 };
 
-use super::{
-    ErrorKind, MessageParseError, ParsePair, Rule, RuleIter, ScopedParsePair, unwrap_single_pair,
-};
+use super::{MessageParseError, ParsePair, Rule, RuleIter, ScopedParsePair, unwrap_single_pair};
 use crate::extensions::any::Any;
 use crate::extensions::registry::{ExtensionError, ExtensionType};
 use crate::extensions::{ExtensionArgs, ExtensionRegistry, SimpleExtensions};
@@ -89,10 +87,25 @@ impl<'a> RelationParsingContext<'a> {
 /// relation. Carried from `build_rel` into [`RelationParsePair::into_rel`]
 /// so each relation type can apply its own advanced extension and row
 /// handling.
+#[derive(Default)]
 pub struct RelationAddenda {
-    /// Pre-parsed `+ Row` data. Only consumed by [`ParsedVirtualReadRel`].
+    /// Pre-parsed `+ Row` data. Only consumed by [`ReadRel`]s with a
+    /// [`VirtualTable`](`substrait::proto::read_rel::ReadType::VirtualTable`).
     pub rows: Vec<nested::Struct>,
     pub advanced_extension: Option<AdvancedExtension>,
+}
+
+impl RelationAddenda {
+    /// Assert that no row addenda were attached. Call this in every
+    /// [`RelationParsePair::into_rel`] implementation that does not consume
+    /// rows (i.e., everything except a `Read:Virtual`).
+    pub fn assert_no_rows(&self) {
+        assert!(
+            self.rows.is_empty(),
+            "row addenda are only valid on Read:Virtual relations; got {} row(s)",
+            self.rows.len()
+        );
+    }
 }
 
 /// A trait for parsing relations with full context for tree building.
@@ -316,6 +329,7 @@ impl RelationParsePair for ReadRel {
         input_field_count: usize,
     ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
+        // ReadRel is a leaf node - it should have no input children and 0 input fields
         if !input_children.is_empty() {
             return Err(MessageParseError::invalid(
                 Self::message(),
@@ -324,16 +338,10 @@ impl RelationParsePair for ReadRel {
             ));
         }
         if input_field_count != 0 {
-            let error = pest::error::Error::new_from_span(
-                pest::error::ErrorVariant::CustomError {
-                    message: "ReadRel should have 0 input fields".to_string(),
-                },
-                pair.as_span(),
-            );
-            return Err(MessageParseError::new(
+            return Err(MessageParseError::invalid(
                 "ReadRel",
-                ErrorKind::InvalidValue,
-                Box::new(error),
+                pair.as_span(),
+                "ReadRel should have 0 input fields",
             ));
         }
 
@@ -357,6 +365,7 @@ impl RelationParsePair for ReadRel {
     }
 
     fn into_rel(mut self, addenda: RelationAddenda) -> Rel {
+        addenda.assert_no_rows();
         self.advanced_extension = addenda.advanced_extension;
         Rel {
             rel_type: Some(RelType::Read(Box::new(self))),
@@ -380,9 +389,9 @@ pub(crate) fn parse_row_addendum(
 /// Parsed `Read:Virtual[rows => columns]` relation. Needs a newtype because
 /// the proto type is `ReadRel` (same as NamedTable), but the grammar rule and
 /// addenda handling differ.
-pub(crate) struct ParsedVirtualReadRel(ReadRel);
+pub(crate) struct VirtualReadRel(ReadRel);
 
-impl RelationParsePair for ParsedVirtualReadRel {
+impl RelationParsePair for VirtualReadRel {
     fn rule() -> Rule {
         Rule::virtual_read_relation
     }
@@ -418,7 +427,7 @@ impl RelationParsePair for ParsedVirtualReadRel {
         // collection path is available.
         let output_count = columns.len();
         Ok((
-            ParsedVirtualReadRel(ReadRel {
+            VirtualReadRel(ReadRel {
                 base_schema: Some(build_named_struct(columns)),
                 read_type: Some(read_rel::ReadType::VirtualTable(read_rel::VirtualTable {
                     expressions: rows,
@@ -434,6 +443,8 @@ impl RelationParsePair for ParsedVirtualReadRel {
         // Extend inline rows with addenda rows from `+ Row` lines.
         if let Some(read_rel::ReadType::VirtualTable(ref mut vt)) = self.0.read_type {
             vt.expressions.extend(addenda.rows);
+        } else {
+            unreachable!("Constructed Read:Virtual with no VirtualTable")
         }
         self.0.advanced_extension = addenda.advanced_extension;
         Rel {
@@ -455,7 +466,7 @@ fn build_named_struct(columns: Vec<Column>) -> NamedStruct {
     }
 }
 
-/// Parse `virtual_read_args`: either `empty` or a list of row tuples.
+/// `Read:Virtual` positional args: either `empty` or a list of row tuples.
 fn parse_virtual_read_args(extensions: &SimpleExtensions, pair: Pair<Rule>) -> Vec<nested::Struct> {
     assert_eq!(pair.as_rule(), Rule::virtual_read_args);
     let inner = unwrap_single_pair(pair);
@@ -476,6 +487,7 @@ fn parse_virtual_read_args(extensions: &SimpleExtensions, pair: Pair<Rule>) -> V
 fn parse_virtual_row(extensions: &SimpleExtensions, pair: Pair<Rule>) -> nested::Struct {
     assert_eq!(pair.as_rule(), Rule::virtual_row);
     let expression_list = unwrap_single_pair(pair);
+    assert_eq!(expression_list.as_rule(), Rule::expression_list);
     nested::Struct {
         fields: parse_expression_list(extensions, expression_list),
     }
@@ -491,6 +503,7 @@ impl RelationParsePair for FilterRel {
     }
 
     fn into_rel(mut self, addenda: RelationAddenda) -> Rel {
+        addenda.assert_no_rows();
         self.advanced_extension = addenda.advanced_extension;
         Rel {
             rel_type: Some(RelType::Filter(Box::new(self))),
@@ -507,6 +520,7 @@ impl RelationParsePair for FilterRel {
         let input = expect_one_child(Self::message(), &pair, input_children)?;
         let mut iter = RuleIter::from(pair.into_inner());
         let condition = iter.parse_next_scoped::<Expression>(extensions)?;
+        // references (which become the emit)
         let references_pair = iter.pop(Rule::reference_list);
         iter.done();
 
@@ -540,6 +554,7 @@ impl RelationParsePair for ProjectRel {
     }
 
     fn into_rel(mut self, addenda: RelationAddenda) -> Rel {
+        addenda.assert_no_rows();
         self.advanced_extension = addenda.advanced_extension;
         Rel {
             rel_type: Some(RelType::Project(Box::new(self))),
@@ -607,6 +622,7 @@ impl RelationParsePair for AggregateRel {
     }
 
     fn into_rel(mut self, addenda: RelationAddenda) -> Rel {
+        addenda.assert_no_rows();
         self.advanced_extension = addenda.advanced_extension;
         Rel {
             rel_type: Some(RelType::Aggregate(Box::new(self))),
@@ -850,6 +866,7 @@ impl RelationParsePair for SortRel {
     }
 
     fn into_rel(mut self, addenda: RelationAddenda) -> Rel {
+        addenda.assert_no_rows();
         self.advanced_extension = addenda.advanced_extension;
         Rel {
             rel_type: Some(RelType::Sort(Box::new(self))),
@@ -1010,6 +1027,7 @@ impl RelationParsePair for FetchRel {
     }
 
     fn into_rel(mut self, addenda: RelationAddenda) -> Rel {
+        addenda.assert_no_rows();
         self.advanced_extension = addenda.advanced_extension;
         Rel {
             rel_type: Some(RelType::Fetch(Box::new(self))),
@@ -1026,6 +1044,9 @@ impl RelationParsePair for FetchRel {
         let input = expect_one_child(Self::message(), &pair, input_children)?;
         let mut iter = RuleIter::from(pair.into_inner());
 
+        // Extract all pairs before any validation: RuleIter's Drop panics on
+        // incomplete consumption, so we must exhaust the iterator before any
+        // early return. Validation runs after iter.done() below.
         let (limit_pair, offset_pair) = match iter.try_pop(Rule::fetch_named_arg_list) {
             None => {
                 iter.pop(Rule::empty);
@@ -1110,6 +1131,7 @@ impl RelationParsePair for JoinRel {
     }
 
     fn into_rel(mut self, addenda: RelationAddenda) -> Rel {
+        addenda.assert_no_rows();
         self.advanced_extension = addenda.advanced_extension;
         Rel {
             rel_type: Some(RelType::Join(Box::new(self))),
@@ -1230,12 +1252,9 @@ mod tests {
         let filter = FilterRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::filter_relation, "Filter[$1 => $0, $1, $2]"),
-            vec![Box::new(example_read_relation().into_rel(
-                RelationAddenda {
-                    rows: vec![],
-                    advanced_extension: None,
-                },
-            ))],
+            vec![Box::new(
+                example_read_relation().into_rel(RelationAddenda::default()),
+            )],
             3,
         )
         .unwrap()
@@ -1254,12 +1273,9 @@ mod tests {
         let project = ProjectRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::project_relation, "Project[$0, $1, 42]"),
-            vec![Box::new(example_read_relation().into_rel(
-                RelationAddenda {
-                    rows: vec![],
-                    advanced_extension: None,
-                },
-            ))],
+            vec![Box::new(
+                example_read_relation().into_rel(RelationAddenda::default()),
+            )],
             3,
         )
         .unwrap()
@@ -1283,12 +1299,9 @@ mod tests {
         let project = ProjectRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::project_relation, "Project[42, $0, 100, $2, $1]"),
-            vec![Box::new(example_read_relation().into_rel(
-                RelationAddenda {
-                    rows: vec![],
-                    advanced_extension: None,
-                },
-            ))],
+            vec![Box::new(
+                example_read_relation().into_rel(RelationAddenda::default()),
+            )],
             5, // Assume 5 input fields
         )
         .unwrap()
@@ -1321,12 +1334,9 @@ mod tests {
                 Rule::aggregate_relation,
                 "Aggregate[($0, $1), _ => sum($2), $0, count($2)]",
             ),
-            vec![Box::new(example_read_relation().into_rel(
-                RelationAddenda {
-                    rows: vec![],
-                    advanced_extension: None,
-                },
-            ))],
+            vec![Box::new(
+                example_read_relation().into_rel(RelationAddenda::default()),
+            )],
             3,
         )
         .unwrap()
@@ -1368,12 +1378,9 @@ mod tests {
                 Rule::aggregate_relation,
                 "Aggregate[$0 => sum($1), $0, count($1)]",
             ),
-            vec![Box::new(example_read_relation().into_rel(
-                RelationAddenda {
-                    rows: vec![],
-                    advanced_extension: None,
-                },
-            ))],
+            vec![Box::new(
+                example_read_relation().into_rel(RelationAddenda::default()),
+            )],
             3,
         )
         .unwrap()
@@ -1409,12 +1416,9 @@ mod tests {
         let aggregate = AggregateRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::aggregate_relation, "Aggregate[$2, $0 => sum($1)]"),
-            vec![Box::new(example_read_relation().into_rel(
-                RelationAddenda {
-                    rows: vec![],
-                    advanced_extension: None,
-                },
-            ))],
+            vec![Box::new(
+                example_read_relation().into_rel(RelationAddenda::default()),
+            )],
             3,
         )
         .unwrap()
@@ -1440,12 +1444,9 @@ mod tests {
                 Rule::aggregate_relation,
                 "Aggregate[_ => sum($0), count($1)]",
             ),
-            vec![Box::new(example_read_relation().into_rel(
-                RelationAddenda {
-                    rows: vec![],
-                    advanced_extension: None,
-                },
-            ))],
+            vec![Box::new(
+                example_read_relation().into_rel(RelationAddenda::default()),
+            )],
             3,
         )
         .unwrap()
@@ -1496,10 +1497,7 @@ mod tests {
                 Rule::aggregate_relation,
                 "Aggregate[($0, $1, $2), ($2, $0), ($1), _ => $0, $1, $2, count($3)]",
             ),
-            vec![Box::new(read_rel.into_rel(RelationAddenda {
-                rows: vec![],
-                advanced_extension: None,
-            }))],
+            vec![Box::new(read_rel.into_rel(RelationAddenda::default()))],
             4,
         )
         .unwrap()
@@ -1526,12 +1524,9 @@ mod tests {
         let fetch_rel = FetchRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::fetch_relation, "Fetch[limit=10, offset=5 => $0]"),
-            vec![Box::new(example_read_relation().into_rel(
-                RelationAddenda {
-                    rows: vec![],
-                    advanced_extension: None,
-                },
-            ))],
+            vec![Box::new(
+                example_read_relation().into_rel(RelationAddenda::default()),
+            )],
             3,
         )
         .unwrap()
@@ -1561,12 +1556,9 @@ mod tests {
                 let result = FetchRel::parse_pair_with_context(
                     &extensions,
                     pair,
-                    vec![Box::new(example_read_relation().into_rel(
-                        RelationAddenda {
-                            rows: vec![],
-                            advanced_extension: None,
-                        },
-                    ))],
+                    vec![Box::new(
+                        example_read_relation().into_rel(RelationAddenda::default()),
+                    )],
                     3,
                 );
                 assert!(result.is_err());
@@ -1597,12 +1589,9 @@ mod tests {
                 let result = FetchRel::parse_pair_with_context(
                     &extensions,
                     pair,
-                    vec![Box::new(example_read_relation().into_rel(
-                        RelationAddenda {
-                            rows: vec![],
-                            advanced_extension: None,
-                        },
-                    ))],
+                    vec![Box::new(
+                        example_read_relation().into_rel(RelationAddenda::default()),
+                    )],
                     3,
                 );
                 assert!(result.is_err());
@@ -1625,14 +1614,8 @@ mod tests {
             .with_function(1, 10, "eq")
             .extensions;
 
-        let left_rel = example_read_relation().into_rel(RelationAddenda {
-            rows: vec![],
-            advanced_extension: None,
-        });
-        let right_rel = example_read_relation().into_rel(RelationAddenda {
-            rows: vec![],
-            advanced_extension: None,
-        });
+        let left_rel = example_read_relation().into_rel(RelationAddenda::default());
+        let right_rel = example_read_relation().into_rel(RelationAddenda::default());
 
         let join = JoinRel::parse_pair_with_context(
             &extensions,
@@ -1672,14 +1655,8 @@ mod tests {
             .with_function(1, 10, "eq")
             .extensions;
 
-        let left_rel = example_read_relation().into_rel(RelationAddenda {
-            rows: vec![],
-            advanced_extension: None,
-        });
-        let right_rel = example_read_relation().into_rel(RelationAddenda {
-            rows: vec![],
-            advanced_extension: None,
-        });
+        let left_rel = example_read_relation().into_rel(RelationAddenda::default());
+        let right_rel = example_read_relation().into_rel(RelationAddenda::default());
 
         let join = JoinRel::parse_pair_with_context(
             &extensions,
@@ -1709,14 +1686,8 @@ mod tests {
             .with_function(1, 10, "eq")
             .extensions;
 
-        let left_rel = example_read_relation().into_rel(RelationAddenda {
-            rows: vec![],
-            advanced_extension: None,
-        });
-        let right_rel = example_read_relation().into_rel(RelationAddenda {
-            rows: vec![],
-            advanced_extension: None,
-        });
+        let left_rel = example_read_relation().into_rel(RelationAddenda::default());
+        let right_rel = example_read_relation().into_rel(RelationAddenda::default());
 
         let join = JoinRel::parse_pair_with_context(
             &extensions,
@@ -1756,12 +1727,9 @@ mod tests {
         let result = JoinRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::join_relation, "Join[&Inner, eq($0, $1) => $0, $1]"),
-            vec![Box::new(example_read_relation().into_rel(
-                RelationAddenda {
-                    rows: vec![],
-                    advanced_extension: None,
-                },
-            ))],
+            vec![Box::new(
+                example_read_relation().into_rel(RelationAddenda::default()),
+            )],
             3,
         );
         assert!(result.is_err());
@@ -1771,18 +1739,9 @@ mod tests {
             &extensions,
             parse_exact(Rule::join_relation, "Join[&Inner, eq($0, $1) => $0, $1]"),
             vec![
-                Box::new(example_read_relation().into_rel(RelationAddenda {
-                    rows: vec![],
-                    advanced_extension: None,
-                })),
-                Box::new(example_read_relation().into_rel(RelationAddenda {
-                    rows: vec![],
-                    advanced_extension: None,
-                })),
-                Box::new(example_read_relation().into_rel(RelationAddenda {
-                    rows: vec![],
-                    advanced_extension: None,
-                })),
+                Box::new(example_read_relation().into_rel(RelationAddenda::default())),
+                Box::new(example_read_relation().into_rel(RelationAddenda::default())),
+                Box::new(example_read_relation().into_rel(RelationAddenda::default())),
             ],
             9,
         );

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -4,7 +4,7 @@ use pest::iterators::Pair;
 use prost::Message;
 use substrait::proto::aggregate_rel::Grouping;
 use substrait::proto::expression::literal::LiteralType;
-use substrait::proto::expression::{Literal, RexType};
+use substrait::proto::expression::{Literal, RexType, nested};
 use substrait::proto::fetch_rel::{CountMode, OffsetMode};
 use substrait::proto::rel::RelType;
 use substrait::proto::rel_common::{Emit, EmitKind};
@@ -326,19 +326,8 @@ impl RelationParsePair for ReadRel {
         let columns = iter.parse_next_scoped::<NamedColumnList>(extensions)?.0;
         iter.done();
 
-        let (names, types): (Vec<_>, Vec<_>) = columns.into_iter().map(|c| (c.name, c.typ)).unzip();
-        let struct_ = r#type::Struct {
-            types,
-            type_variation_reference: 0,
-            nullability: r#type::Nullability::Required as i32,
-        };
-        let named_struct = NamedStruct {
-            names,
-            r#struct: Some(struct_),
-        };
-
         let read_rel = ReadRel {
-            base_schema: Some(named_struct),
+            base_schema: Some(build_named_struct(columns)),
             read_type: Some(read_rel::ReadType::NamedTable(read_rel::NamedTable {
                 names: table,
                 advanced_extension: None,
@@ -347,6 +336,92 @@ impl RelationParsePair for ReadRel {
         };
 
         Ok(read_rel)
+    }
+}
+
+/// Parse a `Read:Virtual[...]` relation with optional `+ Row` addenda,
+/// building the `ReadRel` with all row data in one shot.
+///
+/// Not a `RelationParsePair` because it needs additional row addenda data
+/// that the trait interface doesn't support.
+pub(crate) fn parse_virtual_read(
+    extensions: &SimpleExtensions,
+    pair: Pair<Rule>,
+    row_addenda: Vec<Pair<Rule>>,
+) -> Result<(Rel, usize), MessageParseError> {
+    assert_eq!(pair.as_rule(), Rule::virtual_read_relation);
+
+    let mut iter = RuleIter::from(pair.into_inner());
+    let args_pair = iter.pop(Rule::virtual_read_args);
+    let mut rows = parse_virtual_read_args(extensions, args_pair);
+    let columns = iter.parse_next_scoped::<NamedColumnList>(extensions)?.0;
+    iter.done();
+
+    // Append addenda rows after inline rows
+    for addendum_pair in row_addenda {
+        let expression_list = unwrap_single_pair(addendum_pair);
+        assert_eq!(expression_list.as_rule(), Rule::expression_list);
+        rows.push(nested::Struct {
+            fields: parse_expression_list(extensions, expression_list),
+        });
+    }
+
+    // TODO: Validate that each row has the same number of expressions as columns.
+    // Currently no parser-side warning mechanism exists (the parser is fail-fast,
+    // and a width mismatch isn't a syntax error). Consider adding once a warning
+    // collection path is available.
+    let column_count = columns.len();
+    let named_struct = build_named_struct(columns);
+    let rel = Rel {
+        rel_type: Some(RelType::Read(Box::new(ReadRel {
+            base_schema: Some(named_struct),
+            read_type: Some(read_rel::ReadType::VirtualTable(read_rel::VirtualTable {
+                expressions: rows,
+                ..Default::default()
+            })),
+            ..Default::default()
+        }))),
+    };
+
+    Ok((rel, column_count))
+}
+
+/// Build a `NamedStruct` from parsed columns.
+fn build_named_struct(columns: Vec<Column>) -> NamedStruct {
+    let (names, types): (Vec<_>, Vec<_>) = columns.into_iter().map(|c| (c.name, c.typ)).unzip();
+    NamedStruct {
+        names,
+        r#struct: Some(r#type::Struct {
+            types,
+            type_variation_reference: 0,
+            nullability: r#type::Nullability::Required as i32,
+        }),
+    }
+}
+
+/// Parse `virtual_read_args`: either `empty` or a list of row tuples.
+fn parse_virtual_read_args(extensions: &SimpleExtensions, pair: Pair<Rule>) -> Vec<nested::Struct> {
+    assert_eq!(pair.as_rule(), Rule::virtual_read_args);
+    let inner = unwrap_single_pair(pair);
+    match inner.as_rule() {
+        Rule::empty => vec![],
+        Rule::virtual_row_list => inner
+            .into_inner()
+            .map(|row| parse_virtual_row(extensions, row))
+            .collect(),
+        _ => unreachable!(
+            "Unexpected rule in virtual_read_args: {:?}",
+            inner.as_rule()
+        ),
+    }
+}
+
+/// Parse a single `virtual_row` (`(expr, expr, ...)`) into a `nested::Struct`.
+fn parse_virtual_row(extensions: &SimpleExtensions, pair: Pair<Rule>) -> nested::Struct {
+    assert_eq!(pair.as_rule(), Rule::virtual_row);
+    let expression_list = unwrap_single_pair(pair);
+    nested::Struct {
+        fields: parse_expression_list(extensions, expression_list),
     }
 }
 
@@ -605,7 +680,10 @@ fn parse_grouping_set(extensions: &SimpleExtensions, pair: Pair<'_, Rule>) -> Ve
 }
 
 /// Grammar: `expression_list = { expression ~ ("," ~ expression)* }`
-fn parse_expression_list(extensions: &SimpleExtensions, pair: Pair<'_, Rule>) -> Vec<Expression> {
+pub(crate) fn parse_expression_list(
+    extensions: &SimpleExtensions,
+    pair: Pair<'_, Rule>,
+) -> Vec<Expression> {
     pair.into_inner()
         .map(|expr_pair| {
             Expression::parse_pair(extensions, expr_pair)

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -5,9 +5,10 @@ use prost::Message;
 use substrait::proto::aggregate_rel::Grouping;
 use substrait::proto::expression::literal::LiteralType;
 use substrait::proto::expression::{Literal, RexType, nested};
+use substrait::proto::extensions::AdvancedExtension;
 use substrait::proto::fetch_rel::{CountMode, OffsetMode};
 use substrait::proto::rel::RelType;
-use substrait::proto::rel_common::{Emit, EmitKind};
+use substrait::proto::rel_common::{Direct, Emit, EmitKind};
 use substrait::proto::sort_field::{SortDirection, SortKind};
 use substrait::proto::{
     AggregateRel, Expression, FetchRel, FilterRel, JoinRel, NamedStruct, ProjectRel, ReadRel, Rel,
@@ -84,28 +85,36 @@ impl<'a> RelationParsingContext<'a> {
     }
 }
 
-/// A trait for parsing relations with full context needed for tree building.
-/// This includes extensions, the parsed pair, input children, and output field count.
+/// Processed `+`-prefixed addenda (`+ Enh:` / `+ Opt:` / `+ Row`) for a
+/// relation. Carried from `build_rel` into [`RelationParsePair::into_rel`]
+/// so each relation type can apply its own advanced extension and row
+/// handling.
+pub struct RelationAddenda {
+    /// Pre-parsed `+ Row` data. Only consumed by [`ParsedVirtualReadRel`].
+    pub rows: Vec<nested::Struct>,
+    pub advanced_extension: Option<AdvancedExtension>,
+}
+
+/// A trait for parsing relations with full context for tree building.
 pub trait RelationParsePair: Sized {
     fn rule() -> Rule;
-
     fn message() -> &'static str;
 
-    /// Parse a relation with full context for tree building.
+    /// Parse the grammar pair into this relation type and its output field
+    /// count.
     ///
-    /// Args:
-    /// - extensions: The extensions context
-    /// - pair: The parsed pest pair
-    /// - input_children: The input relations (for wiring)
-    /// - input_field_count: Number of output fields from input children (for output mapping)
+    /// Returns `(Self, usize)` where `usize` is the output field count —
+    /// computed during parsing when `input_field_count` is available.
     fn parse_pair_with_context(
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
         input_children: Vec<Box<Rel>>,
-        _input_field_count: usize,
-    ) -> Result<Self, MessageParseError>;
+        input_field_count: usize,
+    ) -> Result<(Self, usize), MessageParseError>;
 
-    fn into_rel(self) -> Rel;
+    /// Consume this parsed relation, apply addenda (row data and/or advanced
+    /// extension), and produce the final `Rel`.
+    fn into_rel(self, addenda: RelationAddenda) -> Rel;
 }
 
 pub struct TableName(Vec<String>);
@@ -210,13 +219,27 @@ pub(crate) fn expect_one_child(
 }
 
 /// Parse a reference list Pair and return an EmitKind::Emit.
-fn parse_reference_emit(pair: Pair<Rule>) -> EmitKind {
+/// Parse a reference list into field indices for emit mapping.
+fn parse_output_mapping(pair: Pair<Rule>) -> Vec<i32> {
     assert_eq!(pair.as_rule(), Rule::reference_list);
-    let output_mapping = pair
-        .into_inner()
+    pair.into_inner()
         .map(|p| FieldIndex::parse_pair(p).0)
-        .collect::<Vec<i32>>();
-    EmitKind::Emit(Emit { output_mapping })
+        .collect()
+}
+
+/// Build an emit: `Direct` if the mapping is the identity `[0, 1, ..., N-1]`
+/// (where N = `direct_output_count`), otherwise `Emit` with the explicit mapping.
+fn make_emit(output_mapping: Vec<i32>, direct_output_count: usize) -> EmitKind {
+    let is_identity = output_mapping.len() == direct_output_count
+        && output_mapping
+            .iter()
+            .enumerate()
+            .all(|(i, &v)| v == i as i32);
+    if is_identity {
+        EmitKind::Direct(Direct {})
+    } else {
+        EmitKind::Emit(Emit { output_mapping })
+    }
 }
 
 /// Extracts named arguments from pest pairs with duplicate detection and completeness checking.
@@ -286,20 +309,13 @@ impl RelationParsePair for ReadRel {
         "ReadRel"
     }
 
-    fn into_rel(self) -> Rel {
-        Rel {
-            rel_type: Some(RelType::Read(Box::new(self))),
-        }
-    }
-
     fn parse_pair_with_context(
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
         input_children: Vec<Box<Rel>>,
-        _input_field_count: usize,
-    ) -> Result<Self, MessageParseError> {
+        input_field_count: usize,
+    ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
-        // ReadRel is a leaf node - it should have no input children and 0 input fields
         if !input_children.is_empty() {
             return Err(MessageParseError::invalid(
                 Self::message(),
@@ -307,7 +323,7 @@ impl RelationParsePair for ReadRel {
                 "ReadRel should have no input children",
             ));
         }
-        if _input_field_count != 0 {
+        if input_field_count != 0 {
             let error = pest::error::Error::new_from_span(
                 pest::error::ErrorVariant::CustomError {
                     message: "ReadRel should have 0 input fields".to_string(),
@@ -326,64 +342,104 @@ impl RelationParsePair for ReadRel {
         let columns = iter.parse_next_scoped::<NamedColumnList>(extensions)?.0;
         iter.done();
 
-        let read_rel = ReadRel {
-            base_schema: Some(build_named_struct(columns)),
-            read_type: Some(read_rel::ReadType::NamedTable(read_rel::NamedTable {
-                names: table,
-                advanced_extension: None,
-            })),
-            ..Default::default()
-        };
+        let output_count = columns.len();
+        Ok((
+            ReadRel {
+                base_schema: Some(build_named_struct(columns)),
+                read_type: Some(read_rel::ReadType::NamedTable(read_rel::NamedTable {
+                    names: table,
+                    advanced_extension: None,
+                })),
+                ..Default::default()
+            },
+            output_count,
+        ))
+    }
 
-        Ok(read_rel)
+    fn into_rel(mut self, addenda: RelationAddenda) -> Rel {
+        self.advanced_extension = addenda.advanced_extension;
+        Rel {
+            rel_type: Some(RelType::Read(Box::new(self))),
+        }
     }
 }
 
-/// Parse a `Read:Virtual[...]` relation with optional `+ Row` addenda,
-/// building the `ReadRel` with all row data in one shot.
-///
-/// Not a `RelationParsePair` because it needs additional row addenda data
-/// that the trait interface doesn't support.
-pub(crate) fn parse_virtual_read(
+/// Parse a `row_addendum` pair (`+ Row[expr, ...]`) into a `nested::Struct`.
+pub(crate) fn parse_row_addendum(
     extensions: &SimpleExtensions,
     pair: Pair<Rule>,
-    row_addenda: Vec<Pair<Rule>>,
-) -> Result<(Rel, usize), MessageParseError> {
-    assert_eq!(pair.as_rule(), Rule::virtual_read_relation);
+) -> nested::Struct {
+    assert_eq!(pair.as_rule(), Rule::row_addendum);
+    let expression_list = unwrap_single_pair(pair);
+    assert_eq!(expression_list.as_rule(), Rule::expression_list);
+    nested::Struct {
+        fields: parse_expression_list(extensions, expression_list),
+    }
+}
 
-    let mut iter = RuleIter::from(pair.into_inner());
-    let args_pair = iter.pop(Rule::virtual_read_args);
-    let mut rows = parse_virtual_read_args(extensions, args_pair);
-    let columns = iter.parse_next_scoped::<NamedColumnList>(extensions)?.0;
-    iter.done();
+/// Parsed `Read:Virtual[rows => columns]` relation. Needs a newtype because
+/// the proto type is `ReadRel` (same as NamedTable), but the grammar rule and
+/// addenda handling differ.
+pub(crate) struct ParsedVirtualReadRel(ReadRel);
 
-    // Append addenda rows after inline rows
-    for addendum_pair in row_addenda {
-        let expression_list = unwrap_single_pair(addendum_pair);
-        assert_eq!(expression_list.as_rule(), Rule::expression_list);
-        rows.push(nested::Struct {
-            fields: parse_expression_list(extensions, expression_list),
-        });
+impl RelationParsePair for ParsedVirtualReadRel {
+    fn rule() -> Rule {
+        Rule::virtual_read_relation
     }
 
-    // TODO: Validate that each row has the same number of expressions as columns.
-    // Currently no parser-side warning mechanism exists (the parser is fail-fast,
-    // and a width mismatch isn't a syntax error). Consider adding once a warning
-    // collection path is available.
-    let column_count = columns.len();
-    let named_struct = build_named_struct(columns);
-    let rel = Rel {
-        rel_type: Some(RelType::Read(Box::new(ReadRel {
-            base_schema: Some(named_struct),
-            read_type: Some(read_rel::ReadType::VirtualTable(read_rel::VirtualTable {
-                expressions: rows,
-                ..Default::default()
-            })),
-            ..Default::default()
-        }))),
-    };
+    fn message() -> &'static str {
+        "VirtualReadRel"
+    }
 
-    Ok((rel, column_count))
+    fn parse_pair_with_context(
+        extensions: &SimpleExtensions,
+        pair: Pair<Rule>,
+        input_children: Vec<Box<Rel>>,
+        _input_field_count: usize,
+    ) -> Result<(Self, usize), MessageParseError> {
+        assert_eq!(pair.as_rule(), Self::rule());
+        if !input_children.is_empty() {
+            return Err(MessageParseError::invalid(
+                Self::message(),
+                pair.as_span(),
+                "Read:Virtual should have no input children",
+            ));
+        }
+
+        let mut iter = RuleIter::from(pair.into_inner());
+        let args_pair = iter.pop(Rule::virtual_read_args);
+        let rows = parse_virtual_read_args(extensions, args_pair);
+        let columns = iter.parse_next_scoped::<NamedColumnList>(extensions)?.0;
+        iter.done();
+
+        // TODO: Validate that each row has the same number of expressions as columns.
+        // Currently no parser-side warning mechanism exists (the parser is fail-fast,
+        // and a width mismatch isn't a syntax error). Consider adding once a warning
+        // collection path is available.
+        let output_count = columns.len();
+        Ok((
+            ParsedVirtualReadRel(ReadRel {
+                base_schema: Some(build_named_struct(columns)),
+                read_type: Some(read_rel::ReadType::VirtualTable(read_rel::VirtualTable {
+                    expressions: rows,
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }),
+            output_count,
+        ))
+    }
+
+    fn into_rel(mut self, addenda: RelationAddenda) -> Rel {
+        // Extend inline rows with addenda rows from `+ Row` lines.
+        if let Some(read_rel::ReadType::VirtualTable(ref mut vt)) = self.0.read_type {
+            vt.expressions.extend(addenda.rows);
+        }
+        self.0.advanced_extension = addenda.advanced_extension;
+        Rel {
+            rel_type: Some(RelType::Read(Box::new(self.0))),
+        }
+    }
 }
 
 /// Build a `NamedStruct` from parsed columns.
@@ -434,7 +490,8 @@ impl RelationParsePair for FilterRel {
         "FilterRel"
     }
 
-    fn into_rel(self) -> Rel {
+    fn into_rel(mut self, addenda: RelationAddenda) -> Rel {
+        self.advanced_extension = addenda.advanced_extension;
         Rel {
             rel_type: Some(RelType::Filter(Box::new(self))),
         }
@@ -444,31 +501,32 @@ impl RelationParsePair for FilterRel {
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
         input_children: Vec<Box<Rel>>,
-        _input_field_count: usize,
-    ) -> Result<Self, MessageParseError> {
-        // Form: Filter[condition => references]
-
+        input_field_count: usize,
+    ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
         let input = expect_one_child(Self::message(), &pair, input_children)?;
         let mut iter = RuleIter::from(pair.into_inner());
-        // condition
         let condition = iter.parse_next_scoped::<Expression>(extensions)?;
-        // references (which become the emit)
         let references_pair = iter.pop(Rule::reference_list);
         iter.done();
 
-        let emit = parse_reference_emit(references_pair);
+        let output_mapping = parse_output_mapping(references_pair);
+        let output_count = output_mapping.len();
+        let emit = make_emit(output_mapping, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
         };
 
-        Ok(FilterRel {
-            input: Some(input),
-            condition: Some(Box::new(condition)),
-            common: Some(common),
-            advanced_extension: None,
-        })
+        Ok((
+            FilterRel {
+                input: Some(input),
+                condition: Some(Box::new(condition)),
+                common: Some(common),
+                advanced_extension: None,
+            },
+            output_count,
+        ))
     }
 }
 
@@ -481,7 +539,8 @@ impl RelationParsePair for ProjectRel {
         "ProjectRel"
     }
 
-    fn into_rel(self) -> Rel {
+    fn into_rel(mut self, addenda: RelationAddenda) -> Rel {
+        self.advanced_extension = addenda.advanced_extension;
         Rel {
             rel_type: Some(RelType::Project(Box::new(self))),
         }
@@ -491,49 +550,50 @@ impl RelationParsePair for ProjectRel {
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
         input_children: Vec<Box<Rel>>,
-        _input_field_count: usize,
-    ) -> Result<Self, MessageParseError> {
+        input_field_count: usize,
+    ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
         let input = expect_one_child(Self::message(), &pair, input_children)?;
 
-        // Get the argument list (contains references and expressions)
         let arguments_pair = unwrap_single_pair(pair);
 
         let mut expressions = Vec::new();
         let mut output_mapping = Vec::new();
 
-        // Process each argument (can be either a reference or expression)
         for arg in arguments_pair.into_inner() {
             let inner_arg = unwrap_single_pair(arg);
             match inner_arg.as_rule() {
                 Rule::reference => {
-                    // Parse reference like "$0" -> 0
                     let field_index = FieldIndex::parse_pair(inner_arg);
                     output_mapping.push(field_index.0);
                 }
                 Rule::expression => {
-                    // Parse as expression (e.g., 42, add($0, $1))
-                    let _expr = Expression::parse_pair(extensions, inner_arg)?;
-                    expressions.push(_expr);
-                    // Expression: index after all input fields
-                    output_mapping.push(_input_field_count as i32 + (expressions.len() as i32 - 1));
+                    let expr = Expression::parse_pair(extensions, inner_arg)?;
+                    expressions.push(expr);
+                    // Index into the combined schema: [input fields][computed expressions].
+                    output_mapping.push(input_field_count as i32 + (expressions.len() as i32 - 1));
                 }
                 _ => panic!("Unexpected inner argument rule: {:?}", inner_arg.as_rule()),
             }
         }
 
-        let emit = EmitKind::Emit(Emit { output_mapping });
+        let output_count = output_mapping.len();
+        let direct_count = input_field_count + expressions.len();
+        let emit = make_emit(output_mapping, direct_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
         };
 
-        Ok(ProjectRel {
-            input: Some(input),
-            expressions,
-            common: Some(common),
-            advanced_extension: None,
-        })
+        Ok((
+            ProjectRel {
+                input: Some(input),
+                expressions,
+                common: Some(common),
+                advanced_extension: None,
+            },
+            output_count,
+        ))
     }
 }
 
@@ -546,7 +606,8 @@ impl RelationParsePair for AggregateRel {
         "AggregateRel"
     }
 
-    fn into_rel(self) -> Rel {
+    fn into_rel(mut self, addenda: RelationAddenda) -> Rel {
+        self.advanced_extension = addenda.advanced_extension;
         Rel {
             rel_type: Some(RelType::Aggregate(Box::new(self))),
         }
@@ -557,7 +618,7 @@ impl RelationParsePair for AggregateRel {
         pair: Pair<Rule>,
         input_children: Vec<Box<Rel>>,
         _input_field_count: usize,
-    ) -> Result<Self, MessageParseError> {
+    ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
         let input = expect_one_child(Self::message(), &pair, input_children)?;
         let mut iter = RuleIter::from(pair.into_inner());
@@ -576,20 +637,25 @@ impl RelationParsePair for AggregateRel {
         let (measures, output_mapping) =
             parse_aggregate_measures(extensions, output_pair, &grouping_expressions)?;
 
-        let emit = EmitKind::Emit(Emit { output_mapping });
+        let output_count = output_mapping.len();
+        let direct_count = grouping_expressions.len() + measures.len();
+        let emit = make_emit(output_mapping, direct_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
         };
 
-        Ok(AggregateRel {
-            input: Some(input),
-            grouping_expressions,
-            groupings,
-            measures,
-            common: Some(common),
-            advanced_extension: None,
-        })
+        Ok((
+            AggregateRel {
+                input: Some(input),
+                grouping_expressions,
+                groupings,
+                measures,
+                common: Some(common),
+                advanced_extension: None,
+            },
+            output_count,
+        ))
     }
 }
 
@@ -783,7 +849,8 @@ impl RelationParsePair for SortRel {
         "SortRel"
     }
 
-    fn into_rel(self) -> Rel {
+    fn into_rel(mut self, addenda: RelationAddenda) -> Rel {
+        self.advanced_extension = addenda.advanced_extension;
         Rel {
             rel_type: Some(RelType::Sort(Box::new(self))),
         }
@@ -793,8 +860,8 @@ impl RelationParsePair for SortRel {
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
         input_children: Vec<Box<Rel>>,
-        _input_field_count: usize,
-    ) -> Result<Self, MessageParseError> {
+        input_field_count: usize,
+    ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
         let input = expect_one_child(Self::message(), &pair, input_children)?;
         let mut iter = RuleIter::from(pair.into_inner());
@@ -805,18 +872,23 @@ impl RelationParsePair for SortRel {
             let sort_field = SortField::parse_pair(extensions, sort_field_pair)?;
             sorts.push(sort_field);
         }
-        let emit = parse_reference_emit(reference_list_pair);
+        let output_mapping = parse_output_mapping(reference_list_pair);
+        let output_count = output_mapping.len();
+        let emit = make_emit(output_mapping, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
         };
         iter.done();
-        Ok(SortRel {
-            input: Some(input),
-            sorts,
-            common: Some(common),
-            advanced_extension: None,
-        })
+        Ok((
+            SortRel {
+                input: Some(input),
+                sorts,
+                common: Some(common),
+                advanced_extension: None,
+            },
+            output_count,
+        ))
     }
 }
 
@@ -937,7 +1009,8 @@ impl RelationParsePair for FetchRel {
         "FetchRel"
     }
 
-    fn into_rel(self) -> Rel {
+    fn into_rel(mut self, addenda: RelationAddenda) -> Rel {
+        self.advanced_extension = addenda.advanced_extension;
         Rel {
             rel_type: Some(RelType::Fetch(Box::new(self))),
         }
@@ -947,16 +1020,14 @@ impl RelationParsePair for FetchRel {
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
         input_children: Vec<Box<Rel>>,
-        _input_field_count: usize,
-    ) -> Result<Self, MessageParseError> {
+        input_field_count: usize,
+    ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
         let input = expect_one_child(Self::message(), &pair, input_children)?;
         let mut iter = RuleIter::from(pair.into_inner());
 
-        // Extract all pairs first, then do validation
         let (limit_pair, offset_pair) = match iter.try_pop(Rule::fetch_named_arg_list) {
             None => {
-                // If there are no arguments, it should be empty
                 iter.pop(Rule::empty);
                 (None, None)
             }
@@ -971,27 +1042,31 @@ impl RelationParsePair for FetchRel {
         };
 
         let reference_list_pair = iter.pop(Rule::reference_list);
-        let emit = parse_reference_emit(reference_list_pair);
+        let output_mapping = parse_output_mapping(reference_list_pair);
+        let output_count = output_mapping.len();
+        let emit = make_emit(output_mapping, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
         };
         iter.done();
 
-        // Now do validation after iterator is fully consumed
         let count_mode = limit_pair
             .map(|pair| CountMode::parse_pair(extensions, pair))
             .transpose()?;
         let offset_mode = offset_pair
             .map(|pair| OffsetMode::parse_pair(extensions, pair))
             .transpose()?;
-        Ok(FetchRel {
-            input: Some(input),
-            common: Some(common),
-            advanced_extension: None,
-            offset_mode,
-            count_mode,
-        })
+        Ok((
+            FetchRel {
+                input: Some(input),
+                common: Some(common),
+                advanced_extension: None,
+                offset_mode,
+                count_mode,
+            },
+            output_count,
+        ))
     }
 }
 
@@ -1034,7 +1109,8 @@ impl RelationParsePair for JoinRel {
         "JoinRel"
     }
 
-    fn into_rel(self) -> Rel {
+    fn into_rel(mut self, addenda: RelationAddenda) -> Rel {
+        self.advanced_extension = addenda.advanced_extension;
         Rel {
             rel_type: Some(RelType::Join(Box::new(self))),
         }
@@ -1044,11 +1120,10 @@ impl RelationParsePair for JoinRel {
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
         input_children: Vec<Box<Rel>>,
-        _input_field_count: usize,
-    ) -> Result<Self, MessageParseError> {
+        input_field_count: usize,
+    ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
 
-        // Join requires exactly 2 input children
         if input_children.len() != 2 {
             return Err(MessageParseError::invalid(
                 Self::message(),
@@ -1065,32 +1140,31 @@ impl RelationParsePair for JoinRel {
         let right = children_iter.next().unwrap();
 
         let mut iter = RuleIter::from(pair.into_inner());
-
-        // Parse join type
         let join_type = iter.parse_next::<join_rel::JoinType>();
-
-        // Parse join condition expression
         let condition = iter.parse_next_scoped::<Expression>(extensions)?;
-
-        // Parse output references (which become the emit)
         let reference_list_pair = iter.pop(Rule::reference_list);
         iter.done();
 
-        let emit = parse_reference_emit(reference_list_pair);
+        let output_mapping = parse_output_mapping(reference_list_pair);
+        let output_count = output_mapping.len();
+        let emit = make_emit(output_mapping, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
         };
 
-        Ok(JoinRel {
-            common: Some(common),
-            left: Some(left),
-            right: Some(right),
-            expression: Some(Box::new(condition)),
-            post_join_filter: None, // Not supported in grammar yet
-            r#type: join_type as i32,
-            advanced_extension: None,
-        })
+        Ok((
+            JoinRel {
+                common: Some(common),
+                left: Some(left),
+                right: Some(right),
+                expression: Some(Box::new(condition)),
+                post_join_filter: None, // not yet represented in the grammar
+                r#type: join_type as i32,
+                advanced_extension: None,
+            },
+            output_count,
+        ))
     }
 }
 
@@ -1116,7 +1190,8 @@ mod tests {
             vec![],
             0,
         )
-        .unwrap();
+        .unwrap()
+        .0;
         let names = match &read.read_type {
             Some(read_rel::ReadType::NamedTable(table)) => &table.names,
             _ => panic!("Expected NamedTable"),
@@ -1146,6 +1221,7 @@ mod tests {
             0,
         )
         .unwrap()
+        .0
     }
 
     #[test]
@@ -1154,16 +1230,22 @@ mod tests {
         let filter = FilterRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::filter_relation, "Filter[$1 => $0, $1, $2]"),
-            vec![Box::new(example_read_relation().into_rel())],
+            vec![Box::new(example_read_relation().into_rel(
+                RelationAddenda {
+                    rows: vec![],
+                    advanced_extension: None,
+                },
+            ))],
             3,
         )
-        .unwrap();
-        let emit_kind = &filter.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
-        let emit = match emit_kind {
-            EmitKind::Emit(emit) => &emit.output_mapping,
-            _ => panic!("Expected EmitKind::Emit, got {emit_kind:?}"),
-        };
-        assert_eq!(emit, &[0, 1, 2]);
+        .unwrap()
+        .0;
+        // Identity mapping [0, 1, 2] over 3 inputs → Direct
+        let emit_kind = filter.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
+        assert!(
+            matches!(emit_kind, EmitKind::Direct(_)),
+            "Expected Direct for identity emit, got {emit_kind:?}"
+        );
     }
 
     #[test]
@@ -1172,10 +1254,16 @@ mod tests {
         let project = ProjectRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::project_relation, "Project[$0, $1, 42]"),
-            vec![Box::new(example_read_relation().into_rel())],
+            vec![Box::new(example_read_relation().into_rel(
+                RelationAddenda {
+                    rows: vec![],
+                    advanced_extension: None,
+                },
+            ))],
             3,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         // Should have 1 expression (42) and 2 references ($0, $1)
         assert_eq!(project.expressions.len(), 1);
@@ -1195,10 +1283,16 @@ mod tests {
         let project = ProjectRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::project_relation, "Project[42, $0, 100, $2, $1]"),
-            vec![Box::new(example_read_relation().into_rel())],
+            vec![Box::new(example_read_relation().into_rel(
+                RelationAddenda {
+                    rows: vec![],
+                    advanced_extension: None,
+                },
+            ))],
             5, // Assume 5 input fields
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         // Should have 2 expressions (42, 100) and 3 references ($0, $2, $1)
         assert_eq!(project.expressions.len(), 2);
@@ -1227,10 +1321,16 @@ mod tests {
                 Rule::aggregate_relation,
                 "Aggregate[($0, $1), _ => sum($2), $0, count($2)]",
             ),
-            vec![Box::new(example_read_relation().into_rel())],
+            vec![Box::new(example_read_relation().into_rel(
+                RelationAddenda {
+                    rows: vec![],
+                    advanced_extension: None,
+                },
+            ))],
             3,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         // Should have 2 group-by sets ($0, $1) and an empty group, and emit 2 measures (sum($2), count($2))
         assert_eq!(aggregate.grouping_expressions.len(), 2);
@@ -1268,10 +1368,16 @@ mod tests {
                 Rule::aggregate_relation,
                 "Aggregate[$0 => sum($1), $0, count($1)]",
             ),
-            vec![Box::new(example_read_relation().into_rel())],
+            vec![Box::new(example_read_relation().into_rel(
+                RelationAddenda {
+                    rows: vec![],
+                    advanced_extension: None,
+                },
+            ))],
             3,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         // Should have 1 group-by field ($0) and 2 measures (sum($1), count($1))
         assert_eq!(aggregate.grouping_expressions.len(), 1);
@@ -1303,10 +1409,16 @@ mod tests {
         let aggregate = AggregateRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::aggregate_relation, "Aggregate[$2, $0 => sum($1)]"),
-            vec![Box::new(example_read_relation().into_rel())],
+            vec![Box::new(example_read_relation().into_rel(
+                RelationAddenda {
+                    rows: vec![],
+                    advanced_extension: None,
+                },
+            ))],
             3,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         assert_eq!(aggregate.grouping_expressions.len(), 2);
         assert_eq!(aggregate.groupings.len(), 1);
@@ -1328,10 +1440,16 @@ mod tests {
                 Rule::aggregate_relation,
                 "Aggregate[_ => sum($0), count($1)]",
             ),
-            vec![Box::new(example_read_relation().into_rel())],
+            vec![Box::new(example_read_relation().into_rel(
+                RelationAddenda {
+                    rows: vec![],
+                    advanced_extension: None,
+                },
+            ))],
             3,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         // Should have 0 group-by fields and 2 measures
         assert_eq!(aggregate.grouping_expressions.len(), 0);
@@ -1339,19 +1457,18 @@ mod tests {
         assert_eq!(aggregate.groupings[0].expression_references.len(), 0);
         assert_eq!(aggregate.measures.len(), 2);
 
-        let emit_kind = &aggregate
+        // Identity mapping [0, 1] over 2 outputs (0 grouping + 2 measures) → Direct
+        let emit_kind = aggregate
             .common
             .as_ref()
             .unwrap()
             .emit_kind
             .as_ref()
             .unwrap();
-        let emit = match emit_kind {
-            EmitKind::Emit(emit) => &emit.output_mapping,
-            _ => panic!("Expected EmitKind::Emit, got {emit_kind:?}"),
-        };
-        // Output mapping should be [0, 1] (measures only, no group-by fields)
-        assert_eq!(emit, &[0, 1]);
+        assert!(
+            matches!(emit_kind, EmitKind::Direct(_)),
+            "Expected Direct for identity emit, got {emit_kind:?}"
+        );
     }
 
     #[test]
@@ -1370,7 +1487,8 @@ mod tests {
             vec![],
             0,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         let aggregate = AggregateRel::parse_pair_with_context(
             &extensions,
@@ -1378,10 +1496,14 @@ mod tests {
                 Rule::aggregate_relation,
                 "Aggregate[($0, $1, $2), ($2, $0), ($1), _ => $0, $1, $2, count($3)]",
             ),
-            vec![Box::new(read_rel.into_rel())],
+            vec![Box::new(read_rel.into_rel(RelationAddenda {
+                rows: vec![],
+                advanced_extension: None,
+            }))],
             4,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         assert_eq!(aggregate.grouping_expressions.len(), 3);
         assert_eq!(aggregate.groupings.len(), 4);
@@ -1404,10 +1526,16 @@ mod tests {
         let fetch_rel = FetchRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::fetch_relation, "Fetch[limit=10, offset=5 => $0]"),
-            vec![Box::new(example_read_relation().into_rel())],
+            vec![Box::new(example_read_relation().into_rel(
+                RelationAddenda {
+                    rows: vec![],
+                    advanced_extension: None,
+                },
+            ))],
             3,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         // Verify the limit and offset values are correct
         assert_eq!(
@@ -1433,7 +1561,12 @@ mod tests {
                 let result = FetchRel::parse_pair_with_context(
                     &extensions,
                     pair,
-                    vec![Box::new(example_read_relation().into_rel())],
+                    vec![Box::new(example_read_relation().into_rel(
+                        RelationAddenda {
+                            rows: vec![],
+                            advanced_extension: None,
+                        },
+                    ))],
                     3,
                 );
                 assert!(result.is_err());
@@ -1464,7 +1597,12 @@ mod tests {
                 let result = FetchRel::parse_pair_with_context(
                     &extensions,
                     pair,
-                    vec![Box::new(example_read_relation().into_rel())],
+                    vec![Box::new(example_read_relation().into_rel(
+                        RelationAddenda {
+                            rows: vec![],
+                            advanced_extension: None,
+                        },
+                    ))],
                     3,
                 );
                 assert!(result.is_err());
@@ -1487,8 +1625,14 @@ mod tests {
             .with_function(1, 10, "eq")
             .extensions;
 
-        let left_rel = example_read_relation().into_rel();
-        let right_rel = example_read_relation().into_rel();
+        let left_rel = example_read_relation().into_rel(RelationAddenda {
+            rows: vec![],
+            advanced_extension: None,
+        });
+        let right_rel = example_read_relation().into_rel(RelationAddenda {
+            rows: vec![],
+            advanced_extension: None,
+        });
 
         let join = JoinRel::parse_pair_with_context(
             &extensions,
@@ -1499,7 +1643,8 @@ mod tests {
             vec![Box::new(left_rel), Box::new(right_rel)],
             6, // left (3) + right (3) = 6 total input fields
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         // Should be an Inner join
         assert_eq!(join.r#type, join_rel::JoinType::Inner as i32);
@@ -1527,8 +1672,14 @@ mod tests {
             .with_function(1, 10, "eq")
             .extensions;
 
-        let left_rel = example_read_relation().into_rel();
-        let right_rel = example_read_relation().into_rel();
+        let left_rel = example_read_relation().into_rel(RelationAddenda {
+            rows: vec![],
+            advanced_extension: None,
+        });
+        let right_rel = example_read_relation().into_rel(RelationAddenda {
+            rows: vec![],
+            advanced_extension: None,
+        });
 
         let join = JoinRel::parse_pair_with_context(
             &extensions,
@@ -1536,7 +1687,8 @@ mod tests {
             vec![Box::new(left_rel), Box::new(right_rel)],
             6,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         // Should be a Left join
         assert_eq!(join.r#type, join_rel::JoinType::Left as i32);
@@ -1557,8 +1709,14 @@ mod tests {
             .with_function(1, 10, "eq")
             .extensions;
 
-        let left_rel = example_read_relation().into_rel();
-        let right_rel = example_read_relation().into_rel();
+        let left_rel = example_read_relation().into_rel(RelationAddenda {
+            rows: vec![],
+            advanced_extension: None,
+        });
+        let right_rel = example_read_relation().into_rel(RelationAddenda {
+            rows: vec![],
+            advanced_extension: None,
+        });
 
         let join = JoinRel::parse_pair_with_context(
             &extensions,
@@ -1566,7 +1724,8 @@ mod tests {
             vec![Box::new(left_rel), Box::new(right_rel)],
             6,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         // Should be a LeftSemi join
         assert_eq!(join.r#type, join_rel::JoinType::LeftSemi as i32);
@@ -1597,7 +1756,12 @@ mod tests {
         let result = JoinRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::join_relation, "Join[&Inner, eq($0, $1) => $0, $1]"),
-            vec![Box::new(example_read_relation().into_rel())],
+            vec![Box::new(example_read_relation().into_rel(
+                RelationAddenda {
+                    rows: vec![],
+                    advanced_extension: None,
+                },
+            ))],
             3,
         );
         assert!(result.is_err());
@@ -1607,9 +1771,18 @@ mod tests {
             &extensions,
             parse_exact(Rule::join_relation, "Join[&Inner, eq($0, $1) => $0, $1]"),
             vec![
-                Box::new(example_read_relation().into_rel()),
-                Box::new(example_read_relation().into_rel()),
-                Box::new(example_read_relation().into_rel()),
+                Box::new(example_read_relation().into_rel(RelationAddenda {
+                    rows: vec![],
+                    advanced_extension: None,
+                })),
+                Box::new(example_read_relation().into_rel(RelationAddenda {
+                    rows: vec![],
+                    advanced_extension: None,
+                })),
+                Box::new(example_read_relation().into_rel(RelationAddenda {
+                    rows: vec![],
+                    advanced_extension: None,
+                })),
             ],
             9,
         );

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -9,7 +9,6 @@ use std::fmt;
 use pest::iterators::Pair;
 use substrait::proto::expression::nested;
 use substrait::proto::extensions::AdvancedExtension;
-use substrait::proto::rel::RelType;
 use substrait::proto::{
     AggregateRel, FetchRel, FilterRel, JoinRel, Plan, PlanRel, ProjectRel, ReadRel, Rel, RelRoot,
     SortRel, plan_rel,
@@ -23,7 +22,7 @@ use crate::parser::extensions::{
     AdvExtInvocation, ExtensionInvocation, ExtensionParseError, ExtensionParser,
 };
 use crate::parser::relations::{
-    ParsedVirtualReadRel, RelationAddenda, RelationParsingContext, parse_row_addendum,
+    RelationAddenda, RelationParsingContext, VirtualReadRel, parse_row_addendum,
 };
 use crate::parser::{ErrorKind, ExpressionParser, RelationParsePair, Rule, unwrap_single_pair};
 
@@ -80,11 +79,12 @@ pub enum Addendum<'a> {
 }
 
 impl<'a> Addendum<'a> {
-    fn line_no(&self) -> i64 {
-        match self {
-            Addendum::AdvExt(a) => a.line_no,
-            Addendum::Row(r) => r.line_no,
-        }
+    fn context(&self) -> ParseContext {
+        let (line_no, pair) = match self {
+            Addendum::AdvExt(a) => (a.line_no, &a.pair),
+            Addendum::Row(r) => (r.line_no, &r.pair),
+        };
+        ParseContext::new(line_no, pair.as_str().to_string())
     }
 }
 
@@ -202,30 +202,6 @@ impl<'a> LineNode<'a> {
     }
 }
 
-/// Set the `advanced_extension` field on a [`Rel`], covering all standard
-/// relation variants that carry the field directly.
-fn set_advanced_extension(rel: &mut Rel, adv_ext: AdvancedExtension) {
-    match &mut rel.rel_type {
-        Some(RelType::Read(r)) => r.advanced_extension = Some(adv_ext),
-        Some(RelType::Filter(r)) => r.advanced_extension = Some(adv_ext),
-        Some(RelType::Project(r)) => r.advanced_extension = Some(adv_ext),
-        Some(RelType::Aggregate(r)) => r.advanced_extension = Some(adv_ext),
-        Some(RelType::Sort(r)) => r.advanced_extension = Some(adv_ext),
-        Some(RelType::Fetch(r)) => r.advanced_extension = Some(adv_ext),
-        Some(RelType::Join(r)) => r.advanced_extension = Some(adv_ext),
-        Some(RelType::ExtensionLeaf(_)) => {
-            unreachable!("Extension types do not have advanced extensions defined on them")
-        }
-        Some(RelType::ExtensionSingle(_)) => {
-            unreachable!("Extension types do not have advanced extensions defined on them")
-        }
-        Some(RelType::ExtensionMulti(_)) => {
-            unreachable!("Extension types do not have advanced extensions defined on them")
-        }
-        _ => {}
-    }
-}
-
 #[derive(Copy, Clone, Debug)]
 pub enum State {
     // The initial state, before we have parsed any lines.
@@ -290,28 +266,31 @@ impl<'a> TreeBuilder<'a> {
                 parent.children.push(rel_node);
             }
             LineNode::Addendum(addendum) => {
-                let line_no = addendum.line_no();
                 if depth == 0 {
-                    return Err(ParseError::ValidationError(format!(
-                        "line {line_no}: addenda (+ Enh: / + Opt: / + Row) \
-                         cannot appear at the top level",
-                    )));
+                    return Err(ParseError::ValidationError(
+                        addendum.context(),
+                        "addenda (+ Enh: / + Opt: / + Row) cannot appear at the top level"
+                            .to_string(),
+                    ));
                 }
 
                 let parent = match self.get_at_depth(depth - 1) {
                     None => {
-                        return Err(ParseError::ValidationError(format!(
-                            "line {line_no}: no parent found for addendum at depth {depth}",
-                        )));
+                        return Err(ParseError::ValidationError(
+                            addendum.context(),
+                            format!("no parent found for addendum at depth {depth}"),
+                        ));
                     }
                     Some(parent) => parent,
                 };
 
                 if !parent.children.is_empty() {
-                    return Err(ParseError::ValidationError(format!(
-                        "line {line_no}: addenda (+ Enh: / + Opt: / + Row) must \
-                         appear before child relations, not after",
-                    )));
+                    return Err(ParseError::ValidationError(
+                        addendum.context(),
+                        "addenda (+ Enh: / + Opt: / + Row) must appear before child relations, \
+                         not after"
+                            .to_string(),
+                    ));
                 }
 
                 parent.addenda.push(addendum);
@@ -374,17 +353,19 @@ impl<'a> RelationParser<'a> {
         extensions: &SimpleExtensions,
         registry: &ExtensionRegistry,
         ctx: RelationContext,
-    ) -> Result<(substrait::proto::Rel, usize), ParseError> {
+    ) -> Result<(Rel, usize), ParseError> {
         let rule = ctx.pair.as_rule();
         if !ctx.rows.is_empty() && rule != Rule::virtual_read_relation {
-            return Err(ParseError::ValidationError(format!(
-                "line {}: + Row addenda can only be attached to Read:Virtual relations",
-                ctx.line_no
-            )));
+            // TODO: this is at the wrong layer of abstraction; this should probably
+            // be part of `RelationParsePair::into_rel`
+            return Err(ParseError::ValidationError(
+                ParseContext::new(ctx.line_no, ctx.pair.as_str().to_string()),
+                "+ Row addenda can only be attached to Read:Virtual relations".to_string(),
+            ));
         }
 
         match rule {
-            Rule::virtual_read_relation => self.parse_rel::<ParsedVirtualReadRel>(extensions, ctx),
+            Rule::virtual_read_relation => self.parse_rel::<VirtualReadRel>(extensions, ctx),
             Rule::read_relation => self.parse_rel::<ReadRel>(extensions, ctx),
             Rule::filter_relation => self.parse_rel::<FilterRel>(extensions, ctx),
             Rule::project_relation => self.parse_rel::<ProjectRel>(extensions, ctx),
@@ -464,7 +445,7 @@ impl<'a> RelationParser<'a> {
         let detail = context.resolve_extension_detail(&name, &extension_args)?;
         let output_column_count = extension_args.output_columns.len();
 
-        let mut rel = extension_args
+        let rel = extension_args
             .relation_type
             .create_rel(detail, ctx.children)
             .map_err(|e| {
@@ -474,8 +455,12 @@ impl<'a> RelationParser<'a> {
                 )
             })?;
 
-        if let Some(adv_ext) = ctx.advanced_extension {
-            set_advanced_extension(&mut rel, adv_ext);
+        if ctx.advanced_extension.is_some() {
+            return Err(ParseError::ValidationError(
+                ParseContext::new(line_no, line.to_string()),
+                "extension relations do not support advanced extensions (+ Enh / + Opt)"
+                    .to_string(),
+            ));
         }
         Ok((rel, output_column_count))
     }
@@ -489,7 +474,7 @@ impl<'a> RelationParser<'a> {
         extensions: &SimpleExtensions,
         registry: &ExtensionRegistry,
         node: RelationNode,
-    ) -> Result<(substrait::proto::Rel, usize), ParseError> {
+    ) -> Result<(Rel, usize), ParseError> {
         let mut children: Vec<Box<Rel>> = Vec::new();
         let mut input_field_count: usize = 0;
         for child in node.children {
@@ -556,6 +541,7 @@ impl<'a> RelationParser<'a> {
                     )?;
                     if enhancement.is_some() {
                         return Err(ParseError::ValidationError(
+                            ParseContext::new(line_no, line.clone()),
                             "at most one enhancement per relation is allowed".to_string(),
                         ));
                     }
@@ -598,11 +584,10 @@ impl<'a> RelationParser<'a> {
 
         // Root relations don't support addenda — reject rather than silently discard.
         if !node.addenda.is_empty() {
-            let line_no = node.addenda[0].line_no();
-            return Err(ParseError::ValidationError(format!(
-                "line {line_no}: addenda (+ Enh: / + Opt: / + Row) are not \
-                 supported on Root relations",
-            )));
+            return Err(ParseError::ValidationError(
+                node.addenda[0].context(),
+                "addenda (+ Enh: / + Opt: / + Row) are not supported on Root relations".to_string(),
+            ));
         }
 
         // Named root relation.
@@ -941,6 +926,7 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod tests {
     use substrait::proto::extensions::simple_extension_declaration::MappingType;
+    use substrait::proto::rel::RelType;
 
     use super::*;
     use crate::extensions::simple::ExtensionKind;

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -7,9 +7,9 @@
 use std::fmt;
 
 use pest::iterators::Pair;
+use substrait::proto::expression::nested;
 use substrait::proto::extensions::AdvancedExtension;
 use substrait::proto::rel::RelType;
-use substrait::proto::rel_common::EmitKind;
 use substrait::proto::{
     AggregateRel, FetchRel, FilterRel, JoinRel, Plan, PlanRel, ProjectRel, ReadRel, Rel, RelRoot,
     SortRel, plan_rel,
@@ -22,7 +22,9 @@ use crate::parser::expressions::Name;
 use crate::parser::extensions::{
     AdvExtInvocation, ExtensionInvocation, ExtensionParseError, ExtensionParser,
 };
-use crate::parser::relations::{RelationParsingContext, parse_virtual_read};
+use crate::parser::relations::{
+    ParsedVirtualReadRel, RelationAddenda, RelationParsingContext, parse_row_addendum,
+};
 use crate::parser::{ErrorKind, ExpressionParser, RelationParsePair, Rule, unwrap_single_pair};
 
 pub const PLAN_HEADER: &str = "=== Plan";
@@ -200,88 +202,6 @@ impl<'a> LineNode<'a> {
     }
 }
 
-/// Return the number of output columns for a relation.
-///
-/// Extension relations are excluded here intentionally: their output column
-/// count is carried as the `usize` in the `(Rel, usize)` returned by
-/// `build_rel` / `parse_extension_relation`, so they never reach this function.
-fn get_output_field_count(rel: &Rel) -> usize {
-    // An explicit emit mapping defines the exact emitted column count regardless
-    // of relation type
-    if let Some(EmitKind::Emit(e)) = get_emit_kind(rel) {
-        return e.output_mapping.len();
-    }
-
-    match &rel.rel_type {
-        Some(RelType::Read(read_rel)) => {
-            // Read embeds the schema directly — count the typed fields.
-            if let Some(schema) = read_rel.base_schema.as_ref()
-                && let Some(s) = schema.r#struct.as_ref()
-            {
-                return s.types.len();
-            }
-            0
-        }
-        Some(RelType::Filter(filter_rel)) => {
-            // Filter passes all input columns through unchanged.
-            if let Some(input) = filter_rel.input.as_ref() {
-                return get_output_field_count(input);
-            }
-            0
-        }
-        Some(RelType::Project(project_rel)) => {
-            // Without an emit, Project's direct output is all input columns
-            // followed by all computed expressions.
-            if let Some(input) = project_rel.input.as_ref() {
-                return get_output_field_count(input) + project_rel.expressions.len();
-            }
-            0
-        }
-        Some(RelType::Sort(sort_rel)) => {
-            // Sort passes all input columns through unchanged.
-            if let Some(input) = sort_rel.input.as_ref() {
-                return get_output_field_count(input);
-            }
-            0
-        }
-        Some(RelType::Fetch(fetch_rel)) => {
-            // Fetch (LIMIT/OFFSET) passes all input columns through unchanged.
-            if let Some(input) = fetch_rel.input.as_ref() {
-                return get_output_field_count(input);
-            }
-            0
-        }
-        Some(RelType::Join(join_rel)) => {
-            // Join concatenates the columns of its two inputs.
-            let left = join_rel.left.as_deref().map_or(0, get_output_field_count);
-            let right = join_rel.right.as_deref().map_or(0, get_output_field_count);
-            left + right
-        }
-        Some(RelType::Aggregate(agg_rel)) => {
-            // Aggregate's direct output is the grouping expressions followed
-            // by the measure results.
-            agg_rel.grouping_expressions.len() + agg_rel.measures.len()
-        }
-        _ => unimplemented!("TODO: implement this for the specific type"),
-    }
-}
-
-/// Extract the emit kind from a relation's `common` field, covering all
-/// standard relation variants that carry it.
-fn get_emit_kind(rel: &Rel) -> Option<&EmitKind> {
-    match &rel.rel_type {
-        Some(RelType::Read(r)) => r.common.as_ref(),
-        Some(RelType::Filter(r)) => r.common.as_ref(),
-        Some(RelType::Project(r)) => r.common.as_ref(),
-        Some(RelType::Sort(r)) => r.common.as_ref(),
-        Some(RelType::Fetch(r)) => r.common.as_ref(),
-        Some(RelType::Join(r)) => r.common.as_ref(),
-        Some(RelType::Aggregate(r)) => r.common.as_ref(),
-        _ => unimplemented!("TODO: implement this for the specific type"),
-    }
-    .and_then(|c| c.emit_kind.as_ref())
-}
-
 /// Set the `advanced_extension` field on a [`Rel`], covering all standard
 /// relation variants that carry the field directly.
 fn set_advanced_extension(rel: &mut Rel, adv_ext: AdvancedExtension) {
@@ -412,6 +332,19 @@ impl<'a> TreeBuilder<'a> {
     }
 }
 
+/// Intermediate state for relation parsing: the structural tree data
+/// (children, addenda) has been processed into proto types, but the
+/// relation's own grammar pair hasn't been parsed yet.
+struct RelationContext<'a> {
+    pair: Pair<'a, Rule>,
+    line_no: i64,
+    #[allow(clippy::vec_box)]
+    children: Vec<Box<Rel>>,
+    input_field_count: usize,
+    rows: Vec<nested::Struct>,
+    advanced_extension: Option<AdvancedExtension>,
+}
+
 // Relation parsing component - handles converting LineNodes to Relations
 #[derive(Debug, Clone, Default)]
 pub struct RelationParser<'a> {
@@ -432,80 +365,58 @@ impl<'a> RelationParser<'a> {
         self.tree.add_line(depth, node)
     }
 
-    /// Parse a relation from a Pest pair of rule 'relation' into a Substrait
-    /// Rel, together with its output column count.
-    ///
-    /// The `usize` in the return value is the number of columns this relation
-    /// outputs.  Callers accumulate these counts across children and pass the
-    /// sum in as `input_field_count` so that relations like `ProjectRel` can
-    /// assign correct emit-mapping indices to their computed expressions.
-    //
-    // Clippy says a Vec<Box<…>> is unnecessary, as the Vec is already on the
-    // heap, but this is what the protobuf requires so we allow it here
-    #[allow(clippy::vec_box)]
+    /// Dispatch by grammar rule after validating addenda constraints.
+    /// Standard relations go through [`parse_rel`](Self::parse_rel);
+    /// extension relations go through
+    /// [`parse_extension_relation`](Self::parse_extension_relation).
     fn parse_relation(
         &self,
         extensions: &SimpleExtensions,
         registry: &ExtensionRegistry,
-        line_no: i64,
-        pair: Pair<Rule>,
-        child_relations: Vec<Box<substrait::proto::Rel>>,
-        input_field_count: usize,
+        ctx: RelationContext,
     ) -> Result<(substrait::proto::Rel, usize), ParseError> {
-        // `pair` is already the specific relation rule (e.g. Rule::project_relation),
-        // unwrapped from the outer planNode during LineNode construction.
-        let (e, r, l, p_inner, cr, ic) = (
-            extensions,
-            registry,
-            line_no,
-            pair,
-            child_relations,
-            input_field_count,
-        );
+        let rule = ctx.pair.as_rule();
+        if !ctx.rows.is_empty() && rule != Rule::virtual_read_relation {
+            return Err(ParseError::ValidationError(format!(
+                "line {}: + Row addenda can only be attached to Read:Virtual relations",
+                ctx.line_no
+            )));
+        }
 
-        match p_inner.as_rule() {
-            Rule::read_relation => self.parse_rel::<ReadRel>(e, l, p_inner, cr, ic),
-            Rule::filter_relation => self.parse_rel::<FilterRel>(e, l, p_inner, cr, ic),
-            Rule::project_relation => self.parse_rel::<ProjectRel>(e, l, p_inner, cr, ic),
-            Rule::aggregate_relation => self.parse_rel::<AggregateRel>(e, l, p_inner, cr, ic),
-            Rule::sort_relation => self.parse_rel::<SortRel>(e, l, p_inner, cr, ic),
-            Rule::fetch_relation => self.parse_rel::<FetchRel>(e, l, p_inner, cr, ic),
-            Rule::join_relation => self.parse_rel::<JoinRel>(e, l, p_inner, cr, ic),
-            Rule::extension_relation => self.parse_extension_relation(e, r, l, p_inner, cr),
-            _ => unreachable!("unhandled relation rule: {:?}", p_inner.as_rule()),
+        match rule {
+            Rule::virtual_read_relation => self.parse_rel::<ParsedVirtualReadRel>(extensions, ctx),
+            Rule::read_relation => self.parse_rel::<ReadRel>(extensions, ctx),
+            Rule::filter_relation => self.parse_rel::<FilterRel>(extensions, ctx),
+            Rule::project_relation => self.parse_rel::<ProjectRel>(extensions, ctx),
+            Rule::aggregate_relation => self.parse_rel::<AggregateRel>(extensions, ctx),
+            Rule::sort_relation => self.parse_rel::<SortRel>(extensions, ctx),
+            Rule::fetch_relation => self.parse_rel::<FetchRel>(extensions, ctx),
+            Rule::join_relation => self.parse_rel::<JoinRel>(extensions, ctx),
+            Rule::extension_relation => self.parse_extension_relation(extensions, registry, ctx),
+            _ => unreachable!("unhandled relation rule: {:?}", rule),
         }
     }
 
-    /// Parse a specific relation type, returning the relation and its output column count.
-    ///
-    /// The count is derived from the just-built relation via `get_output_field_count`.
-    /// Extension relations are handled separately in `parse_extension_relation` because
-    /// their count comes from the user-supplied output-columns list, not from a schema
-    /// embedded in the protobuf.
-    // Box is needed because Rel is a large enum and we need to pass ownership
-    // through the RelationParsePair trait, which requires Box<Rel>.
-    #[allow(clippy::vec_box)]
+    /// Generic bridge between [`parse_relation`](Self::parse_relation) and
+    /// the [`RelationParsePair`] trait: wraps `MessageParseError` with line
+    /// context and calls [`into_rel`](RelationParsePair::into_rel) to apply
+    /// addenda and produce the final [`Rel`].
     fn parse_rel<T: RelationParsePair>(
         &self,
         extensions: &SimpleExtensions,
-        line_no: i64,
-        pair: Pair<Rule>,
-        child_relations: Vec<Box<substrait::proto::Rel>>,
-        input_field_count: usize,
-    ) -> Result<(substrait::proto::Rel, usize), ParseError> {
-        assert_eq!(pair.as_rule(), T::rule());
+        ctx: RelationContext,
+    ) -> Result<(Rel, usize), ParseError> {
+        assert_eq!(ctx.pair.as_rule(), T::rule());
+        let line_no = ctx.line_no;
+        let line = ctx.pair.as_str();
+        let addenda = RelationAddenda {
+            rows: ctx.rows,
+            advanced_extension: ctx.advanced_extension,
+        };
 
-        let line = pair.as_str();
-
-        let rel_type =
-            T::parse_pair_with_context(extensions, pair, child_relations, input_field_count);
-
-        match rel_type {
-            Ok(rel) => {
-                let as_rel = rel.into_rel();
-                let count = get_output_field_count(&as_rel);
-                Ok((as_rel, count))
-            }
+        match T::parse_pair_with_context(extensions, ctx.pair, ctx.children, ctx.input_field_count)
+        {
+            Ok((parsed, count)) => Ok((parsed.into_rel(addenda), count)),
             Err(e) => Err(ParseError::Plan(
                 ParseContext::new(line_no, line.to_string()),
                 e,
@@ -513,32 +424,26 @@ impl<'a> RelationParser<'a> {
         }
     }
 
-    /// Parse extension relations.
-    /// Extension relations need the full parsing context for registry lookups and warning handling.
-    // Box is needed because Rel is a large enum and we need to pass ownership
-    // through the RelationParsePair trait, which requires Box<Rel>.
-    #[allow(clippy::vec_box)]
+    /// Handle extension relations separately from [`parse_rel`](Self::parse_rel)
+    /// because they need registry lookups that [`RelationParsePair`] doesn't
+    /// support.
     fn parse_extension_relation(
         &self,
         extensions: &SimpleExtensions,
         registry: &ExtensionRegistry,
-        line_no: i64,
-        pair: Pair<Rule>,
-        child_relations: Vec<Box<substrait::proto::Rel>>,
-    ) -> Result<(substrait::proto::Rel, usize), ParseError> {
-        assert_eq!(pair.as_rule(), Rule::extension_relation);
+        ctx: RelationContext,
+    ) -> Result<(Rel, usize), ParseError> {
+        assert_eq!(ctx.pair.as_rule(), Rule::extension_relation);
+        let line_no = ctx.line_no;
+        let line = ctx.pair.as_str();
+        let pair_span = ctx.pair.as_span();
 
-        let line = pair.as_str();
-        let pair_span = pair.as_span();
-
-        // Parse extension invocation, which includes the user-provided name
         let ExtensionInvocation {
             name,
             args: extension_args,
-        } = ExtensionInvocation::parse_pair(pair);
+        } = ExtensionInvocation::parse_pair(ctx.pair);
 
-        // Validate child count matches relation type
-        let child_count = child_relations.len();
+        let child_count = ctx.children.len();
         extension_args
             .relation_type
             .validate_child_count(child_count)
@@ -557,13 +462,11 @@ impl<'a> RelationParser<'a> {
         };
 
         let detail = context.resolve_extension_detail(&name, &extension_args)?;
-        // Capture the output column count before consuming extension_args, so
-        // it can be returned to the caller.
         let output_column_count = extension_args.output_columns.len();
 
-        let rel = extension_args
+        let mut rel = extension_args
             .relation_type
-            .create_rel(detail, child_relations)
+            .create_rel(detail, ctx.children)
             .map_err(|e| {
                 ParseError::Plan(
                     ParseContext::new(line_no, line.to_string()),
@@ -571,79 +474,56 @@ impl<'a> RelationParser<'a> {
                 )
             })?;
 
+        if let Some(adv_ext) = ctx.advanced_extension {
+            set_advanced_extension(&mut rel, adv_ext);
+        }
         Ok((rel, output_column_count))
     }
 
-    /// Convert a [`RelationNode`] into a Substrait Rel, together with its output column count.
-    /// The returned `usize` is the number of columns this relation emits.
+    /// Walk the relation tree depth-first, converting structural types
+    /// (children, addenda) into proto types via [`RelationContext`].
+    /// Delegates grammar-rule-specific work to
+    /// [`parse_relation`](Self::parse_relation).
     fn build_rel(
         &self,
         extensions: &SimpleExtensions,
         registry: &ExtensionRegistry,
         node: RelationNode,
     ) -> Result<(substrait::proto::Rel, usize), ParseError> {
-        let mut child_relations: Vec<Box<Rel>> = Vec::new();
+        let mut children: Vec<Box<Rel>> = Vec::new();
         let mut input_field_count: usize = 0;
-
         for child in node.children {
             let (rel, count) = self.build_rel(extensions, registry, child)?;
             input_field_count += count;
-            child_relations.push(Box::new(rel));
+            children.push(Box::new(rel));
         }
 
-        // Split addenda into adv_extensions and row addenda.
         let mut adv_exts = Vec::new();
-        let mut row_pairs = Vec::new();
-        let mut first_row_line_no: Option<i64> = None;
+        let mut rows = Vec::new();
         for addendum in node.addenda {
             match addendum {
                 Addendum::AdvExt(a) => adv_exts.push(a),
-                Addendum::Row(r) => {
-                    first_row_line_no.get_or_insert(r.line_no);
-                    row_pairs.push(r.pair);
-                }
+                Addendum::Row(r) => rows.push(parse_row_addendum(extensions, r.pair)),
             }
         }
-
-        // Validate addenda constraints before dispatch.
-        let is_virtual = node.pair.as_rule() == Rule::virtual_read_relation;
-        if !row_pairs.is_empty() && !is_virtual {
-            let line_no = first_row_line_no.unwrap();
-            return Err(ParseError::ValidationError(format!(
-                "line {line_no}: + Row addenda can only be attached to Read:Virtual relations",
-            )));
-        }
-        if is_virtual && !child_relations.is_empty() {
-            return Err(ParseError::ValidationError(format!(
-                "line {}: Read:Virtual should have no input children",
-                node.line_no
-            )));
-        }
-
-        // VirtualTable reads get a dedicated path: all row data (inline + addenda)
-        // is gathered before construction, so the proto is built in one shot.
-        let (mut rel, output_count) = if is_virtual {
-            let line = node.pair.as_str();
-            parse_virtual_read(extensions, node.pair, row_pairs).map_err(|e| {
-                ParseError::Plan(ParseContext::new(node.line_no, line.to_string()), e)
-            })?
+        let advanced_extension = if adv_exts.is_empty() {
+            None
         } else {
-            self.parse_relation(
-                extensions,
-                registry,
-                node.line_no,
-                node.pair,
-                child_relations,
-                input_field_count,
-            )?
+            Some(self.build_advanced_extension(extensions, registry, adv_exts)?)
         };
 
-        if !adv_exts.is_empty() {
-            let adv_ext = self.build_advanced_extension(extensions, registry, adv_exts)?;
-            set_advanced_extension(&mut rel, adv_ext);
-        }
-
-        Ok((rel, output_count))
+        self.parse_relation(
+            extensions,
+            registry,
+            RelationContext {
+                pair: node.pair,
+                line_no: node.line_no,
+                children,
+                input_field_count,
+                rows,
+                advanced_extension,
+            },
+        )
     }
 
     /// Parse a list of [`AdvExt`] nodes into an [`AdvancedExtension`] proto.

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -6,6 +6,7 @@
 
 use std::fmt;
 
+use pest::iterators::Pair;
 use substrait::proto::extensions::AdvancedExtension;
 use substrait::proto::rel::RelType;
 use substrait::proto::rel_common::EmitKind;
@@ -21,7 +22,7 @@ use crate::parser::expressions::Name;
 use crate::parser::extensions::{
     AdvExtInvocation, ExtensionInvocation, ExtensionParseError, ExtensionParser,
 };
-use crate::parser::relations::RelationParsingContext;
+use crate::parser::relations::{RelationParsingContext, parse_virtual_read};
 use crate::parser::{ErrorKind, ExpressionParser, RelationParsePair, Rule, unwrap_single_pair};
 
 pub const PLAN_HEADER: &str = "=== Plan";
@@ -56,16 +57,41 @@ impl<'a> From<&'a str> for IndentedLine<'a> {
 /// grammar rule directly (already unwrapped from the outer `planNode`).
 #[derive(Debug, Clone)]
 pub struct AdvExt<'a> {
-    pub pair: pest::iterators::Pair<'a, Rule>, // Rule::adv_extension
+    pub pair: Pair<'a, Rule>, // Rule::adv_extension
     pub line_no: i64,
+}
+
+/// A row addendum (`+ Row[expr, expr, ...]`) for VirtualTable reads.
+#[derive(Debug, Clone)]
+pub struct RowNode<'a> {
+    pub pair: Pair<'a, Rule>, // Rule::row_addendum
+    pub line_no: i64,
+}
+
+/// A `+`-prefixed addendum attached to a relation node. Addenda appear at
+/// the same indentation as child relations but before them, and carry
+/// metadata or data belonging to the parent relation.
+#[derive(Debug, Clone)]
+pub enum Addendum<'a> {
+    AdvExt(AdvExt<'a>),
+    Row(RowNode<'a>),
+}
+
+impl<'a> Addendum<'a> {
+    fn line_no(&self) -> i64 {
+        match self {
+            Addendum::AdvExt(a) => a.line_no,
+            Addendum::Row(r) => r.line_no,
+        }
+    }
 }
 
 /// A relation node in the plan tree, before conversion to a Substrait proto.
 #[derive(Debug, Clone)]
 pub struct RelationNode<'a> {
-    pub pair: pest::iterators::Pair<'a, Rule>,
+    pub pair: Pair<'a, Rule>,
     pub line_no: i64,
-    pub adv_extensions: Vec<AdvExt<'a>>,
+    pub addenda: Vec<Addendum<'a>>,
     pub children: Vec<RelationNode<'a>>,
 }
 
@@ -78,7 +104,7 @@ impl<'a> RelationNode<'a> {
     }
 }
 
-/// A parsed plan line: either a relation or an advanced-extension annotation.
+/// A parsed plan line: either a relation or an addendum (`+`-prefixed line).
 ///
 /// Classification happens at construction time by inspecting the inner grammar
 /// rule, so downstream code can use standard Rust pattern matching rather than
@@ -86,7 +112,7 @@ impl<'a> RelationNode<'a> {
 #[derive(Debug, Clone)]
 pub enum LineNode<'a> {
     Relation(RelationNode<'a>),
-    AdvExt(AdvExt<'a>),
+    Addendum(Addendum<'a>),
 }
 
 impl<'a> LineNode<'a> {
@@ -106,18 +132,21 @@ impl<'a> LineNode<'a> {
         assert!(pairs.next().is_none()); // Should be exactly one pair
         let inner = unwrap_single_pair(outer);
 
-        Ok(if inner.as_rule() == Rule::adv_extension {
-            LineNode::AdvExt(AdvExt {
+        Ok(match inner.as_rule() {
+            Rule::adv_extension => LineNode::Addendum(Addendum::AdvExt(AdvExt {
                 pair: inner,
                 line_no,
-            })
-        } else {
-            LineNode::Relation(RelationNode {
+            })),
+            Rule::row_addendum => LineNode::Addendum(Addendum::Row(RowNode {
                 pair: inner,
                 line_no,
-                adv_extensions: Vec::new(),
+            })),
+            _ => LineNode::Relation(RelationNode {
+                pair: inner,
+                line_no,
+                addenda: Vec::new(),
                 children: Vec::new(),
-            })
+            }),
         })
     }
 
@@ -147,16 +176,25 @@ impl<'a> LineNode<'a> {
             inner // root_relation
         };
 
-        // planNode can technically include adv_extension; surface it as AdvExt so
+        // planNode can include addenda (+Enh:, +Opt:, +Row); surface them so
         // TreeBuilder::add_line can produce the appropriate depth-0 error.
-        if pair.as_rule() == Rule::adv_extension {
-            return Ok(LineNode::AdvExt(AdvExt { pair, line_no })); // Where is the error produced or checked???
+        match pair.as_rule() {
+            Rule::adv_extension => {
+                return Ok(LineNode::Addendum(Addendum::AdvExt(AdvExt {
+                    pair,
+                    line_no,
+                })));
+            }
+            Rule::row_addendum => {
+                return Ok(LineNode::Addendum(Addendum::Row(RowNode { pair, line_no })));
+            }
+            _ => {} // Normal relation rule — fall through
         }
 
         Ok(LineNode::Relation(RelationNode {
             pair,
             line_no,
-            adv_extensions: Vec::new(),
+            addenda: Vec::new(),
             children: Vec::new(),
         }))
     }
@@ -331,19 +369,19 @@ impl<'a> TreeBuilder<'a> {
 
                 parent.children.push(rel_node);
             }
-            LineNode::AdvExt(adv_ext) => {
+            LineNode::Addendum(addendum) => {
+                let line_no = addendum.line_no();
                 if depth == 0 {
                     return Err(ParseError::ValidationError(format!(
-                        "line {}: advanced extension annotations cannot appear at the top level",
-                        adv_ext.line_no
+                        "line {line_no}: addenda (+ Enh: / + Opt: / + Row) \
+                         cannot appear at the top level",
                     )));
                 }
 
                 let parent = match self.get_at_depth(depth - 1) {
                     None => {
                         return Err(ParseError::ValidationError(format!(
-                            "line {}: no parent found for advanced extension at depth {depth}",
-                            adv_ext.line_no
+                            "line {line_no}: no parent found for addendum at depth {depth}",
                         )));
                     }
                     Some(parent) => parent,
@@ -351,13 +389,12 @@ impl<'a> TreeBuilder<'a> {
 
                 if !parent.children.is_empty() {
                     return Err(ParseError::ValidationError(format!(
-                        "line {}: advanced extension annotations (+ Enh: / + Opt:) must \
+                        "line {line_no}: addenda (+ Enh: / + Opt: / + Row) must \
                          appear before child relations, not after",
-                        adv_ext.line_no
                     )));
                 }
 
-                parent.adv_extensions.push(adv_ext);
+                parent.addenda.push(addendum);
             }
         }
         Ok(())
@@ -411,7 +448,7 @@ impl<'a> RelationParser<'a> {
         extensions: &SimpleExtensions,
         registry: &ExtensionRegistry,
         line_no: i64,
-        pair: pest::iterators::Pair<Rule>,
+        pair: Pair<Rule>,
         child_relations: Vec<Box<substrait::proto::Rel>>,
         input_field_count: usize,
     ) -> Result<(substrait::proto::Rel, usize), ParseError> {
@@ -452,7 +489,7 @@ impl<'a> RelationParser<'a> {
         &self,
         extensions: &SimpleExtensions,
         line_no: i64,
-        pair: pest::iterators::Pair<Rule>,
+        pair: Pair<Rule>,
         child_relations: Vec<Box<substrait::proto::Rel>>,
         input_field_count: usize,
     ) -> Result<(substrait::proto::Rel, usize), ParseError> {
@@ -486,7 +523,7 @@ impl<'a> RelationParser<'a> {
         extensions: &SimpleExtensions,
         registry: &ExtensionRegistry,
         line_no: i64,
-        pair: pest::iterators::Pair<Rule>,
+        pair: Pair<Rule>,
         child_relations: Vec<Box<substrait::proto::Rel>>,
     ) -> Result<(substrait::proto::Rel, usize), ParseError> {
         assert_eq!(pair.as_rule(), Rule::extension_relation);
@@ -554,18 +591,55 @@ impl<'a> RelationParser<'a> {
             child_relations.push(Box::new(rel));
         }
 
-        let (mut rel, output_count) = self.parse_relation(
-            extensions,
-            registry,
-            node.line_no,
-            node.pair,
-            child_relations,
-            input_field_count,
-        )?;
+        // Split addenda into adv_extensions and row addenda.
+        let mut adv_exts = Vec::new();
+        let mut row_pairs = Vec::new();
+        let mut first_row_line_no: Option<i64> = None;
+        for addendum in node.addenda {
+            match addendum {
+                Addendum::AdvExt(a) => adv_exts.push(a),
+                Addendum::Row(r) => {
+                    first_row_line_no.get_or_insert(r.line_no);
+                    row_pairs.push(r.pair);
+                }
+            }
+        }
 
-        if !node.adv_extensions.is_empty() {
-            let adv_ext =
-                self.build_advanced_extension(extensions, registry, node.adv_extensions)?;
+        // Validate addenda constraints before dispatch.
+        let is_virtual = node.pair.as_rule() == Rule::virtual_read_relation;
+        if !row_pairs.is_empty() && !is_virtual {
+            let line_no = first_row_line_no.unwrap();
+            return Err(ParseError::ValidationError(format!(
+                "line {line_no}: + Row addenda can only be attached to Read:Virtual relations",
+            )));
+        }
+        if is_virtual && !child_relations.is_empty() {
+            return Err(ParseError::ValidationError(format!(
+                "line {}: Read:Virtual should have no input children",
+                node.line_no
+            )));
+        }
+
+        // VirtualTable reads get a dedicated path: all row data (inline + addenda)
+        // is gathered before construction, so the proto is built in one shot.
+        let (mut rel, output_count) = if is_virtual {
+            let line = node.pair.as_str();
+            parse_virtual_read(extensions, node.pair, row_pairs).map_err(|e| {
+                ParseError::Plan(ParseContext::new(node.line_no, line.to_string()), e)
+            })?
+        } else {
+            self.parse_relation(
+                extensions,
+                registry,
+                node.line_no,
+                node.pair,
+                child_relations,
+                input_field_count,
+            )?
+        };
+
+        if !adv_exts.is_empty() {
+            let adv_ext = self.build_advanced_extension(extensions, registry, adv_exts)?;
             set_advanced_extension(&mut rel, adv_ext);
         }
 
@@ -640,6 +714,15 @@ impl<'a> RelationParser<'a> {
             return Ok(PlanRel {
                 rel_type: Some(plan_rel::RelType::Rel(rel)),
             });
+        }
+
+        // Root relations don't support addenda — reject rather than silently discard.
+        if !node.addenda.is_empty() {
+            let line_no = node.addenda[0].line_no();
+            return Err(ParseError::ValidationError(format!(
+                "line {line_no}: addenda (+ Enh: / + Opt: / + Row) are not \
+                 supported on Root relations",
+            )));
         }
 
         // Named root relation.

--- a/src/textify/foundation.rs
+++ b/src/textify/foundation.rs
@@ -53,6 +53,10 @@ pub struct OutputOptions {
     /// Show the binary values for literal types as hex strings. Normally, they
     /// are shown as '{{binary}}'
     pub show_literal_binaries: bool,
+    /// Maximum number of cells (rows * columns) for a VirtualTable to use
+    /// inline form. Tables exceeding this use verbose `+ Row` form.
+    /// Chosen to keep inline form roughly within one 80-column line.
+    pub virtual_table_inline_threshold: usize,
 }
 
 impl Default for OutputOptions {
@@ -68,6 +72,7 @@ impl Default for OutputOptions {
             nullability: false,
             indent: "  ".to_string(),
             show_literal_binaries: false,
+            virtual_table_inline_threshold: 8,
         }
     }
 }
@@ -88,6 +93,8 @@ impl OutputOptions {
             nullability: true,
             indent: "  ".to_string(),
             show_literal_binaries: true,
+            // Always use verbose (+ Row) form in verbose mode
+            virtual_table_inline_threshold: 0,
         }
     }
 }

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -283,6 +283,9 @@ pub struct Relation<'a> {
     ///  Extension relations (`ExtensionLeaf`, `ExtensionSingle`, `ExtensionMulti`)
     /// do not carry this field and always set it to `None`.
     pub advanced_extension: Option<&'a AdvancedExtension>,
+    /// Row data for VirtualTable reads in verbose form. Each inner Vec holds
+    /// the expressions for one `+ Row[...]` line.
+    pub rows: Vec<Vec<Value<'a>>>,
     /// The input relations.
     pub children: Vec<Option<Relation<'a>>>,
 }
@@ -294,12 +297,21 @@ impl Textify for Relation<'_> {
 
     fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
         self.write_header(ctx, w)?;
+        let child_scope = ctx.push_indent();
         // Emit any enhancement / optimizations between the header line and the
         // child relations, indented one level deeper than this relation — the
         // same position they occupy in the text format when parsed.
         if let Some(adv_ext) = self.advanced_extension {
-            let child_scope = ctx.push_indent();
             adv_ext.textify(&child_scope, w)?;
+        }
+        // Emit verbose row addenda for VirtualTable reads.
+        for row in &self.rows {
+            write!(
+                w,
+                "\n{}+ Row[{}]",
+                child_scope.indent(),
+                ctx.separated(row, ", ")
+            )?;
         }
         self.write_children(ctx, w)?;
         Ok(())
@@ -366,48 +378,99 @@ impl<'a> Textify for TableName<'a> {
     }
 }
 
-pub fn get_table_name(rel: Option<&ReadType>) -> Result<&[String], PlanError> {
-    match rel {
-        Some(ReadType::NamedTable(r)) => Ok(r.names.as_slice()),
-        _ => Err(PlanError::unimplemented(
-            "ReadRel",
-            Some("table_name"),
-            format!("Unexpected read type {rel:?}") as String,
-        )),
+impl<'a> Relation<'a> {
+    fn from_read<S: Scope>(rel: &'a ReadRel, ctx: &S) -> Self {
+        let columns = read_columns(rel);
+        let emit = rel.common.as_ref().and_then(|c| c.emit_kind.as_ref());
+
+        match &rel.read_type {
+            Some(ReadType::NamedTable(table)) => {
+                let table_name = Value::TableName(table.names.iter().map(|n| Name(n)).collect());
+                Relation {
+                    name: Cow::Borrowed("Read"),
+                    arguments: Some(Arguments {
+                        positional: vec![table_name],
+                        named: vec![],
+                    }),
+                    columns,
+                    emit,
+                    advanced_extension: rel.advanced_extension.as_ref(),
+                    rows: vec![],
+                    children: vec![],
+                }
+            }
+            Some(ReadType::VirtualTable(vt)) => {
+                let col_count = columns.len();
+                let row_count = vt.expressions.len();
+                let threshold = ctx.options().virtual_table_inline_threshold;
+                let use_inline = row_count * col_count <= threshold;
+
+                let (inline, rows_addenda) = if use_inline {
+                    // Inline: rows as tuple arguments
+                    (
+                        vt.expressions
+                            .iter()
+                            .map(|row| {
+                                Value::Tuple(row.fields.iter().map(Value::Expression).collect())
+                            })
+                            .collect(),
+                        vec![],
+                    )
+                } else {
+                    // Verbose: empty arguments, rows as addenda
+                    (
+                        vec![],
+                        vt.expressions
+                            .iter()
+                            .map(|row| row.fields.iter().map(Value::Expression).collect())
+                            .collect(),
+                    )
+                };
+                let arguments = Some(Arguments {
+                    positional: inline,
+                    named: vec![],
+                });
+
+                Relation {
+                    name: Cow::Borrowed("Read:Virtual"),
+                    arguments,
+                    columns,
+                    emit,
+                    advanced_extension: rel.advanced_extension.as_ref(),
+                    rows: rows_addenda,
+                    children: vec![],
+                }
+            }
+            other => {
+                let err = PlanError::unimplemented(
+                    "ReadRel",
+                    Some("read_type"),
+                    format!("Unsupported read type {other:?}"),
+                );
+                Relation {
+                    name: Cow::Borrowed("Read"),
+                    arguments: Some(Arguments {
+                        positional: vec![Value::Missing(err)],
+                        named: vec![],
+                    }),
+                    columns,
+                    emit,
+                    advanced_extension: rel.advanced_extension.as_ref(),
+                    rows: vec![],
+                    children: vec![],
+                }
+            }
+        }
     }
 }
 
-impl<'a> Relation<'a> {
-    fn from_read<S: Scope>(rel: &'a ReadRel, _ctx: &S) -> Self {
-        let name = get_table_name(rel.read_type.as_ref());
-        let table_name: Value = match name {
-            Ok(n) => Value::TableName(n.iter().map(|n| Name(n)).collect()),
-            Err(e) => Value::Missing(e),
-        };
-
-        let columns = match rel.base_schema {
-            Some(ref schema) => schema_to_values(schema),
-            None => {
-                let err = PlanError::unimplemented(
-                    "ReadRel",
-                    Some("base_schema"),
-                    "Base schema is required",
-                );
-                vec![Value::Missing(err)]
-            }
-        };
-        let emit = rel.common.as_ref().and_then(|c| c.emit_kind.as_ref());
-
-        Relation {
-            name: Cow::Borrowed("Read"),
-            arguments: Some(Arguments {
-                positional: vec![table_name],
-                named: vec![],
-            }),
-            columns,
-            emit,
-            advanced_extension: rel.advanced_extension.as_ref(),
-            children: vec![],
+fn read_columns<'a>(rel: &'a ReadRel) -> Vec<Value<'a>> {
+    match rel.base_schema {
+        Some(ref schema) => schema_to_values(schema),
+        None => {
+            let err =
+                PlanError::unimplemented("ReadRel", Some("base_schema"), "Base schema is required");
+            vec![Value::Missing(err)]
         }
     }
 }
@@ -478,6 +541,7 @@ impl<'a> Relation<'a> {
             columns,
             emit,
             advanced_extension: rel.advanced_extension.as_ref(),
+            rows: vec![],
             children,
         }
     }
@@ -498,6 +562,7 @@ impl<'a> Relation<'a> {
             columns,
             emit: get_emit(rel.common.as_ref()),
             advanced_extension: rel.advanced_extension.as_ref(),
+            rows: vec![],
             children,
         }
     }
@@ -527,6 +592,7 @@ impl<'a> Relation<'a> {
                     columns: vec![],
                     emit: None,
                     advanced_extension: None,
+                    rows: vec![],
                     children: vec![],
                 }
             }
@@ -600,6 +666,7 @@ impl<'a> Relation<'a> {
                     // `advanced_extension`; the field does not exist on these
                     // proto types.
                     advanced_extension: None,
+                    rows: vec![],
                     children,
                 }
             }
@@ -615,6 +682,7 @@ impl<'a> Relation<'a> {
                     ))],
                     emit: None,
                     advanced_extension: None,
+                    rows: vec![],
                     children,
                 }
             }
@@ -700,6 +768,7 @@ impl<'a> Relation<'a> {
             columns: all_outputs,
             emit,
             advanced_extension: rel.advanced_extension.as_ref(),
+            rows: vec![],
             children,
         }
     }
@@ -808,6 +877,7 @@ impl<'a> Relation<'a> {
             columns: col_values,
             emit,
             advanced_extension: rel.advanced_extension.as_ref(),
+            rows: vec![],
             children,
         }
     }
@@ -865,6 +935,7 @@ impl<'a> Relation<'a> {
             columns,
             emit,
             advanced_extension: rel.advanced_extension.as_ref(),
+            rows: vec![],
             children,
         }
     }
@@ -976,6 +1047,7 @@ impl<'a> Relation<'a> {
             columns,
             emit,
             advanced_extension: rel.advanced_extension.as_ref(),
+            rows: vec![],
             children,
         }
     }

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -310,7 +310,7 @@ impl Textify for Relation<'_> {
                 w,
                 "\n{}+ Row[{}]",
                 child_scope.indent(),
-                ctx.separated(row, ", ")
+                child_scope.separated(row, ", ")
             )?;
         }
         self.write_children(ctx, w)?;

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -883,7 +883,7 @@ impl<'a> Relation<'a> {
     }
 
     fn from_fetch<S: Scope>(rel: &'a FetchRel, ctx: &S) -> Self {
-        let (children, _) = Relation::convert_children(vec![rel.input.as_deref()], ctx);
+        let (children, input_columns) = Relation::convert_children(vec![rel.input.as_deref()], ctx);
         let mut named_args: Vec<NamedArg> = vec![];
         match &rel.count_mode {
             Some(CountMode::CountExpr(expr)) => {
@@ -920,12 +920,10 @@ impl<'a> Relation<'a> {
         }
 
         let emit = get_emit(rel.common.as_ref());
-        let mut columns = vec![];
-        if let Some(EmitKind::Emit(e)) = emit {
-            for &i in &e.output_mapping {
-                columns.push(Value::Reference(i));
-            }
-        }
+        // Fetch is passthrough — direct output is all input columns.
+        let columns: Vec<Value> = (0..input_columns)
+            .map(|i| Value::Reference(i as i32))
+            .collect();
         Relation {
             name: Cow::Borrowed("Fetch"),
             arguments: Some(Arguments {

--- a/tests/adv_extension_roundtrip.rs
+++ b/tests/adv_extension_roundtrip.rs
@@ -607,14 +607,10 @@ Root[result]
         .as_ref()
         .and_then(|c| c.emit_kind.as_ref())
         .expect("ProjectRel must have an emit");
-    let output_mapping = match emit_kind {
-        EmitKind::Emit(e) => &e.output_mapping,
-        EmitKind::Direct(_) => panic!("expected Emit, got Direct"),
-    };
-    assert_eq!(
-        output_mapping,
-        &[0_i32, 1, 2],
-        "emit mapping should be [0, 1, 2]; without fix it would be [0, 1, 0]"
+    // Identity mapping [0, 1, 2] over 3 direct outputs → Direct
+    assert!(
+        matches!(emit_kind, EmitKind::Direct(_)),
+        "Expected Direct for identity emit, got {emit_kind:?}"
     );
 
     // --- round-trip ---

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -602,9 +602,153 @@ Root[id]
         err.contains("+ Row addenda can only be attached to Read:Virtual"),
         "unexpected error: {err}"
     );
-    // Error should report the line number of the offending + Row line.
+    // Error reports the relation's line number (the Read, line 4), not the + Row line.
     assert!(
-        err.contains("line 5"),
+        err.contains("line 4"),
         "expected line number in error: {err}"
     );
+}
+
+// === Emit / output-field-count propagation tests ===
+//
+// These exercise the pipeline: child's output_field_count → parent's
+// input_field_count → correct emit indices for expressions in Project.
+// If any relation type returns the wrong output count, the Project's emit
+// mapping will be offset incorrectly and the roundtrip will fail.
+
+#[test]
+fn test_emit_read_to_project_with_expression() {
+    // Read outputs 2 columns. Project has expression add($0,$1) → emit index should be 2.
+    let plan = r#"
+=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml
+Functions:
+  # 10 @  1: add
+
+=== Plan
+Root[sum]
+  Project[add($0, $1)]
+    Read[t => a:i64, b:i64]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_emit_filter_to_project_with_expression() {
+    // Read outputs 3, Filter emits 2 ($0, $1). Project sees 2 inputs.
+    let plan = r#"
+=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml
+  @  2: https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml
+Functions:
+  # 10 @  1: add
+  # 11 @  2: gt
+
+=== Plan
+Root[sum]
+  Project[add($0, $1)]
+    Filter[gt($2, 0) => $0, $1]
+      Read[t => a:i64, b:i64, c:i64]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_emit_sort_to_project_with_expression() {
+    // Sort is passthrough — its output count should equal its input's.
+    let plan = r#"
+=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml
+Functions:
+  # 10 @  1: add
+
+=== Plan
+Root[sum]
+  Project[add($0, $1)]
+    Sort[($0, &AscNullsFirst) => $0, $1]
+      Read[t => a:i64, b:i64]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_emit_fetch_to_project_with_expression() {
+    // Fetch is passthrough — its output count should equal its input's.
+    let plan = r#"
+=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml
+Functions:
+  # 10 @  1: add
+
+=== Plan
+Root[sum]
+  Project[add($0, $1)]
+    Fetch[limit=10, offset=0 => $0, $1]
+      Read[t => a:i64, b:i64]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_emit_join_to_project_with_expression() {
+    // Join: left has 2 cols, right has 2 cols → 4 total. Project sees 4.
+    let plan = r#"
+=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml
+  @  2: https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml
+Functions:
+  # 10 @  1: add
+  # 11 @  2: eq
+
+=== Plan
+Root[sum]
+  Project[add($1, $3)]
+    Join[&Inner, eq($0, $2) => $0, $1, $2, $3]
+      Read[users => id:i64, age:i64]
+      Read[orders => user_id:i64, amount:i64]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_emit_aggregate_to_project_with_expression() {
+    // Aggregate: 1 grouping field + 1 measure = 2 output columns.
+    let plan = r#"
+=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml
+  @  2: https://github.com/substrait-io/substrait/blob/main/extensions/functions_aggregate.yaml
+Functions:
+  # 10 @  1: add
+  # 11 @  2: sum
+
+=== Plan
+Root[total]
+  Project[add($0, $1)]
+    Aggregate[$0 => $0, sum($1)]
+      Read[t => category:i64, amount:i64]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_emit_virtual_read_to_project_with_expression() {
+    let plan = r#"
+=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml
+Functions:
+  # 10 @  1: add
+
+=== Plan
+Root[sum]
+  Project[add($0, $1)]
+    Read:Virtual[(1, 2), (3, 4) => a:i64, b:i64]"#;
+
+    roundtrip_plan(plan);
 }

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -467,3 +467,144 @@ Root[result]
 
     roundtrip_plan(plan);
 }
+
+// === VirtualTable Read tests ===
+
+#[test]
+fn test_virtual_read_inline_single_row() {
+    let plan = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[(1, 'alice') => id:i64, name:string]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_virtual_read_inline_multi_row() {
+    let plan = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[(1, 'alice'), (2, 'bob') => id:i64, name:string]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_virtual_read_verbose_parses() {
+    // Verbose form with a small table (4 cells) parses correctly and
+    // produces the canonical inline form.
+    let inline = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[(1, 'alice'), (2, 'bob') => id:i64, name:string]"#;
+
+    let verbose = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[_ => id:i64, name:string]
+    + Row[1, 'alice']
+    + Row[2, 'bob']"#;
+
+    assert_roundtrip_canonical(inline, verbose);
+}
+
+#[test]
+fn test_virtual_read_empty() {
+    let plan = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[_ => id:i64, name:string]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_virtual_read_single_column() {
+    let plan = r#"
+=== Plan
+Root[id]
+  Read:Virtual[(1), (2), (3) => id:i64]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_virtual_read_large_table_uses_verbose() {
+    // 3 rows * 3 columns = 9, which is > 8, so verbose is canonical.
+    let verbose = r#"
+=== Plan
+Root[a, b, c]
+  Read:Virtual[_ => a:i64, b:i64, c:i64]
+    + Row[1, 2, 3]
+    + Row[4, 5, 6]
+    + Row[7, 8, 9]"#;
+
+    let inline = r#"
+=== Plan
+Root[a, b, c]
+  Read:Virtual[(1, 2, 3), (4, 5, 6), (7, 8, 9) => a:i64, b:i64, c:i64]"#;
+
+    assert_roundtrip_canonical(verbose, inline);
+}
+
+#[test]
+fn test_virtual_read_in_plan_context() {
+    // VirtualTable as input to Filter and Project
+    let plan = r#"
+=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml
+Functions:
+  # 10 @  1: gt
+
+=== Plan
+Root[name]
+  Filter[gt($0, 1) => $0, $1]
+    Read:Virtual[(1, 'alice'), (2, 'bob'), (3, 'carol') => id:i64, name:string]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_addendum_on_root_rejected() {
+    let plan = r#"
+=== Plan
+Root[id]
+  + Row[1]
+  Read:Virtual[_ => id:i64]"#;
+
+    let result = Parser::parse(plan);
+    assert!(result.is_err(), "addenda on Root should be rejected");
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("not supported on Root"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_row_addendum_on_non_virtual_rejected() {
+    // + Row on a regular Read should be rejected with a line number.
+    let plan = r#"
+=== Plan
+Root[id]
+  Read[data => id:i64]
+    + Row[1]"#;
+
+    let result = Parser::parse(plan);
+    assert!(
+        result.is_err(),
+        "+ Row on non-VirtualTable should be rejected"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("+ Row addenda can only be attached to Read:Virtual"),
+        "unexpected error: {err}"
+    );
+    // Error should report the line number of the offending + Row line.
+    assert!(
+        err.contains("line 5"),
+        "expected line number in error: {err}"
+    );
+}


### PR DESCRIPTION
## Description

Add support for VirtualTable in ReadRel (closes #56), enabling inline literal data tables in Substrait plans — similar to SQL `VALUES` clauses.

Two text formats are supported:

**Inline** (default for small tables, `rows * columns <= 8`):
```
Read:Virtual[(1, 'alice'), (2, 'bob') => id:i64, name:string]
```

**Verbose** (default for larger tables):
```
Read:Virtual[_ => id:i64, name:string]
  + Row[1, 'alice']
  + Row[2, 'bob']
```

Both forms are always accepted by the parser; the textifier selects based on a configurable threshold. Mixed form (inline rows + `+ Row` addenda) is accepted but never produced.

### Design decisions

- `Read:Virtual` uses the `Type:Subtype` colon pattern (consistent with `ExtensionLeaf:Name`)
- `+ Row` uses the `+`-prefixed addendum pattern (same structural role as `+ Enh:` / `+ Opt:`)
- `Addendum` enum unifies `AdvExt` and `Row` handling in the structural parser

### Parser refactoring (included)

VirtualTable support exposed an opportunity to make the parser trait more self-contained:

- **`RelationParsePair` redesign**: `parse_pair_with_context` now returns `(Self, usize)` — each relation type computes its own output field count during parsing rather than having it reconstructed afterward. `into_rel` takes `RelationAddenda` (pre-parsed rows + advanced extension) so each type handles its own addenda.
- **Identity emit**: new `make_emit` helper produces `EmitKind::Direct` for identity output mappings instead of an explicit `Emit`, matching Substrait semantics. This also fixes a Fetch textifier regression where passthrough columns were emitted as empty when `EmitKind::Direct` was in effect.
- **Structured error messages**: `ParseError::ValidationError` now carries `ParseContext` for line-precise diagnostics.
- Extension relations now reject `+ Enh:` / `+ Opt:` addenda with an explicit error (previously silently applied).

## Type of Change

- [x] New feature
- [x] Documentation update

## Testing

- [x] Added 8 roundtrip tests (inline, verbose, empty table, single-column, large table uses verbose, VirtualTable in complex plan, error paths)
- [x] All existing tests pass (309 total)
- [x] GRAMMAR.md doc tests compile and pass

## Checklist

- [x] Code follows Rust conventions
- [x] Documentation updated if needed
- [x] No breaking changes (or breaking changes documented)
- [x] Pre-commit hooks pass

## Related Issues

Closes #56
