### PR TITLE
feat: support VirtualTable Read with inline format

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -537,14 +537,13 @@ The `Read:Virtual` relation uses the same `ReadRel` protobuf message with `ReadT
 
 `"Read:Virtual" "[" (virtual_row ("," virtual_row)*)? "=>" named_column_list "]"`
 
-Where `virtual_row := "(" expression ("," expression)* ")"` — a parenthesized tuple of expressions forming one row. Use `_` in place of rows for an empty virtual table.
+Where `virtual_row := "(" (expression ("," expression)*)? ")"` — a parenthesized tuple of expressions forming one row. Rows may be empty (`()`) for zero-column tables. For an empty virtual table, write `_` in place of the entire row list, e.g. `Read:Virtual[_ => id:i64]` for zero rows.
 
 #### Components
 
-- `virtual_row` - parenthesized tuple of expressions, one per row
+- `virtual_row` - parenthesized tuple of expressions, one per row; `()` for zero-column rows
 - `expression` - any expression (literal, field reference, function call)
 - `named_column_list` - output column names with type annotations
-- `_` - empty marker (no rows)
 
 #### Examples
 
@@ -758,9 +757,11 @@ positional_args := extension_arg ("," extension_arg)*
 extension_arg := reference / literal / expression
 named_args := named_arg ("," named_arg)*
 named_arg := name "=" extension_arg
-extension_columns := extension_column ("," extension_column)*
+extension_columns := (extension_column ("," extension_column)*)?
 extension_column := named_column / reference / expression
 ```
+
+Note: the parser also accepts the `=>` section being omitted entirely (e.g. `ExtensionLeaf:Foo[_]`), treating it as zero output columns. The canonical form always includes `=>`.
 
 #### Components
 
@@ -782,13 +783,13 @@ Root[result]
 Extension with positional arguments and no output columns:
 
 ```text
-ExtensionSingle:VectorNormalize[$0, $1, method='l2']
+ExtensionSingle:VectorNormalize[$0, $1, method='l2' => ]
 ```
 
 Extension with no arguments:
 
 ```text
-ExtensionLeaf:EmptySource[_]
+ExtensionLeaf:EmptySource[_ => ]
 ```
 
 #### Custom Extension Types

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -527,6 +527,57 @@ Root[result2]
 # assert_eq!(plan.relations.len(), 2);
 ```
 
+### VirtualTable Read Relation
+
+A VirtualTable read embeds inline data directly in the plan, similar to SQL's `VALUES` clause. Instead of referencing a catalog table, the data rows are specified as part of the relation.
+
+The `Read:Virtual` relation uses the same `ReadRel` protobuf message with `ReadType::VirtualTable`, where each row is a `nested::Struct` containing expressions.
+
+#### Syntax
+
+`"Read:Virtual" "[" (virtual_row ("," virtual_row)*)? "=>" named_column_list "]"`
+
+Where `virtual_row := "(" expression ("," expression)* ")"` — a parenthesized tuple of expressions forming one row. Use `_` in place of rows for an empty virtual table.
+
+#### Components
+
+- `virtual_row` - parenthesized tuple of expressions, one per row
+- `expression` - any expression (literal, field reference, function call)
+- `named_column_list` - output column names with type annotations
+- `_` - empty marker (no rows)
+
+#### Examples
+
+Inline form with two rows:
+
+```rust
+# use substrait_explain::parser::Parser;
+#
+# let plan_text = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[(1, 'alice'), (2, 'bob') => id:i64, name:string]
+# "#;
+#
+# let plan = Parser::parse(plan_text).unwrap();
+# assert_eq!(plan.relations.len(), 1);
+```
+
+Empty virtual table (no rows):
+
+```rust
+# use substrait_explain::parser::Parser;
+#
+# let plan_text = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[_ => id:i64, name:string]
+# "#;
+#
+# let plan = Parser::parse(plan_text).unwrap();
+# assert_eq!(plan.relations.len(), 1);
+```
+
 ### Filter Relation
 
 #### Syntax

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -212,7 +212,11 @@ named_column      = { name ~ ":" ~ type }
 named_column_list = { (named_column ~ ("," ~ sp ~ named_column)*)? }
 
 planNode = {
-    read_relation
+    // virtual_read_relation must precede read_relation: both start with "Read",
+    // and PEG tries alternatives in order — the longer "Read:Virtual" prefix
+    // must be attempted first.
+    virtual_read_relation
+  | read_relation
   | filter_relation
   | project_relation
   | aggregate_relation
@@ -233,6 +237,13 @@ root_relation  = { "Root" ~ "[" ~ root_name_list ~ "]" }
 root_name_list = { (name ~ (sp ~ "," ~ sp ~ name)*)? }
 
 read_relation = { "Read" ~ "[" ~ table_name ~ sp ~ "=>" ~ sp ~ named_column_list ~ "]" }
+
+// VirtualTable read: Read:Virtual[rows => columns] or Read:Virtual[_ => columns]
+// Rows are parenthesized tuples; _ means empty (no rows).
+virtual_read_relation = { "Read:Virtual" ~ "[" ~ virtual_read_args ~ sp ~ "=>" ~ sp ~ named_column_list ~ "]" }
+virtual_read_args     = { virtual_row_list | empty }
+virtual_row_list      = { virtual_row ~ (sp ~ "," ~ sp ~ virtual_row)* }
+virtual_row           = { "(" ~ sp ~ expression_list ~ sp ~ ")" }
 
 filter_relation = { "Filter" ~ "[" ~ expression ~ sp ~ "=>" ~ sp ~ reference_list ~ "]" }
 reference_list  = { (reference ~ (sp ~ "," ~ sp ~ reference)*)? }

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -243,7 +243,7 @@ read_relation = { "Read" ~ "[" ~ table_name ~ sp ~ "=>" ~ sp ~ named_column_list
 virtual_read_relation = { "Read:Virtual" ~ "[" ~ virtual_read_args ~ sp ~ "=>" ~ sp ~ named_column_list ~ "]" }
 virtual_read_args     = { virtual_row_list | empty }
 virtual_row_list      = { virtual_row ~ (sp ~ "," ~ sp ~ virtual_row)* }
-virtual_row           = { "(" ~ sp ~ expression_list ~ sp ~ ")" }
+virtual_row           = { "(" ~ sp ~ expression_list? ~ sp ~ ")" }
 
 filter_relation = { "Filter" ~ "[" ~ expression ~ sp ~ "=>" ~ sp ~ reference_list ~ "]" }
 reference_list  = { (reference ~ (sp ~ "," ~ sp ~ reference)*)? }
@@ -317,7 +317,7 @@ extension_named_arguments = { extension_named_argument ~ (sp ~ "," ~ sp ~ extens
 extension_named_argument  = { name ~ sp ~ "=" ~ sp ~ extension_argument }
 
 // Output columns - can mix named columns, references, and expressions
-extension_columns = { extension_column ~ (sp ~ "," ~ sp ~ extension_column)* }
+extension_columns = { (extension_column ~ (sp ~ "," ~ sp ~ extension_column)*)? }
 extension_column  = { named_column | reference | expression }
 
 // Advanced extensions: enhancements and optimizations attached to relations

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -451,17 +451,21 @@ fn parse_virtual_read_args(
     }
 }
 
-/// Parse a single `virtual_row` (`(expr, expr, ...)`) into a `nested::Struct`.
+/// Parse a single `virtual_row` (`(expr, expr, ...)` or `()`) into a `nested::Struct`.
 fn parse_virtual_row(
     extensions: &SimpleExtensions,
     pair: Pair<Rule>,
 ) -> Result<nested::Struct, MessageParseError> {
     assert_eq!(pair.as_rule(), Rule::virtual_row);
-    let expression_list = unwrap_single_pair(pair);
-    assert_eq!(expression_list.as_rule(), Rule::expression_list);
-    Ok(nested::Struct {
-        fields: parse_expression_list(extensions, expression_list)?,
-    })
+    let fields = match pair.into_inner().next() {
+        Some(expression_list) => {
+            assert_eq!(expression_list.as_rule(), Rule::expression_list);
+            parse_expression_list(extensions, expression_list)?
+        }
+        // Empty virtual row. An unusual but valid case.
+        None => vec![],
+    };
+    Ok(nested::Struct { fields })
 }
 
 impl RelationParsePair for FilterRel {

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -4,7 +4,7 @@ use pest::iterators::Pair;
 use prost::Message;
 use substrait::proto::aggregate_rel::Grouping;
 use substrait::proto::expression::literal::LiteralType;
-use substrait::proto::expression::{Literal, RexType};
+use substrait::proto::expression::{Literal, RexType, nested};
 use substrait::proto::extensions::AdvancedExtension;
 use substrait::proto::fetch_rel::{CountMode, OffsetMode};
 use substrait::proto::rel::RelType;
@@ -355,6 +355,69 @@ impl RelationParsePair for ReadRel {
     }
 }
 
+/// Parsed `Read:Virtual[rows => columns]` relation. Needs a newtype because the
+/// proto type is `ReadRel` (same as `NamedTable`), but the grammar and handling
+/// are different.
+pub(crate) struct VirtualReadRel(ReadRel);
+
+impl RelationParsePair for VirtualReadRel {
+    fn rule() -> Rule {
+        Rule::virtual_read_relation
+    }
+
+    fn message() -> &'static str {
+        "VirtualReadRel"
+    }
+
+    fn parse_pair_with_context(
+        extensions: &SimpleExtensions,
+        pair: Pair<Rule>,
+        input_children: Vec<Box<Rel>>,
+        _input_field_count: usize,
+    ) -> Result<(Self, usize), MessageParseError> {
+        assert_eq!(pair.as_rule(), Self::rule());
+        if !input_children.is_empty() {
+            return Err(MessageParseError::invalid(
+                Self::message(),
+                pair.as_span(),
+                "Read:Virtual should have no input children",
+            ));
+        }
+
+        let mut iter = RuleIter::from(pair.into_inner());
+        let args_pair = iter.pop(Rule::virtual_read_args);
+        let columns_pair = iter.pop(Rule::named_column_list);
+        iter.done();
+
+        let rows = parse_virtual_read_args(extensions, args_pair)?;
+        let columns = NamedColumnList::parse_pair(extensions, columns_pair)?.0;
+
+        // TODO: Validate that each row has the same number of expressions as
+        // columns. Currently no parser-side warning mechanism exists, and while
+        // this is an invalid plan, it is constructible as Substrait. Consider
+        // adding once a warning collection path is available.
+        let output_count = columns.len();
+        Ok((
+            VirtualReadRel(ReadRel {
+                base_schema: Some(build_named_struct(columns)),
+                read_type: Some(read_rel::ReadType::VirtualTable(read_rel::VirtualTable {
+                    expressions: rows,
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }),
+            output_count,
+        ))
+    }
+
+    fn into_rel(mut self, adv_ext: Option<AdvancedExtension>) -> Rel {
+        self.0.advanced_extension = adv_ext;
+        Rel {
+            rel_type: Some(RelType::Read(Box::new(self.0))),
+        }
+    }
+}
+
 /// Build a `NamedStruct` from parsed columns.
 fn build_named_struct(columns: Vec<Column>) -> NamedStruct {
     let (names, types): (Vec<_>, Vec<_>) = columns.into_iter().map(|c| (c.name, c.typ)).unzip();
@@ -366,6 +429,39 @@ fn build_named_struct(columns: Vec<Column>) -> NamedStruct {
             nullability: r#type::Nullability::Required as i32,
         }),
     }
+}
+
+/// `Read:Virtual` positional args: either `empty` or a list of row tuples.
+fn parse_virtual_read_args(
+    extensions: &SimpleExtensions,
+    pair: Pair<Rule>,
+) -> Result<Vec<nested::Struct>, MessageParseError> {
+    assert_eq!(pair.as_rule(), Rule::virtual_read_args);
+    let inner = unwrap_single_pair(pair);
+    match inner.as_rule() {
+        Rule::empty => Ok(vec![]),
+        Rule::virtual_row_list => inner
+            .into_inner()
+            .map(|row| parse_virtual_row(extensions, row))
+            .collect(),
+        _ => unreachable!(
+            "Unexpected rule in virtual_read_args: {:?}",
+            inner.as_rule()
+        ),
+    }
+}
+
+/// Parse a single `virtual_row` (`(expr, expr, ...)`) into a `nested::Struct`.
+fn parse_virtual_row(
+    extensions: &SimpleExtensions,
+    pair: Pair<Rule>,
+) -> Result<nested::Struct, MessageParseError> {
+    assert_eq!(pair.as_rule(), Rule::virtual_row);
+    let expression_list = unwrap_single_pair(pair);
+    assert_eq!(expression_list.as_rule(), Rule::expression_list);
+    Ok(nested::Struct {
+        fields: parse_expression_list(extensions, expression_list)?,
+    })
 }
 
 impl RelationParsePair for FilterRel {
@@ -519,7 +615,7 @@ impl RelationParsePair for AggregateRel {
             .next()
             .expect("aggregate_group_by must have one inner item");
 
-        let grouping_sets = parse_grouping_sets(extensions, inner);
+        let grouping_sets = parse_grouping_sets(extensions, inner)?;
         let (groupings, grouping_expressions) = build_grouping_fields(&grouping_sets);
 
         let (measures, output_mapping) =
@@ -593,7 +689,7 @@ fn parse_aggregate_measures(
 fn parse_grouping_sets(
     extensions: &SimpleExtensions,
     inner: Pair<'_, Rule>,
-) -> Vec<Vec<Expression>> {
+) -> Result<Vec<Vec<Expression>>, MessageParseError> {
     assert!(
         matches!(
             inner.as_rule(),
@@ -603,9 +699,7 @@ fn parse_grouping_sets(
         inner.as_rule()
     );
     match inner.as_rule() {
-        Rule::expression_list => {
-            vec![parse_expression_list(extensions, inner)]
-        }
+        Rule::expression_list => Ok(vec![parse_expression_list(extensions, inner)?]),
         Rule::grouping_set_list => inner
             .into_inner()
             .map(|pair| parse_grouping_set(extensions, pair))
@@ -620,26 +714,29 @@ fn parse_grouping_sets(
 /// Parses a single grouping set, e.g. `($0, $1)` or `_`.
 ///
 /// Grammar: `grouping_set = { ("(" ~ expression_list ~ ")") | empty }`
-fn parse_grouping_set(extensions: &SimpleExtensions, pair: Pair<'_, Rule>) -> Vec<Expression> {
+fn parse_grouping_set(
+    extensions: &SimpleExtensions,
+    pair: Pair<'_, Rule>,
+) -> Result<Vec<Expression>, MessageParseError> {
     assert_eq!(pair.as_rule(), Rule::grouping_set);
     let inner = pair
         .into_inner()
         .next()
         .expect("grouping_set must have one inner item");
     match inner.as_rule() {
-        Rule::empty => vec![],
+        Rule::empty => Ok(vec![]),
         Rule::expression_list => parse_expression_list(extensions, inner),
         _ => unreachable!("Unexpected item in grouping_set: {:?}", inner.as_rule()),
     }
 }
 
 /// Grammar: `expression_list = { expression ~ ("," ~ expression)* }`
-fn parse_expression_list(extensions: &SimpleExtensions, pair: Pair<'_, Rule>) -> Vec<Expression> {
+pub(crate) fn parse_expression_list(
+    extensions: &SimpleExtensions,
+    pair: Pair<'_, Rule>,
+) -> Result<Vec<Expression>, MessageParseError> {
     pair.into_inner()
-        .map(|expr_pair| {
-            Expression::parse_pair(extensions, expr_pair)
-                .expect("By the grammar rule, only expressions should be parsed")
-        })
+        .map(|expr_pair| Expression::parse_pair(extensions, expr_pair))
         .collect()
 }
 

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -20,7 +20,7 @@ use crate::parser::expressions::Name;
 use crate::parser::extensions::{
     AdvExtInvocation, ExtensionInvocation, ExtensionParseError, ExtensionParser,
 };
-use crate::parser::relations::RelationParsingContext;
+use crate::parser::relations::{RelationParsingContext, VirtualReadRel};
 use crate::parser::{ErrorKind, ExpressionParser, RelationParsePair, Rule, unwrap_single_pair};
 
 pub const PLAN_HEADER: &str = "=== Plan";
@@ -312,6 +312,7 @@ impl<'a> RelationParser<'a> {
         ctx: RelationContext,
     ) -> Result<(Rel, usize), ParseError> {
         match ctx.pair.as_rule() {
+            Rule::virtual_read_relation => self.parse_rel::<VirtualReadRel>(extensions, ctx),
             Rule::read_relation => self.parse_rel::<ReadRel>(extensions, ctx),
             Rule::filter_relation => self.parse_rel::<FilterRel>(extensions, ctx),
             Rule::project_relation => self.parse_rel::<ProjectRel>(extensions, ctx),

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -386,6 +386,25 @@ impl<'a> Relation<'a> {
                     children: vec![],
                 }
             }
+            Some(ReadType::VirtualTable(vt)) => {
+                let positional = vt
+                    .expressions
+                    .iter()
+                    .map(|row| Value::Tuple(row.fields.iter().map(Value::Expression).collect()))
+                    .collect();
+
+                Relation {
+                    name: Cow::Borrowed("Read:Virtual"),
+                    arguments: Some(Arguments {
+                        positional,
+                        named: vec![],
+                    }),
+                    columns,
+                    emit,
+                    advanced_extension: rel.advanced_extension.as_ref(),
+                    children: vec![],
+                }
+            }
             other => {
                 let err = PlanError::unimplemented(
                     "ReadRel",

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -321,11 +321,7 @@ impl Relation<'_> {
             }
             Some(args) => {
                 let args = ctx.display(args);
-                if self.columns.is_empty() && self.emit.is_none() {
-                    write!(w, "{indent}{name}[{args}]")
-                } else {
-                    write!(w, "{indent}{name}[{args} => {cols}]")
-                }
+                write!(w, "{indent}{name}[{args} => {cols}]")
             }
         }
     }

--- a/tests/extension_roundtrip.rs
+++ b/tests/extension_roundtrip.rs
@@ -375,7 +375,7 @@ fn test_extension_empty_args_roundtrip() {
     let plan_text = r#"
 === Plan
 Root[result]
-  ExtensionLeaf:EmptySource[_]
+  ExtensionLeaf:EmptySource[_ => ]
 "#;
 
     let parser = Parser::new().with_extension_registry(registry.clone());

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -529,6 +529,17 @@ Root[name]
 }
 
 #[test]
+fn test_virtual_read_no_columns() {
+    // Degenerate table with zero columns and empty rows.
+    let plan = r#"
+=== Plan
+Root[]
+  Read:Virtual[(), () => ]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
 fn test_virtual_read_invalid_expression_returns_error() {
     // A function call referencing an undeclared extension should produce
     // a parse error, not a panic.

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -468,6 +468,82 @@ Root[result]
     roundtrip_plan(plan);
 }
 
+// === VirtualTable Read tests ===
+
+#[test]
+fn test_virtual_read_inline_single_row() {
+    let plan = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[(1, 'alice') => id:i64, name:string]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_virtual_read_inline_multi_row() {
+    let plan = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[(1, 'alice'), (2, 'bob') => id:i64, name:string]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_virtual_read_empty() {
+    let plan = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[_ => id:i64, name:string]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_virtual_read_single_column() {
+    let plan = r#"
+=== Plan
+Root[id]
+  Read:Virtual[(1), (2), (3) => id:i64]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_virtual_read_in_plan_context() {
+    // VirtualTable as input to Filter and Project
+    let plan = r#"
+=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml
+Functions:
+  # 10 @  1: gt
+
+=== Plan
+Root[name]
+  Filter[gt($0, 1) => $0, $1]
+    Read:Virtual[(1, 'alice'), (2, 'bob'), (3, 'carol') => id:i64, name:string]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_virtual_read_invalid_expression_returns_error() {
+    // A function call referencing an undeclared extension should produce
+    // a parse error, not a panic.
+    let plan = r#"
+=== Plan
+Root[result]
+  Read:Virtual[(unknown_func(1)) => result:i64]"#;
+
+    let result = Parser::parse(plan);
+    assert!(
+        result.is_err(),
+        "undeclared function in VirtualTable row should fail"
+    );
+}
+
 // === Emit / output-field-count propagation tests ===
 //
 // These exercise the pipeline: child's output_field_count → parent's
@@ -591,6 +667,23 @@ Root[total]
   Project[add($0, $1)]
     Aggregate[$0 => $0, sum($1)]
       Read[t => category:i64, amount:i64]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_emit_virtual_read_to_project_with_expression() {
+    let plan = r#"
+=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml
+Functions:
+  # 10 @  1: add
+
+=== Plan
+Root[sum]
+  Project[add($0, $1)]
+    Read:Virtual[(1, 2), (3, 4) => a:i64, b:i64]"#;
 
     roundtrip_plan(plan);
 }


### PR DESCRIPTION
## Description

> Depends on #107 (parser refactoring), which must merge first. Factored out of #101 - this is a simpler version of that (only inline parsing, no `+ Row` syntax).

Add support for `VirtualTable` in `ReadRel` (closes #56), enabling inline literal data tables in Substrait plans — similar to SQL `VALUES` clauses.

The virtual read is written as a `Read:Virtual` operator, with rows inline as positional arguments:

```
Read:Virtual[(1, 'alice'), (2, 'bob') => id:i64, name:string]
```

Use `_` for an empty virtual table (no rows):

```
Read:Virtual[_ => id:i64, name:string]
```

### Design decisions

- `Read:Virtual` uses the `Type:Subtype` colon pattern (consistent with `ExtensionLeaf:Name`)
- Uses the `Addendum` enum introduced in #107 for structural parser integration
- `GRAMMAR.md` updated with syntax, examples, and doc-tested code blocks

## Type of Change

- [x] New feature
- [x] Documentation update

## Testing

- [x] Added roundtrip tests (inline, empty table, single-column, VirtualTable in complex plans)
- [x] All existing tests pass
- [x] GRAMMAR.md doc tests compile and pass

## Checklist

- [x] Code follows Rust conventions
- [x] Documentation updated if needed
- [x] No breaking changes (or breaking changes documented)
- [x] Pre-commit hooks pass

## Related Issues

Closes #56
