### PR TITLE
refactor: self-contained RelationParsePair with identity emit

### DIFF
--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -5,7 +5,6 @@ use crate::extensions::{ExtensionRegistry, SimpleExtensions};
 use crate::format;
 use crate::parser::{MessageParseError, Parser, ScopedParse};
 use crate::textify::foundation::{ErrorAccumulator, ErrorList};
-use crate::textify::plan::PlanWriter;
 use crate::textify::{ErrorQueue, OutputOptions, Scope, ScopedContext, Textify};
 
 pub struct TestContext {
@@ -124,71 +123,5 @@ pub fn roundtrip_plan(input: &str) {
         "Expected:\n---\n{}\n---\nActual:\n---\n{}\n---",
         input.trim(),
         actual.trim()
-    );
-}
-
-/// Roundtrip a plan and verify that the output is the same as the input, after
-/// being parsed to a Substrait plan and then back to text.
-pub fn roundtrip_plan_with_verbose(input: &str, verbose_input: &str) {
-    let default_registry = ExtensionRegistry::new();
-
-    // Parse the simple plan
-    let simple_plan = Parser::parse(input).unwrap_or_else(|e| {
-        println!("Error parsing simple plan:\n{e}");
-        panic!("{e}");
-    });
-
-    // Parse the verbose plan
-    let verbose_plan = Parser::parse(verbose_input).unwrap_or_else(|e| {
-        println!("Error parsing verbose plan:\n{e}");
-        panic!("{e}");
-    });
-
-    // Test verbose output from both plans
-    let verbose_options = OutputOptions::verbose();
-    let (simple_verbose_writer, simple_verbose_errors) =
-        PlanWriter::<ErrorQueue>::new(&verbose_options, &simple_plan, &default_registry);
-    let simple_verbose_actual = format!("{simple_verbose_writer}");
-    simple_verbose_errors
-        .errs()
-        .expect("Errors during simple -> verbose conversion");
-
-    let (verbose_verbose_writer, verbose_verbose_errors) =
-        PlanWriter::<ErrorQueue>::new(&verbose_options, &verbose_plan, &default_registry);
-    let verbose_verbose_actual = format!("{verbose_verbose_writer}");
-    verbose_verbose_errors
-        .errs()
-        .expect("Errors during verbose -> verbose conversion");
-
-    assert_eq!(
-        simple_verbose_actual.trim(),
-        verbose_verbose_actual.trim(),
-        "Expected verbose outputs to match:\n---\n{}\n---\n---\n{}\n---",
-        simple_verbose_actual.trim(),
-        verbose_verbose_actual.trim()
-    );
-
-    // Test simple output from both plans
-    let simple_options = OutputOptions::default();
-    let (simple_simple_writer, simple_simple_errors) =
-        PlanWriter::<ErrorQueue>::new(&simple_options, &simple_plan, &default_registry);
-    let simple_simple_actual = format!("{simple_simple_writer}");
-    simple_simple_errors
-        .errs()
-        .expect("Errors during simple -> simple conversion");
-
-    let (verbose_simple_writer, verbose_simple_errors) =
-        PlanWriter::<ErrorQueue>::new(&simple_options, &verbose_plan, &default_registry);
-    let verbose_simple_actual = format!("{verbose_simple_writer}");
-    verbose_simple_errors
-        .errs()
-        .expect("Errors during verbose -> simple conversion");
-
-    assert_eq!(
-        simple_simple_actual.trim(),
-        verbose_simple_actual.trim(),
-        "Expected simple outputs to match:\n---\n{}\n---\n---\n{}\n---",
-        simple_simple_actual.trim(),
-        verbose_simple_actual.trim()
     );
 }

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -53,7 +53,7 @@ pub enum ParseError {
     #[error("Unknown extension relation type: {0}")]
     UnknownExtensionRelationType(String),
 
-    #[error("Invalid input at line {0}: {1}")]
+    #[error("Invalid input at {0}: {1}")]
     ValidationError(ParseContext, String),
 
     #[error("Error parsing section header on line {0}: {1}")]

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -53,8 +53,8 @@ pub enum ParseError {
     #[error("Unknown extension relation type: {0}")]
     UnknownExtensionRelationType(String),
 
-    #[error("Validation error: {0}")]
-    ValidationError(String),
+    #[error("Invalid input at line {0}: {1}")]
+    ValidationError(ParseContext, String),
 
     #[error("Error parsing section header on line {0}: {1}")]
     Initial(ParseContext, #[source] MessageParseError),

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -230,6 +230,14 @@ fn make_emit(output_mapping: Vec<i32>, direct_output_count: usize) -> EmitKind {
     }
 }
 
+/// Parse a reference list into an emit and output field count.
+fn parse_emit(reference_list: Pair<Rule>, direct_output_count: usize) -> (EmitKind, usize) {
+    let output_mapping = parse_output_mapping(reference_list);
+    let output_count = output_mapping.len();
+    let emit = make_emit(output_mapping, direct_output_count);
+    (emit, output_count)
+}
+
 /// Extracts named arguments from pest pairs with duplicate detection and completeness checking.
 ///
 /// Usage: `extractor.pop("limit", Rule::fetch_value).0.pop("offset", Rule::fetch_value).0.done()`
@@ -390,9 +398,7 @@ impl RelationParsePair for FilterRel {
         let references_pair = iter.pop(Rule::reference_list);
         iter.done();
 
-        let output_mapping = parse_output_mapping(references_pair);
-        let output_count = output_mapping.len();
-        let emit = make_emit(output_mapping, input_field_count);
+        let (emit, output_count) = parse_emit(references_pair, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
@@ -497,6 +503,8 @@ impl RelationParsePair for AggregateRel {
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
         input_children: Vec<Box<Rel>>,
+        // Aggregate defines its own output schema (grouping keys + measures),
+        // so the input field count isn't needed for emit construction.
         _input_field_count: usize,
     ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
@@ -749,9 +757,7 @@ impl RelationParsePair for SortRel {
             let sort_field = SortField::parse_pair(extensions, sort_field_pair)?;
             sorts.push(sort_field);
         }
-        let output_mapping = parse_output_mapping(reference_list_pair);
-        let output_count = output_mapping.len();
-        let emit = make_emit(output_mapping, input_field_count);
+        let (emit, output_count) = parse_emit(reference_list_pair, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
@@ -922,9 +928,7 @@ impl RelationParsePair for FetchRel {
         };
 
         let reference_list_pair = iter.pop(Rule::reference_list);
-        let output_mapping = parse_output_mapping(reference_list_pair);
-        let output_count = output_mapping.len();
-        let emit = make_emit(output_mapping, input_field_count);
+        let (emit, output_count) = parse_emit(reference_list_pair, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
@@ -1025,9 +1029,10 @@ impl RelationParsePair for JoinRel {
         let reference_list_pair = iter.pop(Rule::reference_list);
         iter.done();
 
-        let output_mapping = parse_output_mapping(reference_list_pair);
-        let output_count = output_mapping.len();
-        let emit = make_emit(output_mapping, input_field_count);
+        // TODO: For semi/anti joins, the direct output width differs from
+        // left+right — `input_field_count` would misclassify the emit as Direct.
+        // Revisit when those join types are supported.
+        let (emit, output_count) = parse_emit(reference_list_pair, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -5,18 +5,17 @@ use prost::Message;
 use substrait::proto::aggregate_rel::Grouping;
 use substrait::proto::expression::literal::LiteralType;
 use substrait::proto::expression::{Literal, RexType};
+use substrait::proto::extensions::AdvancedExtension;
 use substrait::proto::fetch_rel::{CountMode, OffsetMode};
 use substrait::proto::rel::RelType;
-use substrait::proto::rel_common::{Emit, EmitKind};
+use substrait::proto::rel_common::{Direct, Emit, EmitKind};
 use substrait::proto::sort_field::{SortDirection, SortKind};
 use substrait::proto::{
     AggregateRel, Expression, FetchRel, FilterRel, JoinRel, NamedStruct, ProjectRel, ReadRel, Rel,
     RelCommon, SortField, SortRel, Type, aggregate_rel, join_rel, read_rel, r#type,
 };
 
-use super::{
-    ErrorKind, MessageParseError, ParsePair, Rule, RuleIter, ScopedParsePair, unwrap_single_pair,
-};
+use super::{MessageParseError, ParsePair, Rule, RuleIter, ScopedParsePair, unwrap_single_pair};
 use crate::extensions::any::Any;
 use crate::extensions::registry::{ExtensionError, ExtensionType};
 use crate::extensions::{ExtensionArgs, ExtensionRegistry, SimpleExtensions};
@@ -84,28 +83,26 @@ impl<'a> RelationParsingContext<'a> {
     }
 }
 
-/// A trait for parsing relations with full context needed for tree building.
-/// This includes extensions, the parsed pair, input children, and output field count.
+/// A trait for parsing relations with full context for tree building.
 pub trait RelationParsePair: Sized {
     fn rule() -> Rule;
-
     fn message() -> &'static str;
 
-    /// Parse a relation with full context for tree building.
+    /// Parse the grammar pair into this relation type and its output field
+    /// count.
     ///
-    /// Args:
-    /// - extensions: The extensions context
-    /// - pair: The parsed pest pair
-    /// - input_children: The input relations (for wiring)
-    /// - input_field_count: Number of output fields from input children (for output mapping)
+    /// Returns `(Self, usize)` where `usize` is the output field count —
+    /// computed during parsing when `input_field_count` is available.
     fn parse_pair_with_context(
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
         input_children: Vec<Box<Rel>>,
-        _input_field_count: usize,
-    ) -> Result<Self, MessageParseError>;
+        input_field_count: usize,
+    ) -> Result<(Self, usize), MessageParseError>;
 
-    fn into_rel(self) -> Rel;
+    /// Consume this parsed relation, apply the advanced extension, and produce
+    /// the final `Rel`.
+    fn into_rel(self, adv_ext: Option<AdvancedExtension>) -> Rel;
 }
 
 pub struct TableName(Vec<String>);
@@ -210,13 +207,27 @@ pub(crate) fn expect_one_child(
 }
 
 /// Parse a reference list Pair and return an EmitKind::Emit.
-fn parse_reference_emit(pair: Pair<Rule>) -> EmitKind {
+/// Parse a reference list into field indices for emit mapping.
+fn parse_output_mapping(pair: Pair<Rule>) -> Vec<i32> {
     assert_eq!(pair.as_rule(), Rule::reference_list);
-    let output_mapping = pair
-        .into_inner()
+    pair.into_inner()
         .map(|p| FieldIndex::parse_pair(p).0)
-        .collect::<Vec<i32>>();
-    EmitKind::Emit(Emit { output_mapping })
+        .collect()
+}
+
+/// Build an emit: `Direct` if the mapping is the identity `[0, 1, ..., N-1]`
+/// (where N = `direct_output_count`), otherwise `Emit` with the explicit mapping.
+fn make_emit(output_mapping: Vec<i32>, direct_output_count: usize) -> EmitKind {
+    let is_identity = output_mapping.len() == direct_output_count
+        && output_mapping
+            .iter()
+            .enumerate()
+            .all(|(i, &v)| v == i as i32);
+    if is_identity {
+        EmitKind::Direct(Direct {})
+    } else {
+        EmitKind::Emit(Emit { output_mapping })
+    }
 }
 
 /// Extracts named arguments from pest pairs with duplicate detection and completeness checking.
@@ -286,18 +297,12 @@ impl RelationParsePair for ReadRel {
         "ReadRel"
     }
 
-    fn into_rel(self) -> Rel {
-        Rel {
-            rel_type: Some(RelType::Read(Box::new(self))),
-        }
-    }
-
     fn parse_pair_with_context(
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
         input_children: Vec<Box<Rel>>,
-        _input_field_count: usize,
-    ) -> Result<Self, MessageParseError> {
+        input_field_count: usize,
+    ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
         // ReadRel is a leaf node - it should have no input children and 0 input fields
         if !input_children.is_empty() {
@@ -307,17 +312,11 @@ impl RelationParsePair for ReadRel {
                 "ReadRel should have no input children",
             ));
         }
-        if _input_field_count != 0 {
-            let error = pest::error::Error::new_from_span(
-                pest::error::ErrorVariant::CustomError {
-                    message: "ReadRel should have 0 input fields".to_string(),
-                },
-                pair.as_span(),
-            );
-            return Err(MessageParseError::new(
+        if input_field_count != 0 {
+            return Err(MessageParseError::invalid(
                 "ReadRel",
-                ErrorKind::InvalidValue,
-                Box::new(error),
+                pair.as_span(),
+                "ReadRel should have 0 input fields",
             ));
         }
 
@@ -326,27 +325,38 @@ impl RelationParsePair for ReadRel {
         let columns = iter.parse_next_scoped::<NamedColumnList>(extensions)?.0;
         iter.done();
 
-        let (names, types): (Vec<_>, Vec<_>) = columns.into_iter().map(|c| (c.name, c.typ)).unzip();
-        let struct_ = r#type::Struct {
+        let output_count = columns.len();
+        Ok((
+            ReadRel {
+                base_schema: Some(build_named_struct(columns)),
+                read_type: Some(read_rel::ReadType::NamedTable(read_rel::NamedTable {
+                    names: table,
+                    advanced_extension: None,
+                })),
+                ..Default::default()
+            },
+            output_count,
+        ))
+    }
+
+    fn into_rel(mut self, adv_ext: Option<AdvancedExtension>) -> Rel {
+        self.advanced_extension = adv_ext;
+        Rel {
+            rel_type: Some(RelType::Read(Box::new(self))),
+        }
+    }
+}
+
+/// Build a `NamedStruct` from parsed columns.
+fn build_named_struct(columns: Vec<Column>) -> NamedStruct {
+    let (names, types): (Vec<_>, Vec<_>) = columns.into_iter().map(|c| (c.name, c.typ)).unzip();
+    NamedStruct {
+        names,
+        r#struct: Some(r#type::Struct {
             types,
             type_variation_reference: 0,
             nullability: r#type::Nullability::Required as i32,
-        };
-        let named_struct = NamedStruct {
-            names,
-            r#struct: Some(struct_),
-        };
-
-        let read_rel = ReadRel {
-            base_schema: Some(named_struct),
-            read_type: Some(read_rel::ReadType::NamedTable(read_rel::NamedTable {
-                names: table,
-                advanced_extension: None,
-            })),
-            ..Default::default()
-        };
-
-        Ok(read_rel)
+        }),
     }
 }
 
@@ -359,7 +369,8 @@ impl RelationParsePair for FilterRel {
         "FilterRel"
     }
 
-    fn into_rel(self) -> Rel {
+    fn into_rel(mut self, adv_ext: Option<AdvancedExtension>) -> Rel {
+        self.advanced_extension = adv_ext;
         Rel {
             rel_type: Some(RelType::Filter(Box::new(self))),
         }
@@ -369,31 +380,33 @@ impl RelationParsePair for FilterRel {
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
         input_children: Vec<Box<Rel>>,
-        _input_field_count: usize,
-    ) -> Result<Self, MessageParseError> {
-        // Form: Filter[condition => references]
-
+        input_field_count: usize,
+    ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
         let input = expect_one_child(Self::message(), &pair, input_children)?;
         let mut iter = RuleIter::from(pair.into_inner());
-        // condition
         let condition = iter.parse_next_scoped::<Expression>(extensions)?;
         // references (which become the emit)
         let references_pair = iter.pop(Rule::reference_list);
         iter.done();
 
-        let emit = parse_reference_emit(references_pair);
+        let output_mapping = parse_output_mapping(references_pair);
+        let output_count = output_mapping.len();
+        let emit = make_emit(output_mapping, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
         };
 
-        Ok(FilterRel {
-            input: Some(input),
-            condition: Some(Box::new(condition)),
-            common: Some(common),
-            advanced_extension: None,
-        })
+        Ok((
+            FilterRel {
+                input: Some(input),
+                condition: Some(Box::new(condition)),
+                common: Some(common),
+                advanced_extension: None,
+            },
+            output_count,
+        ))
     }
 }
 
@@ -406,7 +419,8 @@ impl RelationParsePair for ProjectRel {
         "ProjectRel"
     }
 
-    fn into_rel(self) -> Rel {
+    fn into_rel(mut self, adv_ext: Option<AdvancedExtension>) -> Rel {
+        self.advanced_extension = adv_ext;
         Rel {
             rel_type: Some(RelType::Project(Box::new(self))),
         }
@@ -416,49 +430,50 @@ impl RelationParsePair for ProjectRel {
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
         input_children: Vec<Box<Rel>>,
-        _input_field_count: usize,
-    ) -> Result<Self, MessageParseError> {
+        input_field_count: usize,
+    ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
         let input = expect_one_child(Self::message(), &pair, input_children)?;
 
-        // Get the argument list (contains references and expressions)
         let arguments_pair = unwrap_single_pair(pair);
 
         let mut expressions = Vec::new();
         let mut output_mapping = Vec::new();
 
-        // Process each argument (can be either a reference or expression)
         for arg in arguments_pair.into_inner() {
             let inner_arg = unwrap_single_pair(arg);
             match inner_arg.as_rule() {
                 Rule::reference => {
-                    // Parse reference like "$0" -> 0
                     let field_index = FieldIndex::parse_pair(inner_arg);
                     output_mapping.push(field_index.0);
                 }
                 Rule::expression => {
-                    // Parse as expression (e.g., 42, add($0, $1))
-                    let _expr = Expression::parse_pair(extensions, inner_arg)?;
-                    expressions.push(_expr);
-                    // Expression: index after all input fields
-                    output_mapping.push(_input_field_count as i32 + (expressions.len() as i32 - 1));
+                    let expr = Expression::parse_pair(extensions, inner_arg)?;
+                    expressions.push(expr);
+                    // Index into the combined schema: [input fields][computed expressions].
+                    output_mapping.push(input_field_count as i32 + (expressions.len() as i32 - 1));
                 }
                 _ => panic!("Unexpected inner argument rule: {:?}", inner_arg.as_rule()),
             }
         }
 
-        let emit = EmitKind::Emit(Emit { output_mapping });
+        let output_count = output_mapping.len();
+        let direct_count = input_field_count + expressions.len();
+        let emit = make_emit(output_mapping, direct_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
         };
 
-        Ok(ProjectRel {
-            input: Some(input),
-            expressions,
-            common: Some(common),
-            advanced_extension: None,
-        })
+        Ok((
+            ProjectRel {
+                input: Some(input),
+                expressions,
+                common: Some(common),
+                advanced_extension: None,
+            },
+            output_count,
+        ))
     }
 }
 
@@ -471,7 +486,8 @@ impl RelationParsePair for AggregateRel {
         "AggregateRel"
     }
 
-    fn into_rel(self) -> Rel {
+    fn into_rel(mut self, adv_ext: Option<AdvancedExtension>) -> Rel {
+        self.advanced_extension = adv_ext;
         Rel {
             rel_type: Some(RelType::Aggregate(Box::new(self))),
         }
@@ -482,7 +498,7 @@ impl RelationParsePair for AggregateRel {
         pair: Pair<Rule>,
         input_children: Vec<Box<Rel>>,
         _input_field_count: usize,
-    ) -> Result<Self, MessageParseError> {
+    ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
         let input = expect_one_child(Self::message(), &pair, input_children)?;
         let mut iter = RuleIter::from(pair.into_inner());
@@ -501,20 +517,25 @@ impl RelationParsePair for AggregateRel {
         let (measures, output_mapping) =
             parse_aggregate_measures(extensions, output_pair, &grouping_expressions)?;
 
-        let emit = EmitKind::Emit(Emit { output_mapping });
+        let output_count = output_mapping.len();
+        let direct_count = grouping_expressions.len() + measures.len();
+        let emit = make_emit(output_mapping, direct_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
         };
 
-        Ok(AggregateRel {
-            input: Some(input),
-            grouping_expressions,
-            groupings,
-            measures,
-            common: Some(common),
-            advanced_extension: None,
-        })
+        Ok((
+            AggregateRel {
+                input: Some(input),
+                grouping_expressions,
+                groupings,
+                measures,
+                common: Some(common),
+                advanced_extension: None,
+            },
+            output_count,
+        ))
     }
 }
 
@@ -705,7 +726,8 @@ impl RelationParsePair for SortRel {
         "SortRel"
     }
 
-    fn into_rel(self) -> Rel {
+    fn into_rel(mut self, adv_ext: Option<AdvancedExtension>) -> Rel {
+        self.advanced_extension = adv_ext;
         Rel {
             rel_type: Some(RelType::Sort(Box::new(self))),
         }
@@ -715,8 +737,8 @@ impl RelationParsePair for SortRel {
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
         input_children: Vec<Box<Rel>>,
-        _input_field_count: usize,
-    ) -> Result<Self, MessageParseError> {
+        input_field_count: usize,
+    ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
         let input = expect_one_child(Self::message(), &pair, input_children)?;
         let mut iter = RuleIter::from(pair.into_inner());
@@ -727,18 +749,23 @@ impl RelationParsePair for SortRel {
             let sort_field = SortField::parse_pair(extensions, sort_field_pair)?;
             sorts.push(sort_field);
         }
-        let emit = parse_reference_emit(reference_list_pair);
+        let output_mapping = parse_output_mapping(reference_list_pair);
+        let output_count = output_mapping.len();
+        let emit = make_emit(output_mapping, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
         };
         iter.done();
-        Ok(SortRel {
-            input: Some(input),
-            sorts,
-            common: Some(common),
-            advanced_extension: None,
-        })
+        Ok((
+            SortRel {
+                input: Some(input),
+                sorts,
+                common: Some(common),
+                advanced_extension: None,
+            },
+            output_count,
+        ))
     }
 }
 
@@ -859,7 +886,8 @@ impl RelationParsePair for FetchRel {
         "FetchRel"
     }
 
-    fn into_rel(self) -> Rel {
+    fn into_rel(mut self, adv_ext: Option<AdvancedExtension>) -> Rel {
+        self.advanced_extension = adv_ext;
         Rel {
             rel_type: Some(RelType::Fetch(Box::new(self))),
         }
@@ -869,16 +897,17 @@ impl RelationParsePair for FetchRel {
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
         input_children: Vec<Box<Rel>>,
-        _input_field_count: usize,
-    ) -> Result<Self, MessageParseError> {
+        input_field_count: usize,
+    ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
         let input = expect_one_child(Self::message(), &pair, input_children)?;
         let mut iter = RuleIter::from(pair.into_inner());
 
-        // Extract all pairs first, then do validation
+        // Extract all pairs before any validation: RuleIter's Drop panics on
+        // incomplete consumption, so we must exhaust the iterator before any
+        // early return. Validation runs after iter.done() below.
         let (limit_pair, offset_pair) = match iter.try_pop(Rule::fetch_named_arg_list) {
             None => {
-                // If there are no arguments, it should be empty
                 iter.pop(Rule::empty);
                 (None, None)
             }
@@ -893,27 +922,31 @@ impl RelationParsePair for FetchRel {
         };
 
         let reference_list_pair = iter.pop(Rule::reference_list);
-        let emit = parse_reference_emit(reference_list_pair);
+        let output_mapping = parse_output_mapping(reference_list_pair);
+        let output_count = output_mapping.len();
+        let emit = make_emit(output_mapping, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
         };
         iter.done();
 
-        // Now do validation after iterator is fully consumed
         let count_mode = limit_pair
             .map(|pair| CountMode::parse_pair(extensions, pair))
             .transpose()?;
         let offset_mode = offset_pair
             .map(|pair| OffsetMode::parse_pair(extensions, pair))
             .transpose()?;
-        Ok(FetchRel {
-            input: Some(input),
-            common: Some(common),
-            advanced_extension: None,
-            offset_mode,
-            count_mode,
-        })
+        Ok((
+            FetchRel {
+                input: Some(input),
+                common: Some(common),
+                advanced_extension: None,
+                offset_mode,
+                count_mode,
+            },
+            output_count,
+        ))
     }
 }
 
@@ -956,7 +989,8 @@ impl RelationParsePair for JoinRel {
         "JoinRel"
     }
 
-    fn into_rel(self) -> Rel {
+    fn into_rel(mut self, adv_ext: Option<AdvancedExtension>) -> Rel {
+        self.advanced_extension = adv_ext;
         Rel {
             rel_type: Some(RelType::Join(Box::new(self))),
         }
@@ -966,11 +1000,10 @@ impl RelationParsePair for JoinRel {
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
         input_children: Vec<Box<Rel>>,
-        _input_field_count: usize,
-    ) -> Result<Self, MessageParseError> {
+        input_field_count: usize,
+    ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
 
-        // Join requires exactly 2 input children
         if input_children.len() != 2 {
             return Err(MessageParseError::invalid(
                 Self::message(),
@@ -987,32 +1020,31 @@ impl RelationParsePair for JoinRel {
         let right = children_iter.next().unwrap();
 
         let mut iter = RuleIter::from(pair.into_inner());
-
-        // Parse join type
         let join_type = iter.parse_next::<join_rel::JoinType>();
-
-        // Parse join condition expression
         let condition = iter.parse_next_scoped::<Expression>(extensions)?;
-
-        // Parse output references (which become the emit)
         let reference_list_pair = iter.pop(Rule::reference_list);
         iter.done();
 
-        let emit = parse_reference_emit(reference_list_pair);
+        let output_mapping = parse_output_mapping(reference_list_pair);
+        let output_count = output_mapping.len();
+        let emit = make_emit(output_mapping, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
         };
 
-        Ok(JoinRel {
-            common: Some(common),
-            left: Some(left),
-            right: Some(right),
-            expression: Some(Box::new(condition)),
-            post_join_filter: None, // Not supported in grammar yet
-            r#type: join_type as i32,
-            advanced_extension: None,
-        })
+        Ok((
+            JoinRel {
+                common: Some(common),
+                left: Some(left),
+                right: Some(right),
+                expression: Some(Box::new(condition)),
+                post_join_filter: None, // not yet represented in the grammar
+                r#type: join_type as i32,
+                advanced_extension: None,
+            },
+            output_count,
+        ))
     }
 }
 
@@ -1038,7 +1070,8 @@ mod tests {
             vec![],
             0,
         )
-        .unwrap();
+        .unwrap()
+        .0;
         let names = match &read.read_type {
             Some(read_rel::ReadType::NamedTable(table)) => &table.names,
             _ => panic!("Expected NamedTable"),
@@ -1068,6 +1101,7 @@ mod tests {
             0,
         )
         .unwrap()
+        .0
     }
 
     #[test]
@@ -1076,16 +1110,17 @@ mod tests {
         let filter = FilterRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::filter_relation, "Filter[$1 => $0, $1, $2]"),
-            vec![Box::new(example_read_relation().into_rel())],
+            vec![Box::new(example_read_relation().into_rel(None))],
             3,
         )
-        .unwrap();
-        let emit_kind = &filter.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
-        let emit = match emit_kind {
-            EmitKind::Emit(emit) => &emit.output_mapping,
-            _ => panic!("Expected EmitKind::Emit, got {emit_kind:?}"),
-        };
-        assert_eq!(emit, &[0, 1, 2]);
+        .unwrap()
+        .0;
+        // Identity mapping [0, 1, 2] over 3 inputs → Direct
+        let emit_kind = filter.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
+        assert!(
+            matches!(emit_kind, EmitKind::Direct(_)),
+            "Expected Direct for identity emit, got {emit_kind:?}"
+        );
     }
 
     #[test]
@@ -1094,10 +1129,11 @@ mod tests {
         let project = ProjectRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::project_relation, "Project[$0, $1, 42]"),
-            vec![Box::new(example_read_relation().into_rel())],
+            vec![Box::new(example_read_relation().into_rel(None))],
             3,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         // Should have 1 expression (42) and 2 references ($0, $1)
         assert_eq!(project.expressions.len(), 1);
@@ -1117,10 +1153,11 @@ mod tests {
         let project = ProjectRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::project_relation, "Project[42, $0, 100, $2, $1]"),
-            vec![Box::new(example_read_relation().into_rel())],
+            vec![Box::new(example_read_relation().into_rel(None))],
             5, // Assume 5 input fields
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         // Should have 2 expressions (42, 100) and 3 references ($0, $2, $1)
         assert_eq!(project.expressions.len(), 2);
@@ -1149,10 +1186,11 @@ mod tests {
                 Rule::aggregate_relation,
                 "Aggregate[($0, $1), _ => sum($2), $0, count($2)]",
             ),
-            vec![Box::new(example_read_relation().into_rel())],
+            vec![Box::new(example_read_relation().into_rel(None))],
             3,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         // Should have 2 group-by sets ($0, $1) and an empty group, and emit 2 measures (sum($2), count($2))
         assert_eq!(aggregate.grouping_expressions.len(), 2);
@@ -1190,10 +1228,11 @@ mod tests {
                 Rule::aggregate_relation,
                 "Aggregate[$0 => sum($1), $0, count($1)]",
             ),
-            vec![Box::new(example_read_relation().into_rel())],
+            vec![Box::new(example_read_relation().into_rel(None))],
             3,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         // Should have 1 group-by field ($0) and 2 measures (sum($1), count($1))
         assert_eq!(aggregate.grouping_expressions.len(), 1);
@@ -1225,10 +1264,11 @@ mod tests {
         let aggregate = AggregateRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::aggregate_relation, "Aggregate[$2, $0 => sum($1)]"),
-            vec![Box::new(example_read_relation().into_rel())],
+            vec![Box::new(example_read_relation().into_rel(None))],
             3,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         assert_eq!(aggregate.grouping_expressions.len(), 2);
         assert_eq!(aggregate.groupings.len(), 1);
@@ -1250,10 +1290,11 @@ mod tests {
                 Rule::aggregate_relation,
                 "Aggregate[_ => sum($0), count($1)]",
             ),
-            vec![Box::new(example_read_relation().into_rel())],
+            vec![Box::new(example_read_relation().into_rel(None))],
             3,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         // Should have 0 group-by fields and 2 measures
         assert_eq!(aggregate.grouping_expressions.len(), 0);
@@ -1261,19 +1302,18 @@ mod tests {
         assert_eq!(aggregate.groupings[0].expression_references.len(), 0);
         assert_eq!(aggregate.measures.len(), 2);
 
-        let emit_kind = &aggregate
+        // Identity mapping [0, 1] over 2 outputs (0 grouping + 2 measures) → Direct
+        let emit_kind = aggregate
             .common
             .as_ref()
             .unwrap()
             .emit_kind
             .as_ref()
             .unwrap();
-        let emit = match emit_kind {
-            EmitKind::Emit(emit) => &emit.output_mapping,
-            _ => panic!("Expected EmitKind::Emit, got {emit_kind:?}"),
-        };
-        // Output mapping should be [0, 1] (measures only, no group-by fields)
-        assert_eq!(emit, &[0, 1]);
+        assert!(
+            matches!(emit_kind, EmitKind::Direct(_)),
+            "Expected Direct for identity emit, got {emit_kind:?}"
+        );
     }
 
     #[test]
@@ -1292,7 +1332,8 @@ mod tests {
             vec![],
             0,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         let aggregate = AggregateRel::parse_pair_with_context(
             &extensions,
@@ -1300,10 +1341,11 @@ mod tests {
                 Rule::aggregate_relation,
                 "Aggregate[($0, $1, $2), ($2, $0), ($1), _ => $0, $1, $2, count($3)]",
             ),
-            vec![Box::new(read_rel.into_rel())],
+            vec![Box::new(read_rel.into_rel(None))],
             4,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         assert_eq!(aggregate.grouping_expressions.len(), 3);
         assert_eq!(aggregate.groupings.len(), 4);
@@ -1326,10 +1368,11 @@ mod tests {
         let fetch_rel = FetchRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::fetch_relation, "Fetch[limit=10, offset=5 => $0]"),
-            vec![Box::new(example_read_relation().into_rel())],
+            vec![Box::new(example_read_relation().into_rel(None))],
             3,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         // Verify the limit and offset values are correct
         assert_eq!(
@@ -1355,7 +1398,7 @@ mod tests {
                 let result = FetchRel::parse_pair_with_context(
                     &extensions,
                     pair,
-                    vec![Box::new(example_read_relation().into_rel())],
+                    vec![Box::new(example_read_relation().into_rel(None))],
                     3,
                 );
                 assert!(result.is_err());
@@ -1386,7 +1429,7 @@ mod tests {
                 let result = FetchRel::parse_pair_with_context(
                     &extensions,
                     pair,
-                    vec![Box::new(example_read_relation().into_rel())],
+                    vec![Box::new(example_read_relation().into_rel(None))],
                     3,
                 );
                 assert!(result.is_err());
@@ -1409,8 +1452,8 @@ mod tests {
             .with_function(1, 10, "eq")
             .extensions;
 
-        let left_rel = example_read_relation().into_rel();
-        let right_rel = example_read_relation().into_rel();
+        let left_rel = example_read_relation().into_rel(None);
+        let right_rel = example_read_relation().into_rel(None);
 
         let join = JoinRel::parse_pair_with_context(
             &extensions,
@@ -1421,7 +1464,8 @@ mod tests {
             vec![Box::new(left_rel), Box::new(right_rel)],
             6, // left (3) + right (3) = 6 total input fields
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         // Should be an Inner join
         assert_eq!(join.r#type, join_rel::JoinType::Inner as i32);
@@ -1449,8 +1493,8 @@ mod tests {
             .with_function(1, 10, "eq")
             .extensions;
 
-        let left_rel = example_read_relation().into_rel();
-        let right_rel = example_read_relation().into_rel();
+        let left_rel = example_read_relation().into_rel(None);
+        let right_rel = example_read_relation().into_rel(None);
 
         let join = JoinRel::parse_pair_with_context(
             &extensions,
@@ -1458,7 +1502,8 @@ mod tests {
             vec![Box::new(left_rel), Box::new(right_rel)],
             6,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         // Should be a Left join
         assert_eq!(join.r#type, join_rel::JoinType::Left as i32);
@@ -1479,8 +1524,8 @@ mod tests {
             .with_function(1, 10, "eq")
             .extensions;
 
-        let left_rel = example_read_relation().into_rel();
-        let right_rel = example_read_relation().into_rel();
+        let left_rel = example_read_relation().into_rel(None);
+        let right_rel = example_read_relation().into_rel(None);
 
         let join = JoinRel::parse_pair_with_context(
             &extensions,
@@ -1488,7 +1533,8 @@ mod tests {
             vec![Box::new(left_rel), Box::new(right_rel)],
             6,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         // Should be a LeftSemi join
         assert_eq!(join.r#type, join_rel::JoinType::LeftSemi as i32);
@@ -1519,7 +1565,7 @@ mod tests {
         let result = JoinRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::join_relation, "Join[&Inner, eq($0, $1) => $0, $1]"),
-            vec![Box::new(example_read_relation().into_rel())],
+            vec![Box::new(example_read_relation().into_rel(None))],
             3,
         );
         assert!(result.is_err());
@@ -1529,9 +1575,9 @@ mod tests {
             &extensions,
             parse_exact(Rule::join_relation, "Join[&Inner, eq($0, $1) => $0, $1]"),
             vec![
-                Box::new(example_read_relation().into_rel()),
-                Box::new(example_read_relation().into_rel()),
-                Box::new(example_read_relation().into_rel()),
+                Box::new(example_read_relation().into_rel(None)),
+                Box::new(example_read_relation().into_rel(None)),
+                Box::new(example_read_relation().into_rel(None)),
             ],
             9,
         );

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -332,29 +332,36 @@ impl<'a> TreeBuilder<'a> {
                 parent.children.push(rel_node);
             }
             LineNode::AdvExt(adv_ext) => {
+                let context = ParseContext::new(
+                    adv_ext.line_no,
+                    adv_ext.pair.as_str().to_string(),
+                );
                 if depth == 0 {
-                    return Err(ParseError::ValidationError(format!(
-                        "line {}: advanced extension annotations cannot appear at the top level",
-                        adv_ext.line_no
-                    )));
+                    return Err(ParseError::ValidationError(
+                        context,
+                        "advanced extension annotations (+ Enh: / + Opt:) cannot appear at \
+                         the top level"
+                            .to_string(),
+                    ));
                 }
 
                 let parent = match self.get_at_depth(depth - 1) {
                     None => {
-                        return Err(ParseError::ValidationError(format!(
-                            "line {}: no parent found for advanced extension at depth {depth}",
-                            adv_ext.line_no
-                        )));
+                        return Err(ParseError::ValidationError(
+                            context,
+                            format!("no parent found for advanced extension at depth {depth}"),
+                        ));
                     }
                     Some(parent) => parent,
                 };
 
                 if !parent.children.is_empty() {
-                    return Err(ParseError::ValidationError(format!(
-                        "line {}: advanced extension annotations (+ Enh: / + Opt:) must \
-                         appear before child relations, not after",
-                        adv_ext.line_no
-                    )));
+                    return Err(ParseError::ValidationError(
+                        context,
+                        "advanced extension annotations (+ Enh: / + Opt:) must appear before \
+                         child relations, not after"
+                            .to_string(),
+                    ));
                 }
 
                 parent.adv_extensions.push(adv_ext);

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -6,9 +6,8 @@
 
 use std::fmt;
 
+use pest::iterators::Pair;
 use substrait::proto::extensions::AdvancedExtension;
-use substrait::proto::rel::RelType;
-use substrait::proto::rel_common::EmitKind;
 use substrait::proto::{
     AggregateRel, FetchRel, FilterRel, JoinRel, Plan, PlanRel, ProjectRel, ReadRel, Rel, RelRoot,
     SortRel, plan_rel,
@@ -56,14 +55,14 @@ impl<'a> From<&'a str> for IndentedLine<'a> {
 /// grammar rule directly (already unwrapped from the outer `planNode`).
 #[derive(Debug, Clone)]
 pub struct AdvExt<'a> {
-    pub pair: pest::iterators::Pair<'a, Rule>, // Rule::adv_extension
+    pub pair: Pair<'a, Rule>, // Rule::adv_extension
     pub line_no: i64,
 }
 
 /// A relation node in the plan tree, before conversion to a Substrait proto.
 #[derive(Debug, Clone)]
 pub struct RelationNode<'a> {
-    pub pair: pest::iterators::Pair<'a, Rule>,
+    pub pair: Pair<'a, Rule>,
     pub line_no: i64,
     pub adv_extensions: Vec<AdvExt<'a>>,
     pub children: Vec<RelationNode<'a>>,
@@ -78,7 +77,7 @@ impl<'a> RelationNode<'a> {
     }
 }
 
-/// A parsed plan line: either a relation or an advanced-extension annotation.
+/// A parsed plan line: either a relation or an advanced extension (`+`-prefixed line).
 ///
 /// Classification happens at construction time by inspecting the inner grammar
 /// rule, so downstream code can use standard Rust pattern matching rather than
@@ -106,18 +105,17 @@ impl<'a> LineNode<'a> {
         assert!(pairs.next().is_none()); // Should be exactly one pair
         let inner = unwrap_single_pair(outer);
 
-        Ok(if inner.as_rule() == Rule::adv_extension {
-            LineNode::AdvExt(AdvExt {
+        Ok(match inner.as_rule() {
+            Rule::adv_extension => LineNode::AdvExt(AdvExt {
                 pair: inner,
                 line_no,
-            })
-        } else {
-            LineNode::Relation(RelationNode {
+            }),
+            _ => LineNode::Relation(RelationNode {
                 pair: inner,
                 line_no,
                 adv_extensions: Vec::new(),
                 children: Vec::new(),
-            })
+            }),
         })
     }
 
@@ -147,10 +145,10 @@ impl<'a> LineNode<'a> {
             inner // root_relation
         };
 
-        // planNode can technically include adv_extension; surface it as AdvExt so
+        // planNode can include addenda (+Enh:, +Opt:); surface them so
         // TreeBuilder::add_line can produce the appropriate depth-0 error.
         if pair.as_rule() == Rule::adv_extension {
-            return Ok(LineNode::AdvExt(AdvExt { pair, line_no })); // Where is the error produced or checked???
+            return Ok(LineNode::AdvExt(AdvExt { pair, line_no }));
         }
 
         Ok(LineNode::Relation(RelationNode {
@@ -159,112 +157,6 @@ impl<'a> LineNode<'a> {
             adv_extensions: Vec::new(),
             children: Vec::new(),
         }))
-    }
-}
-
-/// Return the number of output columns for a relation.
-///
-/// Extension relations are excluded here intentionally: their output column
-/// count is carried as the `usize` in the `(Rel, usize)` returned by
-/// `build_rel` / `parse_extension_relation`, so they never reach this function.
-fn get_output_field_count(rel: &Rel) -> usize {
-    // An explicit emit mapping defines the exact emitted column count regardless
-    // of relation type
-    if let Some(EmitKind::Emit(e)) = get_emit_kind(rel) {
-        return e.output_mapping.len();
-    }
-
-    match &rel.rel_type {
-        Some(RelType::Read(read_rel)) => {
-            // Read embeds the schema directly — count the typed fields.
-            if let Some(schema) = read_rel.base_schema.as_ref()
-                && let Some(s) = schema.r#struct.as_ref()
-            {
-                return s.types.len();
-            }
-            0
-        }
-        Some(RelType::Filter(filter_rel)) => {
-            // Filter passes all input columns through unchanged.
-            if let Some(input) = filter_rel.input.as_ref() {
-                return get_output_field_count(input);
-            }
-            0
-        }
-        Some(RelType::Project(project_rel)) => {
-            // Without an emit, Project's direct output is all input columns
-            // followed by all computed expressions.
-            if let Some(input) = project_rel.input.as_ref() {
-                return get_output_field_count(input) + project_rel.expressions.len();
-            }
-            0
-        }
-        Some(RelType::Sort(sort_rel)) => {
-            // Sort passes all input columns through unchanged.
-            if let Some(input) = sort_rel.input.as_ref() {
-                return get_output_field_count(input);
-            }
-            0
-        }
-        Some(RelType::Fetch(fetch_rel)) => {
-            // Fetch (LIMIT/OFFSET) passes all input columns through unchanged.
-            if let Some(input) = fetch_rel.input.as_ref() {
-                return get_output_field_count(input);
-            }
-            0
-        }
-        Some(RelType::Join(join_rel)) => {
-            // Join concatenates the columns of its two inputs.
-            let left = join_rel.left.as_deref().map_or(0, get_output_field_count);
-            let right = join_rel.right.as_deref().map_or(0, get_output_field_count);
-            left + right
-        }
-        Some(RelType::Aggregate(agg_rel)) => {
-            // Aggregate's direct output is the grouping expressions followed
-            // by the measure results.
-            agg_rel.grouping_expressions.len() + agg_rel.measures.len()
-        }
-        _ => unimplemented!("TODO: implement this for the specific type"),
-    }
-}
-
-/// Extract the emit kind from a relation's `common` field, covering all
-/// standard relation variants that carry it.
-fn get_emit_kind(rel: &Rel) -> Option<&EmitKind> {
-    match &rel.rel_type {
-        Some(RelType::Read(r)) => r.common.as_ref(),
-        Some(RelType::Filter(r)) => r.common.as_ref(),
-        Some(RelType::Project(r)) => r.common.as_ref(),
-        Some(RelType::Sort(r)) => r.common.as_ref(),
-        Some(RelType::Fetch(r)) => r.common.as_ref(),
-        Some(RelType::Join(r)) => r.common.as_ref(),
-        Some(RelType::Aggregate(r)) => r.common.as_ref(),
-        _ => unimplemented!("TODO: implement this for the specific type"),
-    }
-    .and_then(|c| c.emit_kind.as_ref())
-}
-
-/// Set the `advanced_extension` field on a [`Rel`], covering all standard
-/// relation variants that carry the field directly.
-fn set_advanced_extension(rel: &mut Rel, adv_ext: AdvancedExtension) {
-    match &mut rel.rel_type {
-        Some(RelType::Read(r)) => r.advanced_extension = Some(adv_ext),
-        Some(RelType::Filter(r)) => r.advanced_extension = Some(adv_ext),
-        Some(RelType::Project(r)) => r.advanced_extension = Some(adv_ext),
-        Some(RelType::Aggregate(r)) => r.advanced_extension = Some(adv_ext),
-        Some(RelType::Sort(r)) => r.advanced_extension = Some(adv_ext),
-        Some(RelType::Fetch(r)) => r.advanced_extension = Some(adv_ext),
-        Some(RelType::Join(r)) => r.advanced_extension = Some(adv_ext),
-        Some(RelType::ExtensionLeaf(_)) => {
-            unreachable!("Extension types do not have advanced extensions defined on them")
-        }
-        Some(RelType::ExtensionSingle(_)) => {
-            unreachable!("Extension types do not have advanced extensions defined on them")
-        }
-        Some(RelType::ExtensionMulti(_)) => {
-            unreachable!("Extension types do not have advanced extensions defined on them")
-        }
-        _ => {}
     }
 }
 
@@ -332,16 +224,11 @@ impl<'a> TreeBuilder<'a> {
                 parent.children.push(rel_node);
             }
             LineNode::AdvExt(adv_ext) => {
-                let context = ParseContext::new(
-                    adv_ext.line_no,
-                    adv_ext.pair.as_str().to_string(),
-                );
+                let context = ParseContext::new(adv_ext.line_no, adv_ext.pair.as_str().to_string());
                 if depth == 0 {
                     return Err(ParseError::ValidationError(
                         context,
-                        "advanced extension annotations (+ Enh: / + Opt:) cannot appear at \
-                         the top level"
-                            .to_string(),
+                        "addenda (+ Enh: / + Opt:) cannot appear at the top level".to_string(),
                     ));
                 }
 
@@ -349,7 +236,7 @@ impl<'a> TreeBuilder<'a> {
                     None => {
                         return Err(ParseError::ValidationError(
                             context,
-                            format!("no parent found for advanced extension at depth {depth}"),
+                            format!("no parent found for addendum at depth {depth}"),
                         ));
                     }
                     Some(parent) => parent,
@@ -358,8 +245,8 @@ impl<'a> TreeBuilder<'a> {
                 if !parent.children.is_empty() {
                     return Err(ParseError::ValidationError(
                         context,
-                        "advanced extension annotations (+ Enh: / + Opt:) must appear before \
-                         child relations, not after"
+                        "addenda (+ Enh: / + Opt:) must appear before child relations, \
+                         not after"
                             .to_string(),
                     ));
                 }
@@ -382,6 +269,18 @@ impl<'a> TreeBuilder<'a> {
     }
 }
 
+/// Intermediate state for relation parsing: the structural tree data
+/// (children, addenda) has been processed into proto types, but the
+/// relation's own grammar pair hasn't been parsed yet.
+struct RelationContext<'a> {
+    pair: Pair<'a, Rule>,
+    line_no: i64,
+    #[allow(clippy::vec_box)]
+    children: Vec<Box<Rel>>,
+    input_field_count: usize,
+    advanced_extension: Option<AdvancedExtension>,
+}
+
 // Relation parsing component - handles converting LineNodes to Relations
 #[derive(Debug, Clone, Default)]
 pub struct RelationParser<'a> {
@@ -402,80 +301,45 @@ impl<'a> RelationParser<'a> {
         self.tree.add_line(depth, node)
     }
 
-    /// Parse a relation from a Pest pair of rule 'relation' into a Substrait
-    /// Rel, together with its output column count.
-    ///
-    /// The `usize` in the return value is the number of columns this relation
-    /// outputs.  Callers accumulate these counts across children and pass the
-    /// sum in as `input_field_count` so that relations like `ProjectRel` can
-    /// assign correct emit-mapping indices to their computed expressions.
-    //
-    // Clippy says a Vec<Box<…>> is unnecessary, as the Vec is already on the
-    // heap, but this is what the protobuf requires so we allow it here
-    #[allow(clippy::vec_box)]
+    /// Dispatch by grammar rule after validating addenda constraints.
+    /// Standard relations go through [`parse_rel`](Self::parse_rel);
+    /// extension relations go through
+    /// [`parse_extension_relation`](Self::parse_extension_relation).
     fn parse_relation(
         &self,
         extensions: &SimpleExtensions,
         registry: &ExtensionRegistry,
-        line_no: i64,
-        pair: pest::iterators::Pair<Rule>,
-        child_relations: Vec<Box<substrait::proto::Rel>>,
-        input_field_count: usize,
-    ) -> Result<(substrait::proto::Rel, usize), ParseError> {
-        // `pair` is already the specific relation rule (e.g. Rule::project_relation),
-        // unwrapped from the outer planNode during LineNode construction.
-        let (e, r, l, p_inner, cr, ic) = (
-            extensions,
-            registry,
-            line_no,
-            pair,
-            child_relations,
-            input_field_count,
-        );
-
-        match p_inner.as_rule() {
-            Rule::read_relation => self.parse_rel::<ReadRel>(e, l, p_inner, cr, ic),
-            Rule::filter_relation => self.parse_rel::<FilterRel>(e, l, p_inner, cr, ic),
-            Rule::project_relation => self.parse_rel::<ProjectRel>(e, l, p_inner, cr, ic),
-            Rule::aggregate_relation => self.parse_rel::<AggregateRel>(e, l, p_inner, cr, ic),
-            Rule::sort_relation => self.parse_rel::<SortRel>(e, l, p_inner, cr, ic),
-            Rule::fetch_relation => self.parse_rel::<FetchRel>(e, l, p_inner, cr, ic),
-            Rule::join_relation => self.parse_rel::<JoinRel>(e, l, p_inner, cr, ic),
-            Rule::extension_relation => self.parse_extension_relation(e, r, l, p_inner, cr),
-            _ => unreachable!("unhandled relation rule: {:?}", p_inner.as_rule()),
+        ctx: RelationContext,
+    ) -> Result<(Rel, usize), ParseError> {
+        match ctx.pair.as_rule() {
+            Rule::read_relation => self.parse_rel::<ReadRel>(extensions, ctx),
+            Rule::filter_relation => self.parse_rel::<FilterRel>(extensions, ctx),
+            Rule::project_relation => self.parse_rel::<ProjectRel>(extensions, ctx),
+            Rule::aggregate_relation => self.parse_rel::<AggregateRel>(extensions, ctx),
+            Rule::sort_relation => self.parse_rel::<SortRel>(extensions, ctx),
+            Rule::fetch_relation => self.parse_rel::<FetchRel>(extensions, ctx),
+            Rule::join_relation => self.parse_rel::<JoinRel>(extensions, ctx),
+            Rule::extension_relation => self.parse_extension_relation(extensions, registry, ctx),
+            _ => unreachable!("unhandled relation rule: {:?}", ctx.pair.as_rule()),
         }
     }
 
-    /// Parse a specific relation type, returning the relation and its output column count.
-    ///
-    /// The count is derived from the just-built relation via `get_output_field_count`.
-    /// Extension relations are handled separately in `parse_extension_relation` because
-    /// their count comes from the user-supplied output-columns list, not from a schema
-    /// embedded in the protobuf.
-    // Box is needed because Rel is a large enum and we need to pass ownership
-    // through the RelationParsePair trait, which requires Box<Rel>.
-    #[allow(clippy::vec_box)]
+    /// Generic bridge between [`parse_relation`](Self::parse_relation) and
+    /// the [`RelationParsePair`] trait: wraps `MessageParseError` with line
+    /// context and calls [`into_rel`](RelationParsePair::into_rel) to apply
+    /// addenda and produce the final [`Rel`].
     fn parse_rel<T: RelationParsePair>(
         &self,
         extensions: &SimpleExtensions,
-        line_no: i64,
-        pair: pest::iterators::Pair<Rule>,
-        child_relations: Vec<Box<substrait::proto::Rel>>,
-        input_field_count: usize,
-    ) -> Result<(substrait::proto::Rel, usize), ParseError> {
-        assert_eq!(pair.as_rule(), T::rule());
+        ctx: RelationContext,
+    ) -> Result<(Rel, usize), ParseError> {
+        assert_eq!(ctx.pair.as_rule(), T::rule());
+        let line_no = ctx.line_no;
+        let line = ctx.pair.as_str();
 
-        let line = pair.as_str();
-
-        let rel_type =
-            T::parse_pair_with_context(extensions, pair, child_relations, input_field_count);
-
-        match rel_type {
-            Ok(rel) => {
-                let as_rel = rel.into_rel();
-                let count = get_output_field_count(&as_rel);
-                Ok((as_rel, count))
-            }
+        match T::parse_pair_with_context(extensions, ctx.pair, ctx.children, ctx.input_field_count)
+        {
+            Ok((parsed, count)) => Ok((parsed.into_rel(ctx.advanced_extension), count)),
             Err(e) => Err(ParseError::Plan(
                 ParseContext::new(line_no, line.to_string()),
                 e,
@@ -483,32 +347,26 @@ impl<'a> RelationParser<'a> {
         }
     }
 
-    /// Parse extension relations.
-    /// Extension relations need the full parsing context for registry lookups and warning handling.
-    // Box is needed because Rel is a large enum and we need to pass ownership
-    // through the RelationParsePair trait, which requires Box<Rel>.
-    #[allow(clippy::vec_box)]
+    /// Handle extension relations separately from [`parse_rel`](Self::parse_rel)
+    /// because they need registry lookups that [`RelationParsePair`] doesn't
+    /// support.
     fn parse_extension_relation(
         &self,
         extensions: &SimpleExtensions,
         registry: &ExtensionRegistry,
-        line_no: i64,
-        pair: pest::iterators::Pair<Rule>,
-        child_relations: Vec<Box<substrait::proto::Rel>>,
-    ) -> Result<(substrait::proto::Rel, usize), ParseError> {
-        assert_eq!(pair.as_rule(), Rule::extension_relation);
+        ctx: RelationContext,
+    ) -> Result<(Rel, usize), ParseError> {
+        assert_eq!(ctx.pair.as_rule(), Rule::extension_relation);
+        let line_no = ctx.line_no;
+        let line = ctx.pair.as_str();
+        let pair_span = ctx.pair.as_span();
 
-        let line = pair.as_str();
-        let pair_span = pair.as_span();
-
-        // Parse extension invocation, which includes the user-provided name
         let ExtensionInvocation {
             name,
             args: extension_args,
-        } = ExtensionInvocation::parse_pair(pair);
+        } = ExtensionInvocation::parse_pair(ctx.pair);
 
-        // Validate child count matches relation type
-        let child_count = child_relations.len();
+        let child_count = ctx.children.len();
         extension_args
             .relation_type
             .validate_child_count(child_count)
@@ -527,13 +385,11 @@ impl<'a> RelationParser<'a> {
         };
 
         let detail = context.resolve_extension_detail(&name, &extension_args)?;
-        // Capture the output column count before consuming extension_args, so
-        // it can be returned to the caller.
         let output_column_count = extension_args.output_columns.len();
 
         let rel = extension_args
             .relation_type
-            .create_rel(detail, child_relations)
+            .create_rel(detail, ctx.children)
             .map_err(|e| {
                 ParseError::Plan(
                     ParseContext::new(line_no, line.to_string()),
@@ -541,42 +397,51 @@ impl<'a> RelationParser<'a> {
                 )
             })?;
 
+        if ctx.advanced_extension.is_some() {
+            return Err(ParseError::ValidationError(
+                ParseContext::new(line_no, line.to_string()),
+                "extension relations do not support advanced extensions (+ Enh / + Opt)"
+                    .to_string(),
+            ));
+        }
         Ok((rel, output_column_count))
     }
 
-    /// Convert a [`RelationNode`] into a Substrait Rel, together with its output column count.
-    /// The returned `usize` is the number of columns this relation emits.
+    /// Walk the relation tree depth-first, converting structural types
+    /// (children, addenda) into proto types via [`RelationContext`].
+    /// Delegates grammar-rule-specific work to
+    /// [`parse_relation`](Self::parse_relation).
     fn build_rel(
         &self,
         extensions: &SimpleExtensions,
         registry: &ExtensionRegistry,
         node: RelationNode,
-    ) -> Result<(substrait::proto::Rel, usize), ParseError> {
-        let mut child_relations: Vec<Box<Rel>> = Vec::new();
+    ) -> Result<(Rel, usize), ParseError> {
+        let mut children: Vec<Box<Rel>> = Vec::new();
         let mut input_field_count: usize = 0;
-
         for child in node.children {
             let (rel, count) = self.build_rel(extensions, registry, child)?;
             input_field_count += count;
-            child_relations.push(Box::new(rel));
+            children.push(Box::new(rel));
         }
 
-        let (mut rel, output_count) = self.parse_relation(
+        let advanced_extension = if node.adv_extensions.is_empty() {
+            None
+        } else {
+            Some(self.build_advanced_extension(extensions, registry, node.adv_extensions)?)
+        };
+
+        self.parse_relation(
             extensions,
             registry,
-            node.line_no,
-            node.pair,
-            child_relations,
-            input_field_count,
-        )?;
-
-        if !node.adv_extensions.is_empty() {
-            let adv_ext =
-                self.build_advanced_extension(extensions, registry, node.adv_extensions)?;
-            set_advanced_extension(&mut rel, adv_ext);
-        }
-
-        Ok((rel, output_count))
+            RelationContext {
+                pair: node.pair,
+                line_no: node.line_no,
+                children,
+                input_field_count,
+                advanced_extension,
+            },
+        )
     }
 
     /// Parse a list of [`AdvExt`] nodes into an [`AdvancedExtension`] proto.
@@ -609,6 +474,7 @@ impl<'a> RelationParser<'a> {
                     )?;
                     if enhancement.is_some() {
                         return Err(ParseError::ValidationError(
+                            ParseContext::new(line_no, line.clone()),
                             "at most one enhancement per relation is allowed".to_string(),
                         ));
                     }
@@ -647,6 +513,16 @@ impl<'a> RelationParser<'a> {
             return Ok(PlanRel {
                 rel_type: Some(plan_rel::RelType::Rel(rel)),
             });
+        }
+
+        // Root relations don't support addenda — reject rather than silently discard.
+        if !node.adv_extensions.is_empty() {
+            let first = &node.adv_extensions[0];
+            let context = ParseContext::new(first.line_no, first.pair.as_str().to_string());
+            return Err(ParseError::ValidationError(
+                context,
+                "addenda (+ Enh: / + Opt:) are not supported on Root relations".to_string(),
+            ));
         }
 
         // Named root relation.
@@ -985,6 +861,7 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod tests {
     use substrait::proto::extensions::simple_extension_declaration::MappingType;
+    use substrait::proto::rel::RelType;
 
     use super::*;
     use crate::extensions::simple::ExtensionKind;

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -294,11 +294,11 @@ impl Textify for Relation<'_> {
 
     fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
         self.write_header(ctx, w)?;
+        let child_scope = ctx.push_indent();
         // Emit any enhancement / optimizations between the header line and the
         // child relations, indented one level deeper than this relation — the
         // same position they occupy in the text format when parsed.
         if let Some(adv_ext) = self.advanced_extension {
-            let child_scope = ctx.push_indent();
             adv_ext.textify(&child_scope, w)?;
         }
         self.write_children(ctx, w)?;
@@ -366,48 +366,55 @@ impl<'a> Textify for TableName<'a> {
     }
 }
 
-pub fn get_table_name(rel: Option<&ReadType>) -> Result<&[String], PlanError> {
-    match rel {
-        Some(ReadType::NamedTable(r)) => Ok(r.names.as_slice()),
-        _ => Err(PlanError::unimplemented(
-            "ReadRel",
-            Some("table_name"),
-            format!("Unexpected read type {rel:?}") as String,
-        )),
+impl<'a> Relation<'a> {
+    fn from_read<S: Scope>(rel: &'a ReadRel, _ctx: &S) -> Self {
+        let columns = read_columns(rel);
+        let emit = rel.common.as_ref().and_then(|c| c.emit_kind.as_ref());
+
+        match &rel.read_type {
+            Some(ReadType::NamedTable(table)) => {
+                let table_name = Value::TableName(table.names.iter().map(|n| Name(n)).collect());
+                Relation {
+                    name: Cow::Borrowed("Read"),
+                    arguments: Some(Arguments {
+                        positional: vec![table_name],
+                        named: vec![],
+                    }),
+                    columns,
+                    emit,
+                    advanced_extension: rel.advanced_extension.as_ref(),
+                    children: vec![],
+                }
+            }
+            other => {
+                let err = PlanError::unimplemented(
+                    "ReadRel",
+                    Some("read_type"),
+                    format!("Unsupported read type {other:?}"),
+                );
+                Relation {
+                    name: Cow::Borrowed("Read"),
+                    arguments: Some(Arguments {
+                        positional: vec![Value::Missing(err)],
+                        named: vec![],
+                    }),
+                    columns,
+                    emit,
+                    advanced_extension: rel.advanced_extension.as_ref(),
+                    children: vec![],
+                }
+            }
+        }
     }
 }
 
-impl<'a> Relation<'a> {
-    fn from_read<S: Scope>(rel: &'a ReadRel, _ctx: &S) -> Self {
-        let name = get_table_name(rel.read_type.as_ref());
-        let table_name: Value = match name {
-            Ok(n) => Value::TableName(n.iter().map(|n| Name(n)).collect()),
-            Err(e) => Value::Missing(e),
-        };
-
-        let columns = match rel.base_schema {
-            Some(ref schema) => schema_to_values(schema),
-            None => {
-                let err = PlanError::unimplemented(
-                    "ReadRel",
-                    Some("base_schema"),
-                    "Base schema is required",
-                );
-                vec![Value::Missing(err)]
-            }
-        };
-        let emit = rel.common.as_ref().and_then(|c| c.emit_kind.as_ref());
-
-        Relation {
-            name: Cow::Borrowed("Read"),
-            arguments: Some(Arguments {
-                positional: vec![table_name],
-                named: vec![],
-            }),
-            columns,
-            emit,
-            advanced_extension: rel.advanced_extension.as_ref(),
-            children: vec![],
+fn read_columns<'a>(rel: &'a ReadRel) -> Vec<Value<'a>> {
+    match rel.base_schema {
+        Some(ref schema) => schema_to_values(schema),
+        None => {
+            let err =
+                PlanError::unimplemented("ReadRel", Some("base_schema"), "Base schema is required");
+            vec![Value::Missing(err)]
         }
     }
 }
@@ -813,7 +820,7 @@ impl<'a> Relation<'a> {
     }
 
     fn from_fetch<S: Scope>(rel: &'a FetchRel, ctx: &S) -> Self {
-        let (children, _) = Relation::convert_children(vec![rel.input.as_deref()], ctx);
+        let (children, input_columns) = Relation::convert_children(vec![rel.input.as_deref()], ctx);
         let mut named_args: Vec<NamedArg> = vec![];
         match &rel.count_mode {
             Some(CountMode::CountExpr(expr)) => {
@@ -850,12 +857,10 @@ impl<'a> Relation<'a> {
         }
 
         let emit = get_emit(rel.common.as_ref());
-        let mut columns = vec![];
-        if let Some(EmitKind::Emit(e)) = emit {
-            for &i in &e.output_mapping {
-                columns.push(Value::Reference(i));
-            }
-        }
+        // Fetch is passthrough — direct output is all input columns.
+        let columns: Vec<Value> = (0..input_columns)
+            .map(|i| Value::Reference(i as i32))
+            .collect();
         Relation {
             name: Cow::Borrowed("Fetch"),
             arguments: Some(Arguments {

--- a/tests/adv_extension_roundtrip.rs
+++ b/tests/adv_extension_roundtrip.rs
@@ -607,14 +607,10 @@ Root[result]
         .as_ref()
         .and_then(|c| c.emit_kind.as_ref())
         .expect("ProjectRel must have an emit");
-    let output_mapping = match emit_kind {
-        EmitKind::Emit(e) => &e.output_mapping,
-        EmitKind::Direct(_) => panic!("expected Emit, got Direct"),
-    };
-    assert_eq!(
-        output_mapping,
-        &[0_i32, 1, 2],
-        "emit mapping should be [0, 1, 2]; without fix it would be [0, 1, 0]"
+    // Identity mapping [0, 1, 2] over 3 direct outputs → Direct
+    assert!(
+        matches!(emit_kind, EmitKind::Direct(_)),
+        "Expected Direct for identity emit, got {emit_kind:?}"
     );
 
     // --- round-trip ---

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -5,7 +5,7 @@
 //! rare, and more likely a reflection of the author's misunderstanding of the
 //! Substrait plan format.
 
-use substrait_explain::fixtures::{roundtrip_plan, roundtrip_plan_with_verbose};
+use substrait_explain::fixtures::roundtrip_plan;
 use substrait_explain::format;
 use substrait_explain::parser::{ParseError, Parser};
 
@@ -111,7 +111,7 @@ Root[name, num]
   Project[$1, coalesce#10($1, $2)]
     Read[schema.table => name:string?, num:fp64?, other_num:fp64?, id:i64]"#;
 
-    roundtrip_plan_with_verbose(simple_plan, verbose_plan);
+    assert_roundtrip_canonical(simple_plan, verbose_plan);
 }
 
 #[test]
@@ -378,7 +378,7 @@ Root[result]
     Read[t => a:i64, b:i64, c:string]"#;
 
     roundtrip_plan(simple);
-    roundtrip_plan_with_verbose(simple, verbose);
+    assert_roundtrip_canonical(simple, verbose);
 }
 
 /// A unique function (only one overload registered) uses the base name in
@@ -424,7 +424,7 @@ Root[result]
     Read[t => a:i64, b:i64]"#;
 
     assert_roundtrip_canonical(compact, compound);
-    roundtrip_plan_with_verbose(compact, verbose);
+    assert_roundtrip_canonical(compact, verbose);
 }
 
 /// A plan that mixes unique and overloaded functions.  Compact mode shows
@@ -464,6 +464,133 @@ Functions:
 Root[result]
   Project[$0, equal:any_any#1($0, $1), equal:any_any#2($0, $1)]
     Read[t => a:i64, b:i64]"#;
+
+    roundtrip_plan(plan);
+}
+
+// === Emit / output-field-count propagation tests ===
+//
+// These exercise the pipeline: child's output_field_count → parent's
+// input_field_count → correct emit indices for expressions in Project.
+// If any relation type returns the wrong output count, the Project's emit
+// mapping will be offset incorrectly and the roundtrip will fail.
+
+#[test]
+fn test_emit_read_to_project_with_expression() {
+    // Read outputs 2 columns. Project has expression add($0,$1) → emit index should be 2.
+    let plan = r#"
+=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml
+Functions:
+  # 10 @  1: add
+
+=== Plan
+Root[sum]
+  Project[add($0, $1)]
+    Read[t => a:i64, b:i64]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_emit_filter_to_project_with_expression() {
+    // Read outputs 3, Filter emits 2 ($0, $1). Project sees 2 inputs.
+    let plan = r#"
+=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml
+  @  2: https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml
+Functions:
+  # 10 @  1: add
+  # 11 @  2: gt
+
+=== Plan
+Root[sum]
+  Project[add($0, $1)]
+    Filter[gt($2, 0) => $0, $1]
+      Read[t => a:i64, b:i64, c:i64]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_emit_sort_to_project_with_expression() {
+    // Sort is passthrough — its output count should equal its input's.
+    let plan = r#"
+=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml
+Functions:
+  # 10 @  1: add
+
+=== Plan
+Root[sum]
+  Project[add($0, $1)]
+    Sort[($0, &AscNullsFirst) => $0, $1]
+      Read[t => a:i64, b:i64]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_emit_fetch_to_project_with_expression() {
+    // Fetch is passthrough — its output count should equal its input's.
+    let plan = r#"
+=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml
+Functions:
+  # 10 @  1: add
+
+=== Plan
+Root[sum]
+  Project[add($0, $1)]
+    Fetch[limit=10, offset=0 => $0, $1]
+      Read[t => a:i64, b:i64]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_emit_join_to_project_with_expression() {
+    // Join: left has 2 cols, right has 2 cols → 4 total. Project sees 4.
+    let plan = r#"
+=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml
+  @  2: https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml
+Functions:
+  # 10 @  1: add
+  # 11 @  2: eq
+
+=== Plan
+Root[sum]
+  Project[add($1, $3)]
+    Join[&Inner, eq($0, $2) => $0, $1, $2, $3]
+      Read[users => id:i64, age:i64]
+      Read[orders => user_id:i64, amount:i64]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_emit_aggregate_to_project_with_expression() {
+    // Aggregate: 1 grouping field + 1 measure = 2 output columns.
+    let plan = r#"
+=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml
+  @  2: https://github.com/substrait-io/substrait/blob/main/extensions/functions_aggregate.yaml
+Functions:
+  # 10 @  1: add
+  # 11 @  2: sum
+
+=== Plan
+Root[total]
+  Project[add($0, $1)]
+    Aggregate[$0 => $0, sum($1)]
+      Read[t => category:i64, amount:i64]"#;
 
     roundtrip_plan(plan);
 }


### PR DESCRIPTION
## Description

This PR refactors a bit to improve emit handling and advanced extension handling, by bringing them into the `RelationParsePair` trait - so that each `Relation` is responsible for both, rather than external handling.

This is factored out of #101, and a precedent for #106.

### Specifics

- **`RelationParsePair` redesign**: The output field count is now computed during parsing and returned from `parse_pair_with_context`, so it's part of the trait rather than computed externally. Similarly, `into_rel` takes `Option<AdvancedExtension>`, so it returns a fully complete `Rel`.
- **Identity emit**: new `make_emit` helper produces `EmitKind::Direct` for identity output mappings instead of an explicit `Emit`, matching Substrait semantics. This also fixes a `Fetch` textifier regression where passthrough columns were emitted as empty when `EmitKind::Direct` was in effect.
- **Structured error messages**: `ParseError::ValidationError` now carries `ParseContext` for line-precise diagnostics.
- Extension relations now reject `+ Enh:` / `+ Opt:` addenda with an explicit error (previously silently applied).

## Type of Change

- [x] Refactor

## Testing

- [x] Added tests for new functionality
- [x] All existing tests pass
- [x] Ran examples to verify behavior

Added 7 roundtrip tests exercising emit/output-field-count propagation across every relation type (`Read`, `Filter`, `Sort`, `Fetch`, `Join`, `Aggregate`) stacked under a `Project` with an expression, ensuring the expression's emit index is computed correctly.

## Checklist

- [x] Code follows Rust conventions
- [x] Documentation updated if needed
- [x] No breaking changes (or breaking changes documented)
- [x] Pre-commit hooks pass
