### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2](https://github.com/DataDog/substrait-explain/compare/v0.3.1...v0.3.2) - 2026-04-29
+
 ## [0.3.1](https://github.com/DataDog/substrait-explain/compare/v0.3.0...v0.3.1) - 2026-04-08
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.2](https://github.com/DataDog/substrait-explain/compare/v0.3.1...v0.3.2) - 2026-04-29
 
+### Bug Fixes
+- CLI text parsing now passes extension registry so text with custom extensions (registered via run_with_extensions) now work
+- refactored emit handling and advanced extension handling by bringing them into the RelationParsePair trait 
+
+### Features
+- added support for VirtualTable Read with inline formatting
+- added support for tuples as extension arguments
+
+
 ## [0.3.1](https://github.com/DataDog/substrait-explain/compare/v0.3.0...v0.3.1) - 2026-04-08
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "substrait-explain"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrait-explain"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 authors = [
     "Wendell Smith <wendell.smith@datadoghq.com>",


### PR DESCRIPTION



## 🤖 New release

* `substrait-explain`: 0.3.1 -> 0.3.2

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).