### PR TITLE
refactor(extensions)!: simplify extension argument handling

### DIFF
--- a/API.md
+++ b/API.md
@@ -181,7 +181,6 @@ Register extensions to the appropriate namespace:
 # use prost::{Message, Name};
 # use substrait_explain::extensions::{
 #     Explainable, ExtensionArgs, ExtensionError, ExtensionRegistry,
-#     ExtensionRelationType,
 # };
 #[derive(Clone, PartialEq, Message)]
 pub struct MySourceConfig {
@@ -198,7 +197,7 @@ impl Name for MySourceConfig {
 #     fn name() -> &'static str { "MySource" }
 #     fn from_args(_: &ExtensionArgs) -> Result<Self, ExtensionError> { Ok(Self::default()) }
 #     fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-#         Ok(ExtensionArgs::new(ExtensionRelationType::Leaf))
+#         Ok(ExtensionArgs::default())
 #     }
 # }
 # use substrait_explain::parser::Parser;

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -855,13 +855,11 @@ enum_value := "&" identifier
 ### Example: Enhancement on a Read Relation
 
 ```rust
-# use substrait_explain::extensions::ExtensionRegistry;
-# use substrait_explain::extensions::examples::PartitionHint;
+# use substrait_explain::extensions::examples;
 # use substrait_explain::format_with_registry;
 # use substrait_explain::parser::Parser;
 #
-# let mut registry = ExtensionRegistry::new();
-# registry.register_enhancement::<PartitionHint>().unwrap();
+# let registry = examples::registry();
 # let parser = Parser::new().with_extension_registry(registry.clone());
 #
 # let plan_text = r#"
@@ -879,13 +877,27 @@ Root[result]
 
 ### Example: Enhancement and Multiple Optimizations
 
-```text
+```rust
+# use substrait_explain::extensions::examples;
+# use substrait_explain::format_with_registry;
+# use substrait_explain::parser::Parser;
+#
+# let registry = examples::registry();
+# let parser = Parser::new().with_extension_registry(registry.clone());
+#
+# let plan_text = r#"
 === Plan
 Root[result]
   Read[data => col:i64]
     + Enh:PartitionHint[&HASH, count=4]
     + Opt:PlanHint[hint='use_index']
     + Opt:PlanHint[hint='parallel']
+# "#;
+#
+# let plan = parser.parse_plan(plan_text).unwrap();
+# let (formatted, errors) = format_with_registry(&plan, &Default::default(), &registry);
+# assert!(errors.is_empty());
+# assert_eq!(formatted.trim(), plan_text.trim());
 ```
 
 ### Custom Extension Types

--- a/examples/extensions.rs
+++ b/examples/extensions.rs
@@ -16,7 +16,6 @@ use substrait::proto::{self, plan_rel, rel};
 use substrait_explain::extensions::any::AnyRef;
 use substrait_explain::extensions::{
     AnyConvertible, Explainable, ExtensionArgs, ExtensionColumn, ExtensionError, ExtensionRegistry,
-    ExtensionRelationType,
 };
 use substrait_explain::parser::Parser;
 use substrait_explain::{OutputOptions, format_with_registry};
@@ -105,7 +104,7 @@ impl Explainable for ParquetScanConfig {
     }
 
     fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-        let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+        let mut args = ExtensionArgs::default();
 
         // Add named arguments from the message
         args.insert("path", self.path.clone());

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -493,9 +493,7 @@ mod tests {
     use substrait::proto::rel::RelType;
 
     use super::*;
-    use crate::extensions::{
-        Explainable, ExtensionArgs, ExtensionColumn, ExtensionError, ExtensionRelationType,
-    };
+    use crate::extensions::{Explainable, ExtensionArgs, ExtensionColumn, ExtensionError};
     use crate::fixtures::parse_type;
     use crate::parse;
 
@@ -943,7 +941,7 @@ Root[result]
         }
 
         fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-            let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+            let mut args = ExtensionArgs::default();
             args.insert("tag", self.tag.clone());
             args.output_columns.push(ExtensionColumn::Named {
                 name: "val".to_string(),

--- a/src/extensions/args.rs
+++ b/src/extensions/args.rs
@@ -37,6 +37,26 @@ use substrait::proto::expression::{RexType, reference_segment};
 use super::ExtensionError;
 use crate::textify::expressions::Reference;
 
+/// Kind of relation addendum in the text format.
+///
+/// Addenda are `+`-prefixed lines attached to relations. They are syntax-level
+/// constructs, distinct from [`crate::extensions::registry::ExtensionType`],
+/// which describes registry namespaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AddendumKind {
+    Enhancement,
+    Optimization,
+}
+
+impl AddendumKind {
+    pub(crate) fn prefix(self) -> &'static str {
+        match self {
+            AddendumKind::Enhancement => "Enh",
+            AddendumKind::Optimization => "Opt",
+        }
+    }
+}
+
 /// A Substrait expression carried as an extension argument or output column.
 ///
 /// Boxed because `proto::Expression` is large (multiple `Vec` fields in

--- a/src/extensions/args.rs
+++ b/src/extensions/args.rs
@@ -173,32 +173,20 @@ impl From<&str> for Expr {
     }
 }
 
-/// Represents text-format arguments for a registered advanced extension.
+/// Represents extension arguments plus optional output columns.
 ///
 /// Named arguments are stored in an [`IndexMap`] whose iteration order
 /// determines display order. Extension [`super::Explainable::to_args()`]
 /// implementations should insert named arguments in the order they should
 /// appear in the text format.
-///
-/// The [`relation_type`](Self::relation_type) and
-/// [`output_columns`](Self::output_columns) fields are meaningful for custom
-/// relation types. Enhancements and optimization hints use the same argument
-/// representation, but their text grammar does not include output columns.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ExtensionArgs {
     /// Positional arguments.
     pub positional: Vec<ExtensionValue>,
     /// Named arguments, displayed in the order they were inserted
     pub named: IndexMap<String, ExtensionValue>,
     /// Output columns for custom relation types.
-    ///
-    /// These are ignored by enhancement and optimization text syntax.
     pub output_columns: Vec<ExtensionColumn>,
-    /// The type of custom relation being represented.
-    ///
-    /// For enhancements and optimization hints this is currently carried as an
-    /// implementation detail because they share the same argument container.
-    pub relation_type: ExtensionRelationType,
 }
 
 /// Helper struct for extracting named arguments with validation.
@@ -620,83 +608,7 @@ pub enum ExtensionColumn {
     Expr(Expr),
 }
 
-/// Extension relation types
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ExtensionRelationType {
-    /// Extension leaf relation - no input children
-    Leaf,
-    /// Extension single relation - exactly one input child
-    Single,
-    /// Extension multi relation - zero or more input children
-    Multi,
-}
-
-impl std::str::FromStr for ExtensionRelationType {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "ExtensionLeaf" => Ok(ExtensionRelationType::Leaf),
-            "ExtensionSingle" => Ok(ExtensionRelationType::Single),
-            "ExtensionMulti" => Ok(ExtensionRelationType::Multi),
-            _ => Err(format!("Unknown extension relation type: {}", s)),
-        }
-    }
-}
-
-impl ExtensionRelationType {
-    /// Get the string representation used in the text format
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            ExtensionRelationType::Leaf => "ExtensionLeaf",
-            ExtensionRelationType::Single => "ExtensionSingle",
-            ExtensionRelationType::Multi => "ExtensionMulti",
-        }
-    }
-
-    /// Validate that the child count matches this relation type
-    pub fn validate_child_count(&self, child_count: usize) -> Result<(), String> {
-        match self {
-            ExtensionRelationType::Leaf => {
-                if child_count == 0 {
-                    Ok(())
-                } else {
-                    Err(format!(
-                        "ExtensionLeaf should have no input children, got {child_count}"
-                    ))
-                }
-            }
-            ExtensionRelationType::Single => {
-                if child_count == 1 {
-                    Ok(())
-                } else {
-                    Err(format!(
-                        "ExtensionSingle should have exactly 1 input child, got {child_count}"
-                    ))
-                }
-            }
-            ExtensionRelationType::Multi => {
-                // ExtensionMulti relations accept zero or more children.
-                Ok(())
-            }
-        }
-    }
-}
-
-// Note: create_rel is implemented in parser/extensions.rs to avoid
-// pulling in protobuf dependencies in the core args module
-
 impl ExtensionArgs {
-    /// Create a new empty ExtensionArgs
-    pub fn new(relation_type: ExtensionRelationType) -> Self {
-        Self {
-            positional: Vec::new(),
-            named: IndexMap::new(),
-            output_columns: Vec::new(),
-            relation_type,
-        }
-    }
-
     /// Push a positional extension argument.
     pub fn push<T>(&mut self, value: T)
     where
@@ -717,52 +629,5 @@ impl ExtensionArgs {
     /// Create an extractor for validating named arguments
     pub fn extractor(&self) -> ArgsExtractor<'_> {
         ArgsExtractor::new(self)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::ExtensionRelationType;
-
-    #[test]
-    fn extension_multi_allows_zero_children() {
-        assert!(ExtensionRelationType::Multi.validate_child_count(0).is_ok());
-    }
-
-    #[test]
-    fn extension_multi_allows_single_child() {
-        assert!(ExtensionRelationType::Multi.validate_child_count(1).is_ok());
-    }
-
-    #[test]
-    fn extension_multi_allows_multiple_children() {
-        assert!(ExtensionRelationType::Multi.validate_child_count(3).is_ok());
-    }
-
-    #[test]
-    fn extension_single_rejects_wrong_child_counts() {
-        assert!(
-            ExtensionRelationType::Single
-                .validate_child_count(0)
-                .is_err()
-        );
-        assert!(
-            ExtensionRelationType::Single
-                .validate_child_count(2)
-                .is_err()
-        );
-    }
-
-    #[test]
-    fn extension_args_helpers_convert_values() {
-        let mut args = super::ExtensionArgs::new(ExtensionRelationType::Leaf);
-        args.push(7_i64);
-        args.insert("path", "data.parquet");
-
-        assert_eq!(i64::try_from(&args.positional[0]).unwrap(), 7);
-        assert_eq!(
-            <&str>::try_from(args.named.get("path").unwrap()).unwrap(),
-            "data.parquet"
-        );
     }
 }

--- a/src/extensions/examples.rs
+++ b/src/extensions/examples.rs
@@ -13,7 +13,7 @@
 //! number of partitions (`0` / absent means "let the executor decide").
 
 use crate::extensions::args::{EnumValue, ExtensionArgs, ExtensionRelationType, ExtensionValue};
-use crate::extensions::registry::{Explainable, ExtensionError};
+use crate::extensions::registry::{Explainable, ExtensionError, ExtensionRegistry};
 
 // ---------------------------------------------------------------------------
 // PartitionStrategy enum
@@ -68,12 +68,11 @@ impl PartitionStrategy {
 /// # Text Format
 ///
 /// ```rust
-/// # use substrait_explain::extensions::{ExtensionRegistry, examples::PartitionHint};
+/// # use substrait_explain::extensions::examples;
 /// # use substrait_explain::format_with_registry;
 /// # use substrait_explain::parser::Parser;
 /// #
-/// # let mut registry = ExtensionRegistry::new();
-/// # registry.register_enhancement::<PartitionHint>().unwrap();
+/// # let registry = examples::registry();
 /// # let parser = Parser::new().with_extension_registry(registry.clone());
 /// #
 /// # let plan_text = r#"
@@ -159,10 +158,93 @@ impl Explainable for PartitionHint {
     }
 }
 
+// ---------------------------------------------------------------------------
+// PlanHint
+// ---------------------------------------------------------------------------
+
+/// Optimization hint that carries a planner directive as a string.
+///
+/// Attach this to any standard relation via `register_optimization` to convey
+/// planner choices without changing relation semantics.
+///
+/// # Text Format
+///
+/// ```rust
+/// # use substrait_explain::extensions::examples;
+/// # use substrait_explain::format_with_registry;
+/// # use substrait_explain::parser::Parser;
+/// #
+/// # let registry = examples::registry();
+/// # let parser = Parser::new().with_extension_registry(registry.clone());
+/// #
+/// # let plan_text = r#"
+/// === Plan
+/// Root[result]
+///   Read[data => col:i64]
+///     + Opt:PlanHint[hint='use_index']
+/// # "#;
+/// #
+/// # let plan = parser.parse_plan(plan_text).unwrap();
+/// # let (formatted, errors) = format_with_registry(&plan, &Default::default(), &registry);
+/// # assert!(errors.is_empty());
+/// # assert_eq!(formatted.trim(), plan_text.trim());
+/// ```
+#[derive(Clone, PartialEq, prost::Message)]
+pub struct PlanHint {
+    /// Planner directive. The text format stores this as `hint='...'`.
+    #[prost(string, tag = "1")]
+    pub hint: String,
+}
+
+impl prost::Name for PlanHint {
+    const PACKAGE: &'static str = "example";
+    const NAME: &'static str = "PlanHint";
+
+    fn full_name() -> String {
+        "example.PlanHint".to_owned()
+    }
+
+    fn type_url() -> String {
+        "type.googleapis.com/example.PlanHint".to_owned()
+    }
+}
+
+impl Explainable for PlanHint {
+    fn name() -> &'static str {
+        "PlanHint"
+    }
+
+    fn from_args(args: &ExtensionArgs) -> Result<Self, ExtensionError> {
+        let mut extractor = args.extractor();
+        let hint: String = extractor.expect_named_arg::<&str>("hint")?.to_owned();
+        extractor.check_exhausted()?;
+        Ok(PlanHint { hint })
+    }
+
+    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+        let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+        args.named
+            .insert("hint".to_owned(), ExtensionValue::String(self.hint.clone()));
+        Ok(args)
+    }
+}
+
+/// Create an [`ExtensionRegistry`] preloaded with the example extension types.
+pub fn registry() -> ExtensionRegistry {
+    let mut registry = ExtensionRegistry::new();
+    registry
+        .register_enhancement::<PartitionHint>()
+        .expect("register PartitionHint example enhancement");
+    registry
+        .register_optimization::<PlanHint>()
+        .expect("register PlanHint example optimization");
+    registry
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extensions::{AnyConvertible, ExtensionRegistry};
+    use crate::extensions::AnyConvertible;
 
     fn make_hint(strategies: Vec<PartitionStrategy>, count: i64) -> PartitionHint {
         PartitionHint {
@@ -248,8 +330,7 @@ mod tests {
 
     #[test]
     fn registry_roundtrip() {
-        let mut registry = ExtensionRegistry::new();
-        registry.register_enhancement::<PartitionHint>().unwrap();
+        let registry = registry();
 
         let original = make_hint(vec![PartitionStrategy::Hash], 4);
         let any = original.to_any().unwrap();
@@ -264,6 +345,37 @@ mod tests {
             .parse_enhancement("PartitionHint", &args)
             .expect("parse_enhancement");
         let decoded = PartitionHint::from_any(any2.as_ref()).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn plan_hint_args_round_trip() {
+        let original = PlanHint {
+            hint: "use_index".to_owned(),
+        };
+        let args = original.to_args().unwrap();
+        let decoded = PlanHint::from_args(&args).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn plan_hint_registry_roundtrip() {
+        let registry = registry();
+
+        let original = PlanHint {
+            hint: "parallel".to_owned(),
+        };
+        let any = original.to_any().unwrap();
+
+        let (name, args) = registry
+            .decode_optimization(any.as_ref())
+            .expect("decode_optimization");
+        assert_eq!(name, "PlanHint");
+
+        let any2 = registry
+            .parse_optimization("PlanHint", &args)
+            .expect("parse_optimization");
+        let decoded = PlanHint::from_any(any2.as_ref()).unwrap();
         assert_eq!(original, decoded);
     }
 }

--- a/src/extensions/examples.rs
+++ b/src/extensions/examples.rs
@@ -12,7 +12,7 @@
 //! the `&` enum prefix.  The optional named argument `count` gives the target
 //! number of partitions (`0` / absent means "let the executor decide").
 
-use crate::extensions::args::{EnumValue, ExtensionArgs, ExtensionRelationType, ExtensionValue};
+use crate::extensions::args::{EnumValue, ExtensionArgs, ExtensionValue};
 use crate::extensions::registry::{Explainable, ExtensionError, ExtensionRegistry};
 
 // ---------------------------------------------------------------------------
@@ -145,7 +145,7 @@ impl Explainable for PartitionHint {
     }
 
     fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-        let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+        let mut args = ExtensionArgs::default();
         for &raw in &self.strategies {
             let s = PartitionStrategy::try_from(raw).unwrap_or(PartitionStrategy::Unspecified);
             args.positional
@@ -222,7 +222,7 @@ impl Explainable for PlanHint {
     }
 
     fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-        let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+        let mut args = ExtensionArgs::default();
         args.named
             .insert("hint".to_owned(), ExtensionValue::String(self.hint.clone()));
         Ok(args)
@@ -288,7 +288,7 @@ mod tests {
 
     #[test]
     fn from_args_rejects_unknown_strategy() {
-        let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+        let mut args = ExtensionArgs::default();
         args.positional
             .push(ExtensionValue::Enum("BOGUS".to_owned()));
         assert!(PartitionHint::from_args(&args).is_err());
@@ -297,7 +297,7 @@ mod tests {
     #[test]
     fn from_args_rejects_non_enum_positional() {
         // An integer positional arg where an enum is expected should fail.
-        let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+        let mut args = ExtensionArgs::default();
         args.push(1_i64);
         let result = PartitionHint::from_args(&args);
         assert!(
@@ -309,7 +309,7 @@ mod tests {
     #[test]
     fn from_args_rejects_extra_named_args() {
         // check_exhausted should reject unknown named args.
-        let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+        let mut args = ExtensionArgs::default();
         args.insert("unknown_key", 99_i64);
         let result = PartitionHint::from_args(&args);
         assert!(

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -15,6 +15,7 @@ pub mod registry;
 pub mod simple;
 
 pub use any::{Any, AnyRef};
+pub(crate) use args::AddendumKind;
 pub use args::{
     EnumValue, Expr, ExtensionArgs, ExtensionColumn, ExtensionRelationType, ExtensionValue,
     ExtensionValueKind, TupleValue,

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -17,8 +17,7 @@ pub mod simple;
 pub use any::{Any, AnyRef};
 pub(crate) use args::AddendumKind;
 pub use args::{
-    EnumValue, Expr, ExtensionArgs, ExtensionColumn, ExtensionRelationType, ExtensionValue,
-    ExtensionValueKind, TupleValue,
+    EnumValue, Expr, ExtensionArgs, ExtensionColumn, ExtensionValue, ExtensionValueKind, TupleValue,
 };
 pub use registry::{
     AnyConvertible, Explainable, Extension, ExtensionError, ExtensionProtoConvert,

--- a/src/extensions/registry.rs
+++ b/src/extensions/registry.rs
@@ -27,7 +27,6 @@
 //! ```rust
 //! use substrait_explain::extensions::{
 //!     Any, AnyConvertible, AnyRef, Explainable, ExtensionArgs, ExtensionError, ExtensionRegistry,
-//!     ExtensionRelationType,
 //! };
 //!
 //! // Define a custom extension type
@@ -70,7 +69,7 @@
 //!     }
 //!
 //!     fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-//!         let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+//!         let mut args = ExtensionArgs::default();
 //!         args.insert("path", self.path.clone());
 //!         Ok(args)
 //!     }
@@ -607,7 +606,7 @@ impl fmt::Debug for ExtensionRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extensions::{ExtensionColumn, ExtensionRelationType};
+    use crate::extensions::ExtensionColumn;
 
     // Mock type for testing
     struct TestExtension {
@@ -665,7 +664,7 @@ mod tests {
         }
 
         fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-            let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+            let mut args = ExtensionArgs::default();
             args.insert("path", self.path.clone());
             args.insert("batch_size", self.batch_size);
             Ok(args)
@@ -688,7 +687,7 @@ mod tests {
         assert!(registry.has_extension(ExtensionType::Relation, "TestExtension"));
 
         // Test parse and textify
-        let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+        let mut args = ExtensionArgs::default();
         args.insert("path", "data.parquet");
         args.insert("batch_size", 2048_i64);
 
@@ -706,7 +705,7 @@ mod tests {
 
     #[test]
     fn test_extension_args() {
-        let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+        let mut args = ExtensionArgs::default();
 
         // Add named args
         args.insert("path", "data/*.parquet");
@@ -742,19 +741,19 @@ mod tests {
         let registry = ExtensionRegistry::new();
 
         // Extension not found
-        let args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+        let args = ExtensionArgs::default();
         let result = registry.parse_extension("NonExistent", &args);
         assert!(matches!(result, Err(ExtensionError::NotFound { .. })));
 
         // Missing argument
-        let args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+        let args = ExtensionArgs::default();
         let mut extractor = args.extractor();
         let result = extractor.get_named_arg("missing");
         assert!(result.is_none());
         assert!(extractor.check_exhausted().is_ok());
 
         // Type check example
-        let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+        let mut args = ExtensionArgs::default();
         args.insert("test", 42_i64);
         let mut extractor = args.extractor();
         let result = extractor.get_named_arg("test");
@@ -804,7 +803,7 @@ mod tests {
         }
 
         fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-            let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+            let mut args = ExtensionArgs::default();
             args.insert("hint", self.hint.clone());
             Ok(args)
         }
@@ -828,7 +827,7 @@ mod tests {
         );
 
         // Test that extension namespace works
-        let mut ext_args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+        let mut ext_args = ExtensionArgs::default();
         ext_args.insert("path", "data.parquet");
         ext_args.insert("batch_size", 2048_i64);
 
@@ -838,7 +837,7 @@ mod tests {
         assert_eq!(ext_any.type_url, "test.TestExtension");
 
         // Test that enhancement namespace works
-        let mut enh_args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+        let mut enh_args = ExtensionArgs::default();
         enh_args.insert("hint", "optimize");
 
         let enh_any = registry
@@ -870,7 +869,7 @@ mod tests {
     #[test]
     fn test_enhancement_not_found_error() {
         let registry = ExtensionRegistry::new();
-        let args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+        let args = ExtensionArgs::default();
         let result = registry.parse_enhancement("NonExistentEnhancement", &args);
         assert!(matches!(result, Err(ExtensionError::NotFound { .. })));
     }
@@ -904,7 +903,7 @@ mod tests {
         }
 
         fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-            Ok(ExtensionArgs::new(ExtensionRelationType::Leaf))
+            Ok(ExtensionArgs::default())
         }
     }
 

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -50,9 +50,6 @@ pub enum ParseError {
     #[error("Failed to parse relation on {0}: {1}")]
     RelationParse(ParseContext, String),
 
-    #[error("Unknown extension relation type: {0}")]
-    UnknownExtensionRelationType(String),
-
     #[error("Invalid input at {0}: {1}")]
     ValidationError(ParseContext, String),
 

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -8,11 +8,10 @@ use super::{
     MessageParseError, ParsePair, Rule, RuleIter, ScopedParsePair, unescape_string,
     unwrap_single_pair,
 };
-use crate::extensions::registry::ExtensionType;
 use crate::extensions::simple::{self, ExtensionKind};
 use crate::extensions::{
-    ExtensionArgs, ExtensionColumn, ExtensionRelationType, ExtensionValue, InsertError,
-    SimpleExtensions, TupleValue,
+    AddendumKind, ExtensionArgs, ExtensionColumn, ExtensionRelationType, ExtensionValue,
+    InsertError, SimpleExtensions, TupleValue,
 };
 use crate::parser::structural::IndentedLine;
 
@@ -431,25 +430,21 @@ impl ScopedParsePair for ExtensionInvocation {
     }
 }
 
-/// A parsed `+ Enh:Name[args]` or `+ Opt:Name[args]` line.
+/// A parsed `+` addendum line.
 #[derive(Debug, Clone)]
-pub struct AdvExtInvocation {
-    /// Whether this is an enhancement (`ExtensionType::Enhancement`) or
-    /// optimization (`ExtensionType::Optimization`).  The grammar restricts
-    /// the value to those two variants; `ExtensionType::Relation` will never
-    /// appear here.
-    pub ext_type: ExtensionType,
-    pub name: String,
-    pub args: ExtensionArgs,
+pub(crate) struct AddendumInvocation {
+    pub(crate) kind: AddendumKind,
+    pub(crate) name: String,
+    pub(crate) args: ExtensionArgs,
 }
 
-impl ScopedParsePair for AdvExtInvocation {
+impl ScopedParsePair for AddendumInvocation {
     fn rule() -> Rule {
         Rule::adv_extension
     }
 
     fn message() -> &'static str {
-        "AdvExtInvocation"
+        "AddendumInvocation"
     }
 
     fn parse_pair(
@@ -462,9 +457,9 @@ impl ScopedParsePair for AdvExtInvocation {
 
         // First token: adv_ext_type — grammar guarantees "Enh" or "Opt"
         let type_pair = iter.next().unwrap(); // Grammar guarantees adv_ext_type exists
-        let ext_type = match type_pair.as_str() {
-            "Enh" => ExtensionType::Enhancement,
-            "Opt" => ExtensionType::Optimization,
+        let kind = match type_pair.as_str() {
+            "Enh" => AddendumKind::Enhancement,
+            "Opt" => AddendumKind::Optimization,
             other => unreachable!("Unexpected adv_ext_type: {other}"),
         };
 
@@ -472,10 +467,8 @@ impl ScopedParsePair for AdvExtInvocation {
         let name_pair = iter.next().unwrap();
         let name = Name::parse_pair(name_pair).0.to_string();
 
-        // Advanced extensions reuse ExtensionArgs, but their text syntax has no
-        // child relations; Leaf is only a placeholder here.
-        //
-        // TODO: this is ugly and misleading
+        // Remaining token: arguments — grammar guarantees it is always present.
+        // Use Leaf as the relation_type placeholder — addenda don't have children.
         let mut args = ExtensionArgs::new(crate::extensions::ExtensionRelationType::Leaf);
 
         let arguments_pair = iter.next().unwrap();
@@ -483,14 +476,10 @@ impl ScopedParsePair for AdvExtInvocation {
             Rule::arguments => {
                 arguments_rule_parsing(extensions, arguments_pair, &mut args)?;
             }
-            r => unreachable!("Unexpected rule in AdvExtInvocation args: {r:?}"),
+            r => unreachable!("Unexpected rule in AddendumInvocation args: {r:?}"),
         }
 
-        Ok(AdvExtInvocation {
-            ext_type,
-            name,
-            args,
-        })
+        Ok(AddendumInvocation { kind, name, args })
     }
 }
 
@@ -750,11 +739,12 @@ Functions:
 
     #[test]
     fn test_tuple_in_adv_extension_parses() {
-        let inv = AdvExtInvocation::parse(
+        let inv = AddendumInvocation::parse(
             &SimpleExtensions::default(),
             "+ Enh:Foo[(&HASH, &RANGE), count=8]",
         )
         .unwrap();
+        assert_eq!(inv.kind, AddendumKind::Enhancement);
         assert_eq!(inv.name, "Foo");
         assert_eq!(inv.args.positional.len(), 1);
         let ExtensionValue::Tuple(items) = &inv.args.positional[0] else {

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -10,8 +10,8 @@ use super::{
 };
 use crate::extensions::simple::{self, ExtensionKind};
 use crate::extensions::{
-    AddendumKind, ExtensionArgs, ExtensionColumn, ExtensionRelationType, ExtensionValue,
-    InsertError, SimpleExtensions, TupleValue,
+    AddendumKind, ExtensionArgs, ExtensionColumn, ExtensionValue, InsertError, SimpleExtensions,
+    TupleValue,
 };
 use crate::parser::structural::IndentedLine;
 
@@ -357,12 +357,95 @@ impl ScopedParsePair for ExtensionColumn {
     }
 }
 
+/// Relation kind encoded by the text syntax prefix (`ExtensionLeaf`,
+/// `ExtensionSingle`, or `ExtensionMulti`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExtensionRelationKind {
+    Leaf,
+    Single,
+    Multi,
+}
+
+impl FromStr for ExtensionRelationKind {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ExtensionLeaf" => Ok(ExtensionRelationKind::Leaf),
+            "ExtensionSingle" => Ok(ExtensionRelationKind::Single),
+            "ExtensionMulti" => Ok(ExtensionRelationKind::Multi),
+            _ => Err(format!("Unknown extension relation type: {s}")),
+        }
+    }
+}
+
+impl ExtensionRelationKind {
+    pub(crate) fn validate_child_count(self, child_count: usize) -> Result<(), String> {
+        match self {
+            ExtensionRelationKind::Leaf => {
+                if child_count == 0 {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "ExtensionLeaf should have no input children, got {child_count}"
+                    ))
+                }
+            }
+            ExtensionRelationKind::Single => {
+                if child_count == 1 {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "ExtensionSingle should have exactly 1 input child, got {child_count}"
+                    ))
+                }
+            }
+            ExtensionRelationKind::Multi => Ok(()),
+        }
+    }
+
+    /// Create appropriate relation structure from extension detail and children.
+    pub(crate) fn create_rel(
+        self,
+        detail: Option<Any>,
+        children: Vec<substrait::proto::Rel>,
+    ) -> substrait::proto::Rel {
+        use substrait::proto::rel::RelType;
+        use substrait::proto::{ExtensionLeafRel, ExtensionMultiRel, ExtensionSingleRel};
+
+        let rel_type = match self {
+            ExtensionRelationKind::Leaf => RelType::ExtensionLeaf(ExtensionLeafRel {
+                common: None,
+                detail: detail.map(Into::into),
+            }),
+            ExtensionRelationKind::Single => {
+                let input = children.into_iter().next();
+                RelType::ExtensionSingle(Box::new(ExtensionSingleRel {
+                    common: None,
+                    detail: detail.map(Into::into),
+                    input: input.map(Box::new),
+                }))
+            }
+            ExtensionRelationKind::Multi => RelType::ExtensionMulti(ExtensionMultiRel {
+                common: None,
+                detail: detail.map(Into::into),
+                inputs: children,
+            }),
+        };
+
+        substrait::proto::Rel {
+            rel_type: Some(rel_type),
+        }
+    }
+}
+
 /// Fully parsed extension invocation, including the user-supplied name and the
 /// structured argument payload.
 #[derive(Debug, Clone)]
-pub struct ExtensionInvocation {
-    pub name: String,
-    pub args: ExtensionArgs,
+pub(crate) struct ExtensionInvocation {
+    pub(crate) relation_kind: ExtensionRelationKind,
+    pub(crate) name: String,
+    pub(crate) args: ExtensionArgs,
 }
 
 impl ScopedParsePair for ExtensionInvocation {
@@ -395,8 +478,8 @@ impl ScopedParsePair for ExtensionInvocation {
             (full_extension_name, "UnknownExtension".to_string())
         };
 
-        let relation_type = ExtensionRelationType::from_str(relation_type_str).unwrap();
-        let mut args = ExtensionArgs::new(relation_type);
+        let relation_kind = ExtensionRelationKind::from_str(relation_type_str).unwrap();
+        let mut args = ExtensionArgs::default();
 
         // Parse optional arguments
         let ext_arguments = iter.next().unwrap();
@@ -424,6 +507,7 @@ impl ScopedParsePair for ExtensionInvocation {
         }
 
         Ok(ExtensionInvocation {
+            relation_kind,
             name: custom_name,
             args,
         })
@@ -468,8 +552,7 @@ impl ScopedParsePair for AddendumInvocation {
         let name = Name::parse_pair(name_pair).0.to_string();
 
         // Remaining token: arguments — grammar guarantees it is always present.
-        // Use Leaf as the relation_type placeholder — addenda don't have children.
-        let mut args = ExtensionArgs::new(crate::extensions::ExtensionRelationType::Leaf);
+        let mut args = ExtensionArgs::default();
 
         let arguments_pair = iter.next().unwrap();
         match arguments_pair.as_rule() {
@@ -512,51 +595,6 @@ fn arguments_rule_parsing(
         }
     }
     Ok(())
-}
-
-impl ExtensionRelationType {
-    /// Create appropriate relation structure from extension detail and children.
-    /// This method handles the structural logic for creating different extension relation types.
-    pub fn create_rel(
-        self,
-        detail: Option<Any>,
-        children: Vec<Box<substrait::proto::Rel>>,
-    ) -> Result<substrait::proto::Rel, String> {
-        use substrait::proto::rel::RelType;
-        use substrait::proto::{ExtensionLeafRel, ExtensionMultiRel, ExtensionSingleRel};
-
-        // Validate child count matches relation type
-        self.validate_child_count(children.len())?;
-
-        // The output column count is returned alongside the Rel by parse_extension_relation
-        // and flows up the parse tree through Rust return values
-        let rel_type = match self {
-            ExtensionRelationType::Leaf => RelType::ExtensionLeaf(ExtensionLeafRel {
-                common: None,
-                detail: detail.map(Into::into),
-            }),
-            ExtensionRelationType::Single => {
-                let input = children.into_iter().next().map(|child| *child);
-                RelType::ExtensionSingle(Box::new(ExtensionSingleRel {
-                    common: None,
-                    detail: detail.map(Into::into),
-                    input: input.map(Box::new),
-                }))
-            }
-            ExtensionRelationType::Multi => {
-                let inputs = children.into_iter().map(|child| *child).collect();
-                RelType::ExtensionMulti(ExtensionMultiRel {
-                    common: None,
-                    detail: detail.map(Into::into),
-                    inputs,
-                })
-            }
-        };
-
-        Ok(substrait::proto::Rel {
-            rel_type: Some(rel_type),
-        })
-    }
 }
 
 #[cfg(test)]
@@ -755,6 +793,43 @@ Functions:
         assert!(matches!(items[0], ExtensionValue::Enum(s) if s == "HASH"));
         assert!(matches!(items[1], ExtensionValue::Enum(s) if s == "RANGE"));
         assert_eq!(inv.args.named.len(), 1);
+    }
+
+    #[test]
+    fn extension_relation_kind_parses_text_prefixes() {
+        assert_eq!(
+            ExtensionRelationKind::from_str("ExtensionLeaf").unwrap(),
+            ExtensionRelationKind::Leaf
+        );
+        assert_eq!(
+            ExtensionRelationKind::from_str("ExtensionSingle").unwrap(),
+            ExtensionRelationKind::Single
+        );
+        assert_eq!(
+            ExtensionRelationKind::from_str("ExtensionMulti").unwrap(),
+            ExtensionRelationKind::Multi
+        );
+    }
+
+    #[test]
+    fn extension_multi_allows_any_child_count() {
+        assert!(ExtensionRelationKind::Multi.validate_child_count(0).is_ok());
+        assert!(ExtensionRelationKind::Multi.validate_child_count(1).is_ok());
+        assert!(ExtensionRelationKind::Multi.validate_child_count(3).is_ok());
+    }
+
+    #[test]
+    fn extension_single_rejects_wrong_child_counts() {
+        assert!(
+            ExtensionRelationKind::Single
+                .validate_child_count(0)
+                .is_err()
+        );
+        assert!(
+            ExtensionRelationKind::Single
+                .validate_child_count(2)
+                .is_err()
+        );
     }
 
     #[test]

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -17,8 +17,8 @@ use substrait::proto::{
 
 use super::{MessageParseError, ParsePair, Rule, RuleIter, ScopedParsePair, unwrap_single_pair};
 use crate::extensions::any::Any;
-use crate::extensions::registry::{ExtensionError, ExtensionType};
-use crate::extensions::{ExtensionArgs, ExtensionRegistry, SimpleExtensions};
+use crate::extensions::registry::ExtensionError;
+use crate::extensions::{AddendumKind, ExtensionArgs, ExtensionRegistry, SimpleExtensions};
 use crate::parser::errors::{ParseContext, ParseError};
 use crate::parser::expressions::{FieldIndex, Name};
 
@@ -56,19 +56,15 @@ impl<'a> RelationParsingContext<'a> {
 
     /// Resolve an advanced-extension detail (enhancement or optimization) using the registry.
     /// Any failure is treated as a hard parse error.
-    ///
-    /// `ext_type` must be `Enhancement` or `Optimization`; `Relation` is not valid here and
-    /// will panic via the unreachable branch in the dispatch below.
-    pub fn resolve_adv_ext_detail(
+    pub(crate) fn resolve_adv_ext_detail(
         &self,
-        ext_type: ExtensionType,
+        kind: AddendumKind,
         name: &str,
         args: &ExtensionArgs,
     ) -> Result<Any, ParseError> {
-        let result = match ext_type {
-            ExtensionType::Enhancement => self.registry.parse_enhancement(name, args),
-            ExtensionType::Optimization => self.registry.parse_optimization(name, args),
-            ExtensionType::Relation => unreachable!("Relation is not an advanced extension type"),
+        let result = match kind {
+            AddendumKind::Enhancement => self.registry.parse_enhancement(name, args),
+            AddendumKind::Optimization => self.registry.parse_optimization(name, args),
         };
         result.map_err(|err| match err {
             ExtensionError::NotFound { .. } => ParseError::UnregisteredExtension {

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -363,14 +363,14 @@ impl<'a> RelationParser<'a> {
         let pair_span = ctx.pair.as_span();
 
         let ExtensionInvocation {
+            relation_kind,
             name,
             args: extension_args,
         } = ExtensionInvocation::parse_pair(extensions, ctx.pair.clone())
             .map_err(|e| ParseError::Plan(ParseContext::new(line_no, line.clone()), e))?;
 
         let child_count = ctx.children.len();
-        extension_args
-            .relation_type
+        relation_kind
             .validate_child_count(child_count)
             .map_err(|e| {
                 ParseError::Plan(
@@ -389,15 +389,8 @@ impl<'a> RelationParser<'a> {
         let detail = context.resolve_extension_detail(&name, &extension_args)?;
         let output_column_count = extension_args.output_columns.len();
 
-        let rel = extension_args
-            .relation_type
-            .create_rel(detail, ctx.children)
-            .map_err(|e| {
-                ParseError::Plan(
-                    ParseContext::new(line_no, line.to_string()),
-                    MessageParseError::invalid("extension_relation", pair_span, e),
-                )
-            })?;
+        let children = ctx.children.into_iter().map(|child| *child).collect();
+        let rel = relation_kind.create_rel(detail, children);
 
         if ctx.advanced_extension.is_some() {
             return Err(ParseError::ValidationError(

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -13,12 +13,12 @@ use substrait::proto::{
     SortRel, plan_rel,
 };
 
-use crate::extensions::{ExtensionRegistry, ExtensionType, SimpleExtensions, simple};
+use crate::extensions::{AddendumKind, ExtensionRegistry, SimpleExtensions, simple};
 use crate::parser::common::{MessageParseError, ParsePair, ScopedParsePair};
 use crate::parser::errors::{ParseContext, ParseError, ParseResult};
 use crate::parser::expressions::Name;
 use crate::parser::extensions::{
-    AdvExtInvocation, ExtensionInvocation, ExtensionParseError, ExtensionParser,
+    AddendumInvocation, ExtensionInvocation, ExtensionParseError, ExtensionParser,
 };
 use crate::parser::relations::{RelationParsingContext, VirtualReadRel};
 use crate::parser::{ErrorKind, ExpressionParser, RelationParsePair, Rule, unwrap_single_pair};
@@ -50,11 +50,10 @@ impl<'a> From<&'a str> for IndentedLine<'a> {
     }
 }
 
-/// An advanced-extension annotation (`+ Enh:Name[args]` or `+ Opt:Name[args]`)
-/// that is attached to a relation node. The `pair` holds the `adv_extension`
-/// grammar rule directly (already unwrapped from the outer `planNode`).
+/// A `+`-prefixed addendum line attached to a relation node. The `pair` holds
+/// the grammar rule directly (already unwrapped from the outer `planNode`).
 #[derive(Debug, Clone)]
-pub struct AdvExt<'a> {
+pub struct Addendum<'a> {
     pub pair: Pair<'a, Rule>, // Rule::adv_extension
     pub line_no: i64,
 }
@@ -64,7 +63,7 @@ pub struct AdvExt<'a> {
 pub struct RelationNode<'a> {
     pub pair: Pair<'a, Rule>,
     pub line_no: i64,
-    pub adv_extensions: Vec<AdvExt<'a>>,
+    pub addenda: Vec<Addendum<'a>>,
     pub children: Vec<RelationNode<'a>>,
 }
 
@@ -77,7 +76,7 @@ impl<'a> RelationNode<'a> {
     }
 }
 
-/// A parsed plan line: either a relation or an advanced extension (`+`-prefixed line).
+/// A parsed plan line: either a relation or a `+`-prefixed addendum line.
 ///
 /// Classification happens at construction time by inspecting the inner grammar
 /// rule, so downstream code can use standard Rust pattern matching rather than
@@ -85,7 +84,7 @@ impl<'a> RelationNode<'a> {
 #[derive(Debug, Clone)]
 pub enum LineNode<'a> {
     Relation(RelationNode<'a>),
-    AdvExt(AdvExt<'a>),
+    Addendum(Addendum<'a>),
 }
 
 impl<'a> LineNode<'a> {
@@ -106,14 +105,14 @@ impl<'a> LineNode<'a> {
         let inner = unwrap_single_pair(outer);
 
         Ok(match inner.as_rule() {
-            Rule::adv_extension => LineNode::AdvExt(AdvExt {
+            Rule::adv_extension => LineNode::Addendum(Addendum {
                 pair: inner,
                 line_no,
             }),
             _ => LineNode::Relation(RelationNode {
                 pair: inner,
                 line_no,
-                adv_extensions: Vec::new(),
+                addenda: Vec::new(),
                 children: Vec::new(),
             }),
         })
@@ -148,13 +147,13 @@ impl<'a> LineNode<'a> {
         // planNode can include addenda (+Enh:, +Opt:); surface them so
         // TreeBuilder::add_line can produce the appropriate depth-0 error.
         if pair.as_rule() == Rule::adv_extension {
-            return Ok(LineNode::AdvExt(AdvExt { pair, line_no }));
+            return Ok(LineNode::Addendum(Addendum { pair, line_no }));
         }
 
         Ok(LineNode::Relation(RelationNode {
             pair,
             line_no,
-            adv_extensions: Vec::new(),
+            addenda: Vec::new(),
             children: Vec::new(),
         }))
     }
@@ -223,8 +222,9 @@ impl<'a> TreeBuilder<'a> {
 
                 parent.children.push(rel_node);
             }
-            LineNode::AdvExt(adv_ext) => {
-                let context = ParseContext::new(adv_ext.line_no, adv_ext.pair.as_str().to_string());
+            LineNode::Addendum(addendum) => {
+                let context =
+                    ParseContext::new(addendum.line_no, addendum.pair.as_str().to_string());
                 if depth == 0 {
                     return Err(ParseError::ValidationError(
                         context,
@@ -251,7 +251,7 @@ impl<'a> TreeBuilder<'a> {
                     ));
                 }
 
-                parent.adv_extensions.push(adv_ext);
+                parent.addenda.push(addendum);
             }
         }
         Ok(())
@@ -427,10 +427,10 @@ impl<'a> RelationParser<'a> {
             children.push(Box::new(rel));
         }
 
-        let advanced_extension = if node.adv_extensions.is_empty() {
+        let advanced_extension = if node.addenda.is_empty() {
             None
         } else {
-            Some(self.build_advanced_extension(extensions, registry, node.adv_extensions)?)
+            Some(self.build_advanced_extension(extensions, registry, node.addenda)?)
         };
 
         self.parse_relation(
@@ -446,20 +446,20 @@ impl<'a> RelationParser<'a> {
         )
     }
 
-    /// Parse a list of [`AdvExt`] nodes into an [`AdvancedExtension`] proto.
+    /// Parse enhancement/optimization addenda into an [`AdvancedExtension`] proto.
     fn build_advanced_extension(
         &self,
         extensions: &SimpleExtensions,
         registry: &ExtensionRegistry,
-        adv_exts: Vec<AdvExt>,
+        addenda: Vec<Addendum>,
     ) -> Result<AdvancedExtension, ParseError> {
         let mut enhancement = None;
         let mut optimizations = Vec::new();
 
-        for adv_ext in adv_exts {
-            let line_no = adv_ext.line_no;
-            let line = adv_ext.pair.as_str().to_string();
-            let invocation = AdvExtInvocation::parse_pair(extensions, adv_ext.pair)
+        for addendum in addenda {
+            let line_no = addendum.line_no;
+            let line = addendum.pair.as_str().to_string();
+            let invocation = AddendumInvocation::parse_pair(extensions, addendum.pair)
                 .map_err(|e| ParseError::Plan(ParseContext::new(line_no, line.clone()), e))?;
             let context = RelationParsingContext {
                 extensions,
@@ -468,10 +468,10 @@ impl<'a> RelationParser<'a> {
                 line: &line,
             };
 
-            match invocation.ext_type {
-                ExtensionType::Enhancement => {
+            match invocation.kind {
+                AddendumKind::Enhancement => {
                     let detail = context.resolve_adv_ext_detail(
-                        ExtensionType::Enhancement,
+                        AddendumKind::Enhancement,
                         &invocation.name,
                         &invocation.args,
                     )?;
@@ -483,16 +483,13 @@ impl<'a> RelationParser<'a> {
                     }
                     enhancement = Some(detail.into());
                 }
-                ExtensionType::Optimization => {
+                AddendumKind::Optimization => {
                     let detail = context.resolve_adv_ext_detail(
-                        ExtensionType::Optimization,
+                        AddendumKind::Optimization,
                         &invocation.name,
                         &invocation.args,
                     )?;
                     optimizations.push(detail.into());
-                }
-                ExtensionType::Relation => {
-                    unreachable!("Grammar restricts adv_ext_type to 'Enh' or 'Opt'")
                 }
             }
         }
@@ -519,8 +516,8 @@ impl<'a> RelationParser<'a> {
         }
 
         // Root relations don't support addenda — reject rather than silently discard.
-        if !node.adv_extensions.is_empty() {
-            let first = &node.adv_extensions[0];
+        if !node.addenda.is_empty() {
+            let first = &node.addenda[0];
             let context = ParseContext::new(first.line_no, first.pair.as_str().to_string());
             return Err(ParseError::ValidationError(
                 context,

--- a/src/textify/extensions.rs
+++ b/src/textify/extensions.rs
@@ -11,8 +11,9 @@ use substrait::proto::extensions::AdvancedExtension;
 
 use crate::FormatError;
 use crate::extensions::any::AnyRef;
-use crate::extensions::registry::ExtensionType;
-use crate::extensions::{Expr, ExtensionArgs, ExtensionColumn, ExtensionValue, TupleValue};
+use crate::extensions::{
+    AddendumKind, Expr, ExtensionArgs, ExtensionColumn, ExtensionValue, TupleValue,
+};
 use crate::textify::foundation::{PlanError, Scope, Textify};
 use crate::textify::types::{Name, escaped};
 
@@ -124,15 +125,15 @@ impl Textify for ExtensionArgs {
 fn format_adv_ext_line<S: Scope, W: fmt::Write>(
     ctx: &S,
     w: &mut W,
-    ext_type: ExtensionType,
+    kind: AddendumKind,
     detail: AnyRef<'_>,
 ) -> fmt::Result {
     let indent = ctx.indent();
     let registry = ctx.extension_registry();
-    let (prefix, decode_result) = match ext_type {
-        ExtensionType::Enhancement => ("Enh", registry.decode_enhancement(detail)),
-        ExtensionType::Optimization => ("Opt", registry.decode_optimization(detail)),
-        ExtensionType::Relation => unreachable!("Relation extensions don't use adv_ext lines"),
+    let prefix = kind.prefix();
+    let decode_result = match kind {
+        AddendumKind::Enhancement => registry.decode_enhancement(detail),
+        AddendumKind::Optimization => registry.decode_optimization(detail),
     };
     match decode_result {
         Ok((name, args)) => {
@@ -166,19 +167,14 @@ impl Textify for AdvancedExtension {
     fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
         if let Some(enhancement) = &self.enhancement {
             writeln!(w)?;
-            format_adv_ext_line(
-                ctx,
-                w,
-                ExtensionType::Enhancement,
-                AnyRef::from(enhancement),
-            )?;
+            format_adv_ext_line(ctx, w, AddendumKind::Enhancement, AnyRef::from(enhancement))?;
         }
         for optimization in &self.optimization {
             writeln!(w)?;
             format_adv_ext_line(
                 ctx,
                 w,
-                ExtensionType::Optimization,
+                AddendumKind::Optimization,
                 AnyRef::from(optimization),
             )?;
         }

--- a/tests/adv_extension_roundtrip.rs
+++ b/tests/adv_extension_roundtrip.rs
@@ -164,9 +164,7 @@ Root[result]
 /// A minimal Explainable + prost::Message used to register as an optimization.
 mod opt_fixture {
     use prost::Name;
-    use substrait_explain::extensions::{
-        Explainable, ExtensionArgs, ExtensionError, ExtensionRelationType,
-    };
+    use substrait_explain::extensions::{Explainable, ExtensionArgs, ExtensionError};
 
     #[derive(Clone, PartialEq, prost::Message)]
     pub struct PlanHint {
@@ -200,7 +198,7 @@ mod opt_fixture {
         }
 
         fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-            let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+            let mut args = ExtensionArgs::default();
             args.insert("hint", self.hint.clone());
             Ok(args)
         }
@@ -521,7 +519,7 @@ Root[result]
 mod extension_child_fixture {
     use prost::Name;
     use substrait_explain::extensions::{
-        Explainable, ExtensionArgs, ExtensionColumn, ExtensionError, ExtensionRelationType,
+        Explainable, ExtensionArgs, ExtensionColumn, ExtensionError,
     };
 
     #[derive(Clone, PartialEq, prost::Message)]
@@ -554,7 +552,7 @@ mod extension_child_fixture {
         }
 
         fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-            let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+            let mut args = ExtensionArgs::default();
             args.output_columns.push(ExtensionColumn::Named {
                 name: "col0".to_owned(),
                 r#type: super::parse_type("i64"),
@@ -845,7 +843,7 @@ Root[result]
 mod adv_ext_with_columns_fixture {
     use prost::Name;
     use substrait_explain::extensions::{
-        Explainable, ExtensionArgs, ExtensionColumn, ExtensionError, ExtensionRelationType,
+        Explainable, ExtensionArgs, ExtensionColumn, ExtensionError,
     };
 
     #[derive(Clone, PartialEq, prost::Message)]
@@ -876,7 +874,7 @@ mod adv_ext_with_columns_fixture {
         }
 
         fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-            let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+            let mut args = ExtensionArgs::default();
             // Deliberately populate output_columns — the adv_extension grammar
             // has no "=> columns" clause, so this cannot be round-tripped.
             args.output_columns.push(ExtensionColumn::Named {

--- a/tests/extension_roundtrip.rs
+++ b/tests/extension_roundtrip.rs
@@ -8,7 +8,7 @@ use substrait::proto::r#type::Nullability;
 use substrait_explain::extensions::examples::PartitionHint;
 use substrait_explain::extensions::{
     EnumValue, Explainable, Expr, ExtensionArgs, ExtensionColumn, ExtensionError,
-    ExtensionProtoConvert, ExtensionRegistry, ExtensionRelationType, ExtensionValue, TupleValue,
+    ExtensionProtoConvert, ExtensionRegistry, ExtensionValue, TupleValue,
 };
 use substrait_explain::fixtures::parse_type;
 use substrait_explain::format_with_registry;
@@ -81,7 +81,7 @@ impl Explainable for UserTableConfig {
     }
 
     fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-        let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+        let mut args = ExtensionArgs::default();
 
         // Add named arguments
         args.insert("name", self.table_name.clone());
@@ -175,7 +175,7 @@ fn test_multiple_extensions_in_plan() {
         }
 
         fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-            let mut args = ExtensionArgs::new(ExtensionRelationType::Single);
+            let mut args = ExtensionArgs::default();
             args.insert("expr", self.expression.clone());
             Ok(args)
         }
@@ -265,7 +265,7 @@ impl Explainable for LiteralConfig {
     }
 
     fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-        let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+        let mut args = ExtensionArgs::default();
         args.insert("path", self.path.clone());
         args.insert("big", self.big);
         args.insert("ratio", self.ratio);
@@ -353,7 +353,7 @@ impl Explainable for EmptySource {
     }
 
     fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-        Ok(ExtensionArgs::new(ExtensionRelationType::Leaf))
+        Ok(ExtensionArgs::default())
     }
 }
 
@@ -434,7 +434,7 @@ impl Explainable for PassThroughWrapper {
     }
 
     fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-        let mut args = ExtensionArgs::new(ExtensionRelationType::Single);
+        let mut args = ExtensionArgs::default();
         args.output_columns
             .push(ExtensionColumn::Expr(Reference(0).into()));
         Ok(args)
@@ -469,7 +469,7 @@ impl Explainable for BinaryMerge {
     }
 
     fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-        let mut args = ExtensionArgs::new(ExtensionRelationType::Multi);
+        let mut args = ExtensionArgs::default();
         args.output_columns
             .push(ExtensionColumn::Expr(Reference(0).into()));
         args.output_columns
@@ -636,7 +636,7 @@ impl Explainable for TupleSortHint {
     }
 
     fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-        let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+        let mut args = ExtensionArgs::default();
         let tv: TupleValue = self
             .directions
             .iter()
@@ -689,7 +689,7 @@ Root[result]
 
 #[test]
 fn test_tuple_sort_hint_from_args_rejects_non_tuple() {
-    let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+    let mut args = ExtensionArgs::default();
     args.positional
         .push(ExtensionValue::Enum("ASC".to_string()));
     let result = TupleSortHint::from_args(&args);

--- a/tests/json_parsing.rs
+++ b/tests/json_parsing.rs
@@ -9,7 +9,6 @@ use substrait::proto;
 use substrait_explain::cli::{Cli, Commands, Format};
 use substrait_explain::extensions::{
     Explainable, ExtensionArgs, ExtensionColumn, ExtensionError, ExtensionRegistry,
-    ExtensionRelationType,
 };
 use substrait_explain::json::{build_descriptor_pool, parse_json};
 use substrait_explain::parser::Parser;
@@ -41,7 +40,7 @@ impl Explainable for ParquetScanConfig {
     }
 
     fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-        let mut args = ExtensionArgs::new(ExtensionRelationType::Leaf);
+        let mut args = ExtensionArgs::default();
         args.insert("path", self.path.clone());
         args.insert("batch_size", self.batch_size);
         args.output_columns.push(ExtensionColumn::Named {


### PR DESCRIPTION
## Description

This PR refactors `ExtensionArgs`, moving `ExtensionRelationType` out of `ExtensionArgs` and into `extensions`. Extension implementations now return only the values written inside their brackets: positional args, named args, and output columns.

This also clears up some poor parsing: previous to this PR, extension authors could specify the `ExtensionRelationType`, but it was ignored.

## Changes

- Add internal addendum labels for `+ Enh:` and `+ Opt:` so text syntax labels are separate from registry namespaces.
- Move extension relation form handling into parser-side relation parsing.
- Remove `ExtensionRelationType` from the public extension argument API.
- Replace `ExtensionArgs::new(...)` with `ExtensionArgs::default()` in examples, tests, and docs.

## API Impact

- Breaking: `ExtensionRelationType` and `ExtensionArgs::new(...)` are removed.
- Extension authors should construct `ExtensionArgs` with `ExtensionArgs::default()`.
- Extension authors no longer specify `Leaf`, `Single`, or `Multi` from `to_args()`.

## Validation

- `cargo test`
- `cargo test --doc`
- `cargo test --features=cli`
- `just check`
