### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0](https://github.com/DataDog/substrait-explain/compare/v0.3.2...v0.4.0) - 2026-05-27
+
+### Bug Fixes
+
+- adding support for root reference root type on fieldReferences ([#134](https://github.com/DataDog/substrait-explain/pull/134))
+
+### Documentation
+
+- clarify squash-merge and admin-only tagging in RELEASING.md ([#120](https://github.com/DataDog/substrait-explain/pull/120))
+
+### Features
+
+- [**breaking**] rich proto types in ExtensionArgs for Explainable trait ([#102](https://github.com/DataDog/substrait-explain/pull/102))
+
 ## [0.3.2](https://github.com/DataDog/substrait-explain/compare/v0.3.1...v0.3.2) - 2026-04-29
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "substrait-explain"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrait-explain"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2024"
 authors = [
     "Wendell Smith <wendell.smith@datadoghq.com>",


### PR DESCRIPTION



## 🤖 New release

* `substrait-explain`: 0.3.2 -> 0.4.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/DataDog/substrait-explain/compare/v0.3.2...v0.4.0) - 2026-05-27

### Bug Fixes

- adding support for root reference root type on fieldReferences ([#134](https://github.com/DataDog/substrait-explain/pull/134))

### Documentation

- clarify squash-merge and admin-only tagging in RELEASING.md ([#120](https://github.com/DataDog/substrait-explain/pull/120))

### Features

- [**breaking**] rich proto types in ExtensionArgs for Explainable trait ([#102](https://github.com/DataDog/substrait-explain/pull/102))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).