### PR TITLE
fix: use cargo info for release guard

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -61,7 +61,7 @@ release-tag:
     fi
 
     # Guard: version should be published on crates.io
-    if ! curl -sf "https://crates.io/api/v1/crates/substrait-explain/${version}" >/dev/null; then
+    if ! cargo info --registry crates-io "substrait-explain@${version}" >/dev/null 2>&1; then
         echo "Error: ${version} not found on crates.io — wait for CI to publish first" >&2
         exit 1
     fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,7 +33,9 @@ Steps, run locally:
    3. `cargo install --locked release-plz` - the CLI for making the Release PR
    4. `cargo install --locked cargo-semver-checks` - used by release-plz to detect API-breaking changes; without it, release-plz can't choose the right version bump for breaking changes
 2. `git checkout main` - need to be on `main` for a release
-3. `release-plz release-pr --git-token $(gh auth token)` - `release-plz` will analyze the current state, and generate a Changelog, version bump, and PR on Github.
+3. Run `just release-pr`
+   - This will in turn call `release-plz release-pr --git-token $(gh auth token)`
+   - `release-plz` will analyze the current state, generate a Changelog, version bump, and PR on Github.
 
 ### 3. You review and merge the Release PR
 
@@ -101,11 +103,11 @@ gh release create v<VERSION> --title "v<VERSION>" --notes "See CHANGELOG.md"
 
 ## Configuration
 
-| File                                | Purpose                                                  |
-| ----------------------------------- | -------------------------------------------------------- |
-| `.github/workflows/release-plz.yml` | GitHub Actions workflow (publish to crates.io)           |
-| `release-plz.toml`                  | release-plz behavior and changelog format                |
-| `CHANGELOG.md`                      | Auto-updated changelog                                   |
+| File                                | Purpose                                        |
+| ----------------------------------- | ---------------------------------------------- |
+| `.github/workflows/release-plz.yml` | GitHub Actions workflow (publish to crates.io) |
+| `release-plz.toml`                  | release-plz behavior and changelog format      |
+| `CHANGELOG.md`                      | Auto-updated changelog                         |
 
 ### Secrets
 


### PR DESCRIPTION
## Summary

Use `cargo info --registry crates-io` for the `release-tag` publication guard instead of calling the crates.io API with plain `curl`.

The direct API request can be rejected by crates.io's data access policy, which made an available version look like it had not been published yet.

Also updated the `RELEASING.md` instructions to note the call to `just release-pr`.

## Validation

- `just --dry-run release-tag`
- `cargo info --registry crates-io substrait-explain@0.4.0`
- And finally, used this to tag [`v0.4.0`](https://github.com/DataDog/substrait-explain/releases/tag/v0.4.0)