### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0](https://github.com/DataDog/substrait-explain/compare/v0.4.0...v0.5.0) - 2026-05-28
+
+### Features
+
+- *(extensions)* [**breaking**] support extension table reads ([#129](https://github.com/DataDog/substrait-explain/pull/129))
+
+### Refactoring
+
+- *(parser)* generalize relation addendum handling ([#132](https://github.com/DataDog/substrait-explain/pull/132))
+
+### Test
+
+- add extension table read examples ([#130](https://github.com/DataDog/substrait-explain/pull/130))
+
 ## [0.4.0](https://github.com/DataDog/substrait-explain/compare/v0.3.2...v0.4.0) - 2026-05-27
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "substrait-explain"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrait-explain"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 authors = [
     "Wendell Smith <wendell.smith@datadoghq.com>",


### PR DESCRIPTION



## 🤖 New release

* `substrait-explain`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `substrait-explain` breaking changes

```text
--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field Relation.addenda in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/textify/rels.rs:284

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant ExtensionType::Enhancement 1 -> 2 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/extensions/registry.rs:102
  variant ExtensionType::Optimization 2 -> 3 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/extensions/registry.rs:104
  variant ExtensionType::Enhancement 1 -> 2 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/extensions/registry.rs:102
  variant ExtensionType::Optimization 2 -> 3 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/extensions/registry.rs:104
  variant Rule::virtual_read_relation 44 -> 45 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::virtual_read_args 45 -> 46 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::virtual_row_list 46 -> 47 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::virtual_row 47 -> 48 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::filter_relation 48 -> 49 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::reference_list 49 -> 50 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::project_relation 50 -> 51 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::project_argument_list 51 -> 52 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::project_argument 52 -> 53 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::aggregate_relation 53 -> 54 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::aggregate_group_by 54 -> 55 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::grouping_set_list 55 -> 56 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::grouping_set 56 -> 57 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::expression_list 57 -> 58 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::aggregate_output 58 -> 59 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::aggregate_output_item 59 -> 60 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::aggregate_measure 60 -> 61 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::empty 61 -> 62 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::sort_relation 62 -> 63 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::sort_field_list 63 -> 64 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::sort_field 64 -> 65 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::sort_direction 65 -> 66 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::fetch_arg_name 66 -> 67 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::fetch_value 67 -> 68 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::fetch_named_arg 68 -> 69 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::fetch_named_arg_list 69 -> 70 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::fetch_args 70 -> 71 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::fetch_relation 71 -> 72 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::join_type 72 -> 73 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::join_relation 73 -> 74 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::extension_relation 74 -> 75 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::extension_name 75 -> 76 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::extension_type 76 -> 77 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::arguments 77 -> 78 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::extension_arguments 78 -> 79 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::untyped_literal 79 -> 80 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::tuple 80 -> 81 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::extension_argument 81 -> 82 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::extension_named_arguments 82 -> 83 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::extension_named_argument 83 -> 84 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::extension_columns 84 -> 85 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::extension_column 85 -> 86 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::virtual_read_relation 44 -> 45 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::virtual_read_args 45 -> 46 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::virtual_row_list 46 -> 47 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::virtual_row 47 -> 48 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::filter_relation 48 -> 49 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::reference_list 49 -> 50 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::project_relation 50 -> 51 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::project_argument_list 51 -> 52 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::project_argument 52 -> 53 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::aggregate_relation 53 -> 54 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::aggregate_group_by 54 -> 55 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::grouping_set_list 55 -> 56 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::grouping_set 56 -> 57 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::expression_list 57 -> 58 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::aggregate_output 58 -> 59 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::aggregate_output_item 59 -> 60 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::aggregate_measure 60 -> 61 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::empty 61 -> 62 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::sort_relation 62 -> 63 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::sort_field_list 63 -> 64 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::sort_field 64 -> 65 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::sort_direction 65 -> 66 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::fetch_arg_name 66 -> 67 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::fetch_value 67 -> 68 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::fetch_named_arg 68 -> 69 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::fetch_named_arg_list 69 -> 70 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::fetch_args 70 -> 71 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::fetch_relation 71 -> 72 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::join_type 72 -> 73 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::join_relation 73 -> 74 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::extension_relation 74 -> 75 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::extension_name 75 -> 76 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::extension_type 76 -> 77 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::arguments 77 -> 78 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::extension_arguments 78 -> 79 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::untyped_literal 79 -> 80 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::tuple 80 -> 81 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::extension_argument 81 -> 82 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::extension_named_arguments 82 -> 83 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::extension_named_argument 83 -> 84 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::extension_columns 84 -> 85 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule::extension_column 85 -> 86 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant Rule:extension_read_relation in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule:addendum in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule:addendum_type in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule:extension_read_relation in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule:addendum in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant Rule:addendum_type in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  variant ExtensionType:ExtensionTable in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/extensions/registry.rs:100
  variant ExtensionType:ExtensionTable in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/extensions/registry.rs:100

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Rule::adv_extension, previously in file /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpbUD28L/substrait-explain/src/parser/common.rs:10
  variant Rule::adv_ext_type, previously in file /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpbUD28L/substrait-explain/src/parser/common.rs:10
  variant Rule::adv_extension, previously in file /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpbUD28L/substrait-explain/src/parser/common.rs:10
  variant Rule::adv_ext_type, previously in file /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpbUD28L/substrait-explain/src/parser/common.rs:10

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_missing.ron

Failed in:
  struct substrait_explain::parser::relations::NamedColumnList, previously in file /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpbUD28L/substrait-explain/src/parser/relations.rs:156

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field advanced_extension of struct Relation, previously in file /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpbUD28L/substrait-explain/src/textify/rels.rs:285

--- warning partial_ord_enum_variants_reordered: enum variants reordered in #[derive(PartialOrd)] enum ---

Description:
A public enum that derives PartialOrd had its variants reordered. #[derive(PartialOrd)] uses the enum variant order to set the enum's ordering behavior, so this change may break downstream code that relies on the previous order.
        ref: https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html#derivable
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/partial_ord_enum_variants_reordered.ron

Failed in:
  Rule::virtual_read_relation moved from position 45 to 46, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::virtual_read_args moved from position 46 to 47, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::virtual_row_list moved from position 47 to 48, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::virtual_row moved from position 48 to 49, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::filter_relation moved from position 49 to 50, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::reference_list moved from position 50 to 51, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::project_relation moved from position 51 to 52, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::project_argument_list moved from position 52 to 53, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::project_argument moved from position 53 to 54, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::aggregate_relation moved from position 54 to 55, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::aggregate_group_by moved from position 55 to 56, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::grouping_set_list moved from position 56 to 57, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::grouping_set moved from position 57 to 58, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::expression_list moved from position 58 to 59, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::aggregate_output moved from position 59 to 60, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::aggregate_output_item moved from position 60 to 61, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::aggregate_measure moved from position 61 to 62, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::empty moved from position 62 to 63, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::sort_relation moved from position 63 to 64, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::sort_field_list moved from position 64 to 65, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::sort_field moved from position 65 to 66, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::sort_direction moved from position 66 to 67, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::fetch_arg_name moved from position 67 to 68, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::fetch_value moved from position 68 to 69, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::fetch_named_arg moved from position 69 to 70, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::fetch_named_arg_list moved from position 70 to 71, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::fetch_args moved from position 71 to 72, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::fetch_relation moved from position 72 to 73, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::join_type moved from position 73 to 74, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::join_relation moved from position 74 to 75, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::extension_relation moved from position 75 to 76, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::extension_name moved from position 76 to 77, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::extension_type moved from position 77 to 78, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::arguments moved from position 78 to 79, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::extension_arguments moved from position 79 to 80, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::untyped_literal moved from position 80 to 81, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::tuple moved from position 81 to 82, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::extension_argument moved from position 82 to 83, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::extension_named_arguments moved from position 83 to 84, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::extension_named_argument moved from position 84 to 85, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::extension_columns moved from position 85 to 86, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::extension_column moved from position 86 to 87, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::virtual_read_relation moved from position 45 to 46, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::virtual_read_args moved from position 46 to 47, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::virtual_row_list moved from position 47 to 48, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::virtual_row moved from position 48 to 49, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::filter_relation moved from position 49 to 50, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::reference_list moved from position 50 to 51, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::project_relation moved from position 51 to 52, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::project_argument_list moved from position 52 to 53, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::project_argument moved from position 53 to 54, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::aggregate_relation moved from position 54 to 55, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::aggregate_group_by moved from position 55 to 56, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::grouping_set_list moved from position 56 to 57, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::grouping_set moved from position 57 to 58, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::expression_list moved from position 58 to 59, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::aggregate_output moved from position 59 to 60, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::aggregate_output_item moved from position 60 to 61, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::aggregate_measure moved from position 61 to 62, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::empty moved from position 62 to 63, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::sort_relation moved from position 63 to 64, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::sort_field_list moved from position 64 to 65, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::sort_field moved from position 65 to 66, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::sort_direction moved from position 66 to 67, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::fetch_arg_name moved from position 67 to 68, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::fetch_value moved from position 68 to 69, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::fetch_named_arg moved from position 69 to 70, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::fetch_named_arg_list moved from position 70 to 71, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::fetch_args moved from position 71 to 72, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::fetch_relation moved from position 72 to 73, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::join_type moved from position 73 to 74, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::join_relation moved from position 74 to 75, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::extension_relation moved from position 75 to 76, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::extension_name moved from position 76 to 77, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::extension_type moved from position 77 to 78, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::arguments moved from position 78 to 79, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::extension_arguments moved from position 79 to 80, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::untyped_literal moved from position 80 to 81, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::tuple moved from position 81 to 82, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::extension_argument moved from position 82 to 83, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::extension_named_arguments moved from position 83 to 84, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::extension_named_argument moved from position 84 to 85, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::extension_columns moved from position 85 to 86, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
  Rule::extension_column moved from position 86 to 87, in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpdKSd1J/substrait-explain/src/parser/common.rs:10
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/DataDog/substrait-explain/compare/v0.4.0...v0.5.0) - 2026-05-28

### Features

- *(extensions)* [**breaking**] support extension table reads ([#129](https://github.com/DataDog/substrait-explain/pull/129))

### Refactoring

- *(parser)* generalize relation addendum handling ([#132](https://github.com/DataDog/substrait-explain/pull/132))

### Test

- add extension table read examples ([#130](https://github.com/DataDog/substrait-explain/pull/130))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).