### PR TITLE
refactor!(api): narrow parser internals

### DIFF
--- a/src/extensions/args.rs
+++ b/src/extensions/args.rs
@@ -67,6 +67,11 @@ impl AddendumKind {
 pub struct Expr(Box<proto::Expression>);
 
 impl Expr {
+    /// Create a direct field-reference expression (`$N`).
+    pub fn field(index: i32) -> Self {
+        Reference(index).into()
+    }
+
     /// Borrow the underlying Substrait expression protobuf.
     pub fn as_proto(&self) -> &proto::Expression {
         self.0.as_ref()
@@ -78,7 +83,7 @@ impl Expr {
     }
 
     /// If this expression is a direct field reference (`$N`), return it.
-    pub fn as_direct_reference(&self) -> Option<Reference> {
+    pub fn as_direct_reference(&self) -> Option<i32> {
         let Some(RexType::Selection(field_ref)) = self.as_proto().rex_type.as_ref() else {
             return None;
         };
@@ -94,7 +99,7 @@ impl Expr {
         if field.child.is_some() {
             return None;
         }
-        Some(Reference(field.field))
+        Some(field.field)
     }
 }
 
@@ -196,7 +201,8 @@ pub struct ExtensionArgs {
 /// Tracks which arguments have been consumed. Callers **must** call
 /// [`check_exhausted`](ArgsExtractor::check_exhausted) before dropping to
 /// verify no unexpected arguments remain. In debug builds, dropping without
-/// calling `check_exhausted` will panic (matching the [`RuleIter`](crate::parser::RuleIter) pattern).
+/// calling `check_exhausted` will panic. This catches [`Explainable`](super::Explainable)
+/// implementations that forget to reject unexpected named arguments.
 pub struct ArgsExtractor<'a> {
     args: &'a ExtensionArgs,
     consumed: HashSet<&'a str>,
@@ -563,6 +569,7 @@ impl TryFrom<&ExtensionValue> for Reference {
         match value {
             ExtensionValue::Expr(expr) => expr
                 .as_direct_reference()
+                .map(Reference)
                 .ok_or_else(|| invalid_type(ExtensionValueKind::Reference, value)),
             v => Err(invalid_type(ExtensionValueKind::Reference, v)),
         }
@@ -608,6 +615,13 @@ pub enum ExtensionColumn {
     },
     /// Expression-compatible output column, including field references.
     Expr(Expr),
+}
+
+impl ExtensionColumn {
+    /// Create an expression output column that references an existing input field (`$N`).
+    pub fn field(index: i32) -> Self {
+        Self::Expr(Expr::field(index))
+    }
 }
 
 impl ExtensionArgs {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,10 @@ pub mod cli;
 pub mod json;
 
 // Re-export commonly used types for easier access
-pub use parser::ParseError;
+pub use parser::{ExtensionParseError, MessageParseError, ParseContext, ParseError, Parser};
 use substrait::proto::Plan;
 use textify::foundation::ErrorQueue;
-pub use textify::foundation::{FormatError, OutputOptions, Visibility};
+pub use textify::foundation::{FormatError, FormatErrorType, OutputOptions, PlanError, Visibility};
 use textify::plan::PlanWriter;
 
 /// Parse a Substrait plan from text format.

--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -9,37 +9,32 @@ use crate::extensions::simple::MissingReference;
 
 #[derive(PestDeriveParser)]
 #[grammar = "parser/expression_grammar.pest"] // Path relative to src
-pub struct ExpressionParser;
+pub(crate) struct ExpressionParser;
 
 /// An error that occurs when parsing a message within a specific line. Contains
 /// context pointing at that specific error.
 #[derive(Error, Debug, Clone)]
 #[error("{kind} Error parsing {message}:\n{error}")]
 pub struct MessageParseError {
-    pub message: &'static str,
-    pub kind: ErrorKind,
+    message: &'static str,
+    kind: ErrorKind,
     #[source]
-    pub error: Box<pest::error::Error<Rule>>,
+    error: Box<pest::error::Error<Rule>>,
 }
 
 #[derive(Debug, Clone)]
-pub enum ErrorKind {
+pub(crate) enum ErrorKind {
     Syntax,
     InvalidValue,
     Lookup(MissingReference),
 }
 
 impl MessageParseError {
-    pub fn syntax(message: &'static str, span: pest::Span, description: impl ToString) -> Self {
-        let error = pest::error::Error::new_from_span(
-            pest::error::ErrorVariant::CustomError {
-                message: description.to_string(),
-            },
-            span,
-        );
-        Self::new(message, ErrorKind::Syntax, Box::new(error))
-    }
-    pub fn invalid(message: &'static str, span: pest::Span, description: impl ToString) -> Self {
+    pub(crate) fn invalid(
+        message: &'static str,
+        span: pest::Span,
+        description: impl ToString,
+    ) -> Self {
         let error = pest::error::Error::new_from_span(
             pest::error::ErrorVariant::CustomError {
                 message: description.to_string(),
@@ -49,7 +44,7 @@ impl MessageParseError {
         Self::new(message, ErrorKind::InvalidValue, Box::new(error))
     }
 
-    pub fn lookup(
+    pub(crate) fn lookup(
         message: &'static str,
         missing: MissingReference,
         span: pest::Span,
@@ -66,7 +61,7 @@ impl MessageParseError {
 }
 
 impl MessageParseError {
-    pub fn new(
+    pub(crate) fn new(
         message: &'static str,
         kind: ErrorKind,
         error: Box<pest::error::Error<Rule>>,
@@ -89,7 +84,7 @@ impl fmt::Display for ErrorKind {
     }
 }
 
-pub fn unwrap_single_pair(pair: pest::iterators::Pair<Rule>) -> pest::iterators::Pair<Rule> {
+pub(crate) fn unwrap_single_pair(pair: pest::iterators::Pair<Rule>) -> pest::iterators::Pair<Rule> {
     let mut pairs = pair.into_inner();
     let pair = pairs.next().unwrap();
     assert_eq!(pairs.next(), None);
@@ -108,7 +103,7 @@ pub fn unwrap_single_pair(pair: pest::iterators::Pair<Rule>) -> pest::iterators:
 /// Panics if the rule is not `string_literal` or `quoted_name` (this should never happen
 /// if the pest grammar is working correctly).
 ///
-pub fn unescape_string(pair: pest::iterators::Pair<Rule>) -> String {
+pub(crate) fn unescape_string(pair: pest::iterators::Pair<Rule>) -> String {
     let s = pair.as_str();
 
     // Determine opener/closer based on rule type
@@ -164,7 +159,7 @@ pub fn unescape_string(pair: pest::iterators::Pair<Rule>) -> String {
 // A trait for converting a pest::iterators::Pair<Rule> into a Rust type. This
 // is used to convert from the uniformly structured nesting
 // pest::iterators::Pair<Rule> into more structured types.
-pub trait ParsePair: Sized {
+pub(crate) trait ParsePair: Sized {
     // The rule that this type is parsed from.
     fn rule() -> Rule;
 
@@ -204,7 +199,7 @@ impl<T: ParsePair> Parse for T {
 /// depends on the context - e.g. extension lookups or other contextual
 /// information. This is used for types that are not directly parsed from the
 /// grammar, but rather require additional context to parse correctly.
-pub trait ScopedParsePair: Sized {
+pub(crate) trait ScopedParsePair: Sized {
     // The rule that this type is parsed from.
     fn rule() -> Rule;
 
@@ -237,14 +232,14 @@ impl<T: ScopedParsePair> ScopedParse for T {
     }
 }
 
-pub fn iter_pairs(pair: pest::iterators::Pairs<'_, Rule>) -> RuleIter<'_> {
+pub(crate) fn iter_pairs(pair: pest::iterators::Pairs<'_, Rule>) -> RuleIter<'_> {
     RuleIter {
         iter: pair,
         done: false,
     }
 }
 
-pub struct RuleIter<'a> {
+pub(crate) struct RuleIter<'a> {
     iter: pest::iterators::Pairs<'a, Rule>,
     // Set to true when done is called, so destructor doesn't panic
     done: bool,
@@ -257,12 +252,12 @@ impl<'a> From<pest::iterators::Pairs<'a, Rule>> for RuleIter<'a> {
 }
 
 impl<'a> RuleIter<'a> {
-    pub fn peek(&self) -> Option<pest::iterators::Pair<'a, Rule>> {
+    pub(crate) fn peek(&self) -> Option<pest::iterators::Pair<'a, Rule>> {
         self.iter.peek()
     }
 
     // Pop the next pair if it matches the rule. Returns None if not.
-    pub fn try_pop(&mut self, rule: Rule) -> Option<pest::iterators::Pair<'a, Rule>> {
+    pub(crate) fn try_pop(&mut self, rule: Rule) -> Option<pest::iterators::Pair<'a, Rule>> {
         match self.peek() {
             Some(pair) if pair.as_rule() == rule => {
                 self.iter.next();
@@ -273,7 +268,7 @@ impl<'a> RuleIter<'a> {
     }
 
     // Pop the next pair, asserting it matches the given rule. Panics if not.
-    pub fn pop(&mut self, rule: Rule) -> pest::iterators::Pair<'a, Rule> {
+    pub(crate) fn pop(&mut self, rule: Rule) -> pest::iterators::Pair<'a, Rule> {
         let pair = self.iter.next().expect("expected another pair");
         assert_eq!(
             pair.as_rule(),
@@ -286,7 +281,7 @@ impl<'a> RuleIter<'a> {
     }
 
     // Parse the next pair if it matches the rule. Returns None if not.
-    pub fn parse_if_next<T: ParsePair>(&mut self) -> Option<T> {
+    pub(crate) fn parse_if_next<T: ParsePair>(&mut self) -> Option<T> {
         match self.peek() {
             Some(pair) if pair.as_rule() == T::rule() => {
                 self.iter.next();
@@ -297,7 +292,7 @@ impl<'a> RuleIter<'a> {
     }
 
     // Parse the next pair if it matches the rule. Returns None if not.
-    pub fn parse_if_next_scoped<T: ScopedParsePair>(
+    pub(crate) fn parse_if_next_scoped<T: ScopedParsePair>(
         &mut self,
         extensions: &SimpleExtensions,
     ) -> Option<Result<T, MessageParseError>> {
@@ -311,13 +306,13 @@ impl<'a> RuleIter<'a> {
     }
 
     // Parse the next pair, assuming it matches the rule. Panics if not.
-    pub fn parse_next<T: ParsePair>(&mut self) -> T {
+    pub(crate) fn parse_next<T: ParsePair>(&mut self) -> T {
         let pair = self.iter.next().unwrap();
         T::parse_pair(pair)
     }
 
     // Parse the next pair, assuming it matches the rule. Panics if not.
-    pub fn parse_next_scoped<T: ScopedParsePair>(
+    pub(crate) fn parse_next_scoped<T: ScopedParsePair>(
         &mut self,
         extensions: &SimpleExtensions,
     ) -> Result<T, MessageParseError> {
@@ -325,7 +320,7 @@ impl<'a> RuleIter<'a> {
         T::parse_pair(extensions, pair)
     }
 
-    pub fn done(mut self) {
+    pub(crate) fn done(mut self) {
         self.done = true;
         assert_eq!(self.iter.next(), None);
     }

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -18,7 +18,6 @@ use super::{
 };
 use crate::extensions::SimpleExtensions;
 use crate::extensions::simple::{CompoundName, ExtensionKind};
-use crate::parser::ErrorKind;
 
 /// A field index (e.g., parsed from "$0" -> 0).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -115,18 +114,11 @@ fn to_int_literal(
             i.type_variation_reference,
         ),
         k => {
-            let pest_error = pest::error::Error::new_from_span(
-                pest::error::ErrorVariant::CustomError {
-                    message: format!("Invalid type for integer literal: {k:?}"),
-                },
+            return Err(MessageParseError::invalid(
+                "int_literal_type",
                 value.as_span(),
-            );
-            let error = MessageParseError {
-                message: "int_literal_type",
-                kind: ErrorKind::InvalidValue,
-                error: Box::new(pest_error),
-            };
-            return Err(error);
+                format!("Invalid type for integer literal: {k:?}"),
+            ));
         }
     };
 
@@ -164,18 +156,11 @@ fn to_float_literal(
             f.type_variation_reference,
         ),
         k => {
-            let pest_error = pest::error::Error::new_from_span(
-                pest::error::ErrorVariant::CustomError {
-                    message: format!("Invalid type for float literal: {k:?}"),
-                },
+            return Err(MessageParseError::invalid(
+                "float_literal_type",
                 value.as_span(),
-            );
-            let error = MessageParseError {
-                message: "float_literal_type",
-                kind: ErrorKind::InvalidValue,
-                error: Box::new(pest_error),
-            };
-            return Err(error);
+                format!("Invalid type for float literal: {k:?}"),
+            ));
         }
     };
 
@@ -200,17 +185,11 @@ fn to_boolean_literal(
         ),
         None => (false, 0),
         Some(k) => {
-            let pest_error = pest::error::Error::new_from_span(
-                pest::error::ErrorVariant::CustomError {
-                    message: format!("Invalid type for boolean literal: {k:?}"),
-                },
+            return Err(MessageParseError::invalid(
+                "bool_literal_type",
                 value.as_span(),
-            );
-            return Err(MessageParseError {
-                message: "bool_literal_type",
-                kind: ErrorKind::InvalidValue,
-                error: Box::new(pest_error),
-            });
+                format!("Invalid type for boolean literal: {k:?}"),
+            ));
         }
     };
 
@@ -301,18 +280,11 @@ fn parse_date_to_days(date_str: &str, span: pest::Span) -> Result<i32, MessagePa
         }
     }
 
-    Err(MessageParseError {
-        message: "date_parse_format",
-        kind: ErrorKind::InvalidValue,
-        error: Box::new(pest::error::Error::new_from_span(
-            pest::error::ErrorVariant::CustomError {
-                message: format!(
-                    "Invalid date format: '{date_str}'. Expected YYYY-MM-DD or YYYY/MM/DD"
-                ),
-            },
-            span,
-        )),
-    })
+    Err(MessageParseError::invalid(
+        "date_parse_format",
+        span,
+        format!("Invalid date format: '{date_str}'. Expected YYYY-MM-DD or YYYY/MM/DD"),
+    ))
 }
 
 /// Parse a time string using chrono to microseconds since midnight
@@ -329,18 +301,11 @@ fn parse_time_to_microseconds(time_str: &str, span: pest::Span) -> Result<i64, M
         }
     }
 
-    Err(MessageParseError {
-        message: "time_parse_format",
-        kind: ErrorKind::InvalidValue,
-        error: Box::new(pest::error::Error::new_from_span(
-            pest::error::ErrorVariant::CustomError {
-                message: format!(
-                    "Invalid time format: '{time_str}'. Expected HH:MM:SS or HH:MM:SS.fff"
-                ),
-            },
-            span,
-        )),
-    })
+    Err(MessageParseError::invalid(
+        "time_parse_format",
+        span,
+        format!("Invalid time format: '{time_str}'. Expected HH:MM:SS or HH:MM:SS.fff"),
+    ))
 }
 
 /// Parse a timestamp string using chrono to microseconds since Unix epoch
@@ -369,18 +334,13 @@ fn parse_timestamp_to_microseconds(
         }
     }
 
-    Err(MessageParseError {
-        message: "timestamp_parse_format",
-        kind: ErrorKind::InvalidValue,
-        error: Box::new(pest::error::Error::new_from_span(
-            pest::error::ErrorVariant::CustomError {
-                message: format!(
-                    "Invalid timestamp format: '{timestamp_str}'. Expected YYYY-MM-DDTHH:MM:SS or YYYY-MM-DD HH:MM:SS"
-                ),
-            },
-            span,
-        )),
-    })
+    Err(MessageParseError::invalid(
+        "timestamp_parse_format",
+        span,
+        format!(
+            "Invalid timestamp format: '{timestamp_str}'. Expected YYYY-MM-DDTHH:MM:SS or YYYY-MM-DD HH:MM:SS"
+        ),
+    ))
 }
 
 impl ScopedParsePair for Literal {

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -152,7 +152,8 @@ impl ExtensionParser {
         &self.extensions
     }
 
-    pub fn state(&self) -> ExtensionParserState {
+    #[cfg(test)]
+    pub(crate) fn state(&self) -> ExtensionParserState {
         self.state
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,12 +1,18 @@
-pub mod common;
-pub mod errors;
-pub mod expressions;
-pub mod extensions;
-pub mod relations;
-pub mod structural;
-pub mod types;
+pub(crate) mod common;
+pub(crate) mod errors;
+pub(crate) mod expressions;
+pub(crate) mod extensions;
+pub(crate) mod relations;
+pub(crate) mod structural;
+pub(crate) mod types;
 
-pub use common::*;
+pub(crate) use common::{
+    ErrorKind, ExpressionParser, ParsePair, Rule, RuleIter, ScopedParsePair, iter_pairs,
+    unescape_string, unwrap_single_pair,
+};
+pub use common::{MessageParseError, Parse, ScopedParse};
 pub use errors::{ParseContext, ParseError, ParseResult};
-pub use relations::RelationParsePair;
-pub use structural::{PLAN_HEADER, Parser};
+pub use extensions::ExtensionParseError;
+pub(crate) use relations::RelationParsePair;
+pub(crate) use structural::PLAN_HEADER;
+pub use structural::Parser;

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -24,7 +24,6 @@ use crate::parser::expressions::{FieldIndex, Name};
 
 /// Parsing context for relations that includes extensions, registry, and optional warning collection
 pub struct RelationParsingContext<'a> {
-    pub extensions: &'a SimpleExtensions,
     pub registry: &'a ExtensionRegistry,
     pub line_no: i64,
     pub line: &'a str,
@@ -93,7 +92,7 @@ pub trait RelationParsePair: Sized {
     fn parse_pair_with_context(
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
-        input_children: Vec<Box<Rel>>,
+        input_children: Vec<Rel>,
         input_field_count: usize,
     ) -> Result<(Self, usize), MessageParseError>;
 
@@ -182,11 +181,10 @@ impl ScopedParsePair for NamedColumnList {
 /// children, to be used in the RelationParsePair trait. The RelationParsePair
 /// trait passes a Vec of children, because some relations have multiple
 /// children - but most accept exactly one child.
-#[allow(clippy::vec_box)]
 pub(crate) fn expect_one_child(
     message: &'static str,
     pair: &Pair<Rule>,
-    mut input_children: Vec<Box<Rel>>,
+    mut input_children: Vec<Rel>,
 ) -> Result<Box<Rel>, MessageParseError> {
     match input_children.len() {
         0 => Err(MessageParseError::invalid(
@@ -194,7 +192,7 @@ pub(crate) fn expect_one_child(
             pair.as_span(),
             format!("{message} missing child"),
         )),
-        1 => Ok(input_children.pop().unwrap()),
+        1 => Ok(Box::new(input_children.pop().unwrap())),
         n => Err(MessageParseError::invalid(
             message,
             pair.as_span(),
@@ -305,7 +303,7 @@ impl RelationParsePair for ReadRel {
     fn parse_pair_with_context(
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
-        input_children: Vec<Box<Rel>>,
+        input_children: Vec<Rel>,
         input_field_count: usize,
     ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
@@ -369,7 +367,7 @@ impl RelationParsePair for VirtualReadRel {
     fn parse_pair_with_context(
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
-        input_children: Vec<Box<Rel>>,
+        input_children: Vec<Rel>,
         _input_field_count: usize,
     ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
@@ -421,16 +419,10 @@ impl RelationParsePair for VirtualReadRel {
 pub(crate) struct ExtensionReadRel(ReadRel);
 
 impl ExtensionReadRel {
-    // Clippy allow: normally Vec<Box<…>> is a warning, because Vec is already
-    // on the heap, so Vec<Box<…>> just adds a layer of indirection. Here, the
-    // protobuf generated code already comes with boxes, so not using boxes
-    // would mean copying things around, which would be more wasteful. So we
-    // allow(…) it.
-    #[allow(clippy::vec_box)]
     pub(crate) fn parse_pair_with_detail(
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
-        input_children: Vec<Box<Rel>>,
+        input_children: Vec<Rel>,
         input_field_count: usize,
         detail: Any,
         advanced_extension: Option<AdvancedExtension>,
@@ -547,7 +539,7 @@ impl RelationParsePair for FilterRel {
     fn parse_pair_with_context(
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
-        input_children: Vec<Box<Rel>>,
+        input_children: Vec<Rel>,
         input_field_count: usize,
     ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
@@ -595,7 +587,7 @@ impl RelationParsePair for ProjectRel {
     fn parse_pair_with_context(
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
-        input_children: Vec<Box<Rel>>,
+        input_children: Vec<Rel>,
         input_field_count: usize,
     ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
@@ -662,7 +654,7 @@ impl RelationParsePair for AggregateRel {
     fn parse_pair_with_context(
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
-        input_children: Vec<Box<Rel>>,
+        input_children: Vec<Rel>,
         // Aggregate defines its own output schema (grouping keys + measures),
         // so the input field count isn't needed for emit construction.
         _input_field_count: usize,
@@ -905,7 +897,7 @@ impl RelationParsePair for SortRel {
     fn parse_pair_with_context(
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
-        input_children: Vec<Box<Rel>>,
+        input_children: Vec<Rel>,
         input_field_count: usize,
     ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
@@ -1063,7 +1055,7 @@ impl RelationParsePair for FetchRel {
     fn parse_pair_with_context(
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
-        input_children: Vec<Box<Rel>>,
+        input_children: Vec<Rel>,
         input_field_count: usize,
     ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
@@ -1164,7 +1156,7 @@ impl RelationParsePair for JoinRel {
     fn parse_pair_with_context(
         extensions: &SimpleExtensions,
         pair: Pair<Rule>,
-        input_children: Vec<Box<Rel>>,
+        input_children: Vec<Rel>,
         input_field_count: usize,
     ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
@@ -1181,8 +1173,8 @@ impl RelationParsePair for JoinRel {
         }
 
         let mut children_iter = input_children.into_iter();
-        let left = children_iter.next().unwrap();
-        let right = children_iter.next().unwrap();
+        let left = Box::new(children_iter.next().unwrap());
+        let right = Box::new(children_iter.next().unwrap());
 
         let mut iter = RuleIter::from(pair.into_inner());
         let join_type = iter.parse_next::<join_rel::JoinType>();
@@ -1276,7 +1268,7 @@ mod tests {
         let filter = FilterRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::filter_relation, "Filter[$1 => $0, $1, $2]"),
-            vec![Box::new(example_read_relation().into_rel(None))],
+            vec![example_read_relation().into_rel(None)],
             3,
         )
         .unwrap()
@@ -1295,7 +1287,7 @@ mod tests {
         let project = ProjectRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::project_relation, "Project[$0, $1, 42]"),
-            vec![Box::new(example_read_relation().into_rel(None))],
+            vec![example_read_relation().into_rel(None)],
             3,
         )
         .unwrap()
@@ -1319,7 +1311,7 @@ mod tests {
         let project = ProjectRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::project_relation, "Project[42, $0, 100, $2, $1]"),
-            vec![Box::new(example_read_relation().into_rel(None))],
+            vec![example_read_relation().into_rel(None)],
             5, // Assume 5 input fields
         )
         .unwrap()
@@ -1352,7 +1344,7 @@ mod tests {
                 Rule::aggregate_relation,
                 "Aggregate[($0, $1), _ => sum($2), $0, count($2)]",
             ),
-            vec![Box::new(example_read_relation().into_rel(None))],
+            vec![example_read_relation().into_rel(None)],
             3,
         )
         .unwrap()
@@ -1394,7 +1386,7 @@ mod tests {
                 Rule::aggregate_relation,
                 "Aggregate[$0 => sum($1), $0, count($1)]",
             ),
-            vec![Box::new(example_read_relation().into_rel(None))],
+            vec![example_read_relation().into_rel(None)],
             3,
         )
         .unwrap()
@@ -1430,7 +1422,7 @@ mod tests {
         let aggregate = AggregateRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::aggregate_relation, "Aggregate[$2, $0 => sum($1)]"),
-            vec![Box::new(example_read_relation().into_rel(None))],
+            vec![example_read_relation().into_rel(None)],
             3,
         )
         .unwrap()
@@ -1456,7 +1448,7 @@ mod tests {
                 Rule::aggregate_relation,
                 "Aggregate[_ => sum($0), count($1)]",
             ),
-            vec![Box::new(example_read_relation().into_rel(None))],
+            vec![example_read_relation().into_rel(None)],
             3,
         )
         .unwrap()
@@ -1507,7 +1499,7 @@ mod tests {
                 Rule::aggregate_relation,
                 "Aggregate[($0, $1, $2), ($2, $0), ($1), _ => $0, $1, $2, count($3)]",
             ),
-            vec![Box::new(read_rel.into_rel(None))],
+            vec![read_rel.into_rel(None)],
             4,
         )
         .unwrap()
@@ -1534,7 +1526,7 @@ mod tests {
         let fetch_rel = FetchRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::fetch_relation, "Fetch[limit=10, offset=5 => $0]"),
-            vec![Box::new(example_read_relation().into_rel(None))],
+            vec![example_read_relation().into_rel(None)],
             3,
         )
         .unwrap()
@@ -1564,7 +1556,7 @@ mod tests {
                 let result = FetchRel::parse_pair_with_context(
                     &extensions,
                     pair,
-                    vec![Box::new(example_read_relation().into_rel(None))],
+                    vec![example_read_relation().into_rel(None)],
                     3,
                 );
                 assert!(result.is_err());
@@ -1595,7 +1587,7 @@ mod tests {
                 let result = FetchRel::parse_pair_with_context(
                     &extensions,
                     pair,
-                    vec![Box::new(example_read_relation().into_rel(None))],
+                    vec![example_read_relation().into_rel(None)],
                     3,
                 );
                 assert!(result.is_err());
@@ -1627,7 +1619,7 @@ mod tests {
                 Rule::join_relation,
                 "Join[&Inner, eq($0, $3) => $0, $1, $3, $4]",
             ),
-            vec![Box::new(left_rel), Box::new(right_rel)],
+            vec![left_rel, right_rel],
             6, // left (3) + right (3) = 6 total input fields
         )
         .unwrap()
@@ -1665,7 +1657,7 @@ mod tests {
         let join = JoinRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::join_relation, "Join[&Left, eq($0, $3) => $0, $1, $2]"),
-            vec![Box::new(left_rel), Box::new(right_rel)],
+            vec![left_rel, right_rel],
             6,
         )
         .unwrap()
@@ -1696,7 +1688,7 @@ mod tests {
         let join = JoinRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::join_relation, "Join[&LeftSemi, eq($0, $3) => $0, $1]"),
-            vec![Box::new(left_rel), Box::new(right_rel)],
+            vec![left_rel, right_rel],
             6,
         )
         .unwrap()
@@ -1731,7 +1723,7 @@ mod tests {
         let result = JoinRel::parse_pair_with_context(
             &extensions,
             parse_exact(Rule::join_relation, "Join[&Inner, eq($0, $1) => $0, $1]"),
-            vec![Box::new(example_read_relation().into_rel(None))],
+            vec![example_read_relation().into_rel(None)],
             3,
         );
         assert!(result.is_err());
@@ -1741,9 +1733,9 @@ mod tests {
             &extensions,
             parse_exact(Rule::join_relation, "Join[&Inner, eq($0, $1) => $0, $1]"),
             vec![
-                Box::new(example_read_relation().into_rel(None)),
-                Box::new(example_read_relation().into_rel(None)),
-                Box::new(example_read_relation().into_rel(None)),
+                example_read_relation().into_rel(None),
+                example_read_relation().into_rel(None),
+                example_read_relation().into_rel(None),
             ],
             9,
         );

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -277,8 +277,7 @@ impl<'a> TreeBuilder<'a> {
 struct RelationContext<'a> {
     pair: Pair<'a, Rule>,
     line_no: i64,
-    #[allow(clippy::vec_box)]
-    children: Vec<Box<Rel>>,
+    children: Vec<Rel>,
     input_field_count: usize,
     addenda: Addenda<'a>,
 }
@@ -310,27 +309,20 @@ impl<'a> ParsedAddendum<'a> {
 
     fn relation_context<'b>(
         &'b self,
-        extensions: &'b SimpleExtensions,
         registry: &'b ExtensionRegistry,
     ) -> RelationParsingContext<'b> {
         RelationParsingContext {
-            extensions,
             registry,
             line_no: self.line_no,
             line: self.line,
         }
     }
-    fn resolve_detail(
-        &self,
-        extensions: &SimpleExtensions,
-        registry: &ExtensionRegistry,
-    ) -> Result<Any, ParseError> {
-        self.relation_context(extensions, registry)
-            .resolve_addendum_detail(
-                self.invocation.kind,
-                &self.invocation.name,
-                &self.invocation.args,
-            )
+    fn resolve_detail(&self, registry: &ExtensionRegistry) -> Result<Any, ParseError> {
+        self.relation_context(registry).resolve_addendum_detail(
+            self.invocation.kind,
+            &self.invocation.name,
+            &self.invocation.args,
+        )
     }
 }
 
@@ -368,7 +360,6 @@ impl<'a> Addenda<'a> {
 
     fn into_standard_advanced_extension(
         self,
-        extensions: &SimpleExtensions,
         registry: &ExtensionRegistry,
     ) -> Result<Option<AdvancedExtension>, ParseError> {
         let mut enhancement = None;
@@ -383,10 +374,10 @@ impl<'a> Addenda<'a> {
                             "at most one enhancement per relation is allowed".to_string(),
                         ));
                     }
-                    enhancement = Some(addendum.resolve_detail(extensions, registry)?.into());
+                    enhancement = Some(addendum.resolve_detail(registry)?.into());
                 }
                 AddendumKind::Optimization => {
-                    optimizations.push(addendum.resolve_detail(extensions, registry)?.into());
+                    optimizations.push(addendum.resolve_detail(registry)?.into());
                 }
                 AddendumKind::ExtensionTable => {
                     return Err(ParseError::ValidationError(
@@ -409,7 +400,6 @@ impl<'a> Addenda<'a> {
 
     fn into_extension_read_parts(
         self,
-        extensions: &SimpleExtensions,
         registry: &ExtensionRegistry,
         relation_context: ParseContext,
     ) -> Result<(Any, Option<AdvancedExtension>), ParseError> {
@@ -440,11 +430,11 @@ impl<'a> Addenda<'a> {
             )
         })?;
 
-        let detail = extension_table.resolve_detail(extensions, registry)?;
+        let detail = extension_table.resolve_detail(registry)?;
         let advanced_extension = Addenda {
             items: advanced_addenda,
         }
-        .into_standard_advanced_extension(extensions, registry)?;
+        .into_standard_advanced_extension(registry)?;
 
         Ok((detail, advanced_extension))
     }
@@ -457,19 +447,6 @@ pub struct RelationParser<'a> {
 }
 
 impl<'a> RelationParser<'a> {
-    pub fn parse_line(&mut self, line: IndentedLine<'a>, line_no: i64) -> Result<(), ParseError> {
-        let IndentedLine(depth, line) = line;
-
-        // Use parse_root for depth 0 (top-level relations), parse for other depths
-        let node = if depth == 0 {
-            LineNode::parse_root(line, line_no)?
-        } else {
-            LineNode::parse(line, line_no)?
-        };
-
-        self.tree.add_line(depth, node)
-    }
-
     /// Dispatch by grammar rule after validating addenda constraints.
     /// Standard relations go through [`parse_rel`](Self::parse_rel);
     /// extension relations go through
@@ -518,7 +495,7 @@ impl<'a> RelationParser<'a> {
         } = ctx;
         assert_eq!(pair.as_rule(), T::rule());
         let line = pair.as_str();
-        let advanced_extension = addenda.into_standard_advanced_extension(extensions, registry)?;
+        let advanced_extension = addenda.into_standard_advanced_extension(registry)?;
 
         match T::parse_pair_with_context(extensions, pair, children, input_field_count) {
             Ok((parsed, count)) => Ok((parsed.into_rel(advanced_extension), count)),
@@ -564,7 +541,6 @@ impl<'a> RelationParser<'a> {
             })?;
 
         let context = RelationParsingContext {
-            extensions,
             registry,
             line_no,
             line: &line,
@@ -573,8 +549,7 @@ impl<'a> RelationParser<'a> {
         let detail = context.resolve_extension_detail(&name, &extension_args)?;
         let output_column_count = extension_args.output_columns.len();
 
-        let children = ctx.children.into_iter().map(|child| *child).collect();
-        let rel = relation_kind.create_rel(detail, children);
+        let rel = relation_kind.create_rel(detail, ctx.children);
 
         Ok((rel, output_column_count))
     }
@@ -589,9 +564,9 @@ impl<'a> RelationParser<'a> {
     ) -> Result<(Rel, usize), ParseError> {
         assert_eq!(ctx.pair.as_rule(), Rule::extension_read_relation);
         let context = ParseContext::new(ctx.line_no, ctx.pair.as_str().to_string());
-        let (detail, advanced_extension) =
-            ctx.addenda
-                .into_extension_read_parts(extensions, registry, context.clone())?;
+        let (detail, advanced_extension) = ctx
+            .addenda
+            .into_extension_read_parts(registry, context.clone())?;
 
         ExtensionReadRel::parse_pair_with_detail(
             extensions,
@@ -614,12 +589,12 @@ impl<'a> RelationParser<'a> {
         registry: &ExtensionRegistry,
         node: RelationNode,
     ) -> Result<(Rel, usize), ParseError> {
-        let mut children: Vec<Box<Rel>> = Vec::new();
+        let mut children: Vec<Rel> = Vec::new();
         let mut input_field_count: usize = 0;
         for child in node.children {
             let (rel, count) = self.build_rel(extensions, registry, child)?;
             input_field_count += count;
-            children.push(Box::new(rel));
+            children.push(rel);
         }
 
         let addenda = Addenda::parse(extensions, node.addenda)?;

--- a/tests/extension_roundtrip.rs
+++ b/tests/extension_roundtrip.rs
@@ -13,7 +13,6 @@ use substrait_explain::extensions::{
 use substrait_explain::fixtures::parse_type;
 use substrait_explain::format_with_registry;
 use substrait_explain::parser::Parser;
-use substrait_explain::textify::expressions::Reference;
 
 /// A custom extension configuration for a hypothetical "UserTable" data source.
 /// This differs from the file-based scan in the example by using logical table properties.
@@ -435,8 +434,7 @@ impl Explainable for PassThroughWrapper {
 
     fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
-        args.output_columns
-            .push(ExtensionColumn::Expr(Reference(0).into()));
+        args.output_columns.push(ExtensionColumn::field(0));
         Ok(args)
     }
 }
@@ -470,10 +468,8 @@ impl Explainable for BinaryMerge {
 
     fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
-        args.output_columns
-            .push(ExtensionColumn::Expr(Reference(0).into()));
-        args.output_columns
-            .push(ExtensionColumn::Expr(Reference(1).into()));
+        args.output_columns.push(ExtensionColumn::field(0));
+        args.output_columns.push(ExtensionColumn::field(1));
         Ok(args)
     }
 }
@@ -750,7 +746,7 @@ fn test_extension_proto_convert_schema_columns_roundtrip() {
 
 #[test]
 fn test_extension_proto_convert_schema_rejects_references() {
-    let columns = vec![ExtensionColumn::Expr(Reference(0).into())];
+    let columns = vec![ExtensionColumn::field(0)];
     assert!(columns.as_slice().convert().is_err());
 }
 


### PR DESCRIPTION
## Summary

- Re-export the intended parser/format error types and `Parser` from the crate root.
- Narrow parser child modules and constructors that are not part of the public API.
- Add public extension field-reference helpers so users/tests do not need textifier internals.

Using `cargo public-api -p substrait-explain --omit 'blanket-impls,auto-trait-impls,auto-derived-impls' | wc -l`, this reduces the public API from 2311 to 1605 items.

## Review guide

This PR is the first step in narrowing the public API. The intended public surface is the crate-root parser/formatter API plus extension-authoring types; parser implementation modules should not be part of that contract.

There are two enabling changes mixed in with the visibility cleanup:

- `Expr::field` and `ExtensionColumn::field` replace test/user imports from textifier internals for direct field references.
- Internal relation assembly now carries `Vec<Rel>` and only boxes relations when constructing protobuf fields. The generated Substrait types still use boxes at the protobuf boundary.

There is no intended text-format or protobuf behavior change.

## Stack

1. This PR
2. `wendell/api-public-test-surface`
3. `wendell/api-private-parser-textifier`

## Validation

- `just test`
- `just check`
- `cargo clippy --examples --tests --all-features -- -D warnings`
