### PR TITLE
test(api): move tests and examples to public surface

### DIFF
--- a/API.md
+++ b/API.md
@@ -200,7 +200,7 @@ impl Name for MySourceConfig {
 #         Ok(ExtensionArgs::default())
 #     }
 # }
-# use substrait_explain::parser::Parser;
+# use substrait_explain::Parser;
 # use substrait_explain::format_with_registry;
 
 let mut registry = ExtensionRegistry::new();

--- a/examples/advanced_usage.rs
+++ b/examples/advanced_usage.rs
@@ -3,27 +3,31 @@
 //! This example shows how to parse a Substrait plan and format it with
 //! different output options.
 
-use std::borrow::Cow;
-
 use substrait::proto::Plan;
-use substrait_explain::extensions::ExtensionRegistry;
-use substrait_explain::parser::Parser;
-use substrait_explain::textify::foundation::ErrorList;
-use substrait_explain::textify::plan::PlanWriter;
-use substrait_explain::textify::{ErrorQueue, OutputOptions, Visibility};
+use substrait_explain::{OutputOptions, Parser, Visibility, format_with_options};
 
 /// Helper function to format a plan with given options and print the result with error handling
-fn print_with_errors(plan: &Plan, options: Option<&OutputOptions>) -> Result<(), ErrorList> {
+fn print_with_errors(
+    plan: &Plan,
+    options: Option<&OutputOptions>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let default_options;
     let options = match options {
-        Some(options) => Cow::Borrowed(options),
-        None => Cow::Owned(OutputOptions::default()),
+        Some(options) => options,
+        None => {
+            default_options = OutputOptions::default();
+            &default_options
+        }
     };
-    let registry = ExtensionRegistry::default();
-    let (formatter, errors) = PlanWriter::<ErrorQueue>::new(&options, plan, &registry);
+    let (formatted, errors) = format_with_options(plan, options);
 
-    println!("{formatter}");
+    println!("{formatted}");
 
-    errors.errs()
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(format!("formatting produced errors: {errors:?}").into())
+    }
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -2,8 +2,7 @@
 //!
 //! This example shows how to parse a Substrait plan and format it with different output options.
 
-use substrait_explain::parser::Parser;
-use substrait_explain::{OutputOptions, format, format_with_options};
+use substrait_explain::{OutputOptions, Parser, format, format_with_options};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== Substrait-Explain Basic Usage ===\n");

--- a/examples/extensions.rs
+++ b/examples/extensions.rs
@@ -17,8 +17,7 @@ use substrait_explain::extensions::any::AnyRef;
 use substrait_explain::extensions::{
     AnyConvertible, Explainable, ExtensionArgs, ExtensionColumn, ExtensionError, ExtensionRegistry,
 };
-use substrait_explain::parser::Parser;
-use substrait_explain::{OutputOptions, format_with_registry};
+use substrait_explain::{OutputOptions, Parser, format_with_registry};
 
 /// Custom protobuf message for a ParquetScan extension configuration. In a real
 /// implementation, this would be generated from a .proto file.

--- a/src/extensions/examples.rs
+++ b/src/extensions/examples.rs
@@ -70,7 +70,7 @@ impl PartitionStrategy {
 /// ```rust
 /// # use substrait_explain::extensions::examples;
 /// # use substrait_explain::format_with_registry;
-/// # use substrait_explain::parser::Parser;
+/// # use substrait_explain::Parser;
 /// #
 /// # let registry = examples::registry();
 /// # let parser = Parser::new().with_extension_registry(registry.clone());
@@ -172,7 +172,7 @@ impl Explainable for PartitionHint {
 /// ```rust
 /// # use substrait_explain::extensions::examples;
 /// # use substrait_explain::format_with_registry;
-/// # use substrait_explain::parser::Parser;
+/// # use substrait_explain::Parser;
 /// #
 /// # let registry = examples::registry();
 /// # let parser = Parser::new().with_extension_registry(registry.clone());
@@ -250,7 +250,7 @@ impl Explainable for PlanHint {
 /// ```rust
 /// # use substrait_explain::extensions::examples;
 /// # use substrait_explain::format_with_registry;
-/// # use substrait_explain::parser::Parser;
+/// # use substrait_explain::Parser;
 /// #
 /// # let registry = examples::registry();
 /// # let parser = Parser::new().with_extension_registry(registry.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@ pub mod grammar;
 pub mod parser;
 pub mod textify;
 
+#[cfg(test)]
+mod types_tests;
+
 #[cfg(feature = "cli")]
 pub mod cli;
 #[cfg(feature = "cli")]

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -706,7 +706,7 @@ impl<'a> RelationParser<'a> {
 /// The simplest entry point is the static `parse()` method:
 ///
 /// ```rust
-/// use substrait_explain::parser::Parser;
+/// use substrait_explain::Parser;
 ///
 /// let plan_text = r#"
 /// === Plan
@@ -745,7 +745,7 @@ impl<'a> RelationParser<'a> {
 /// - Specific error type and description
 ///
 /// ```rust
-/// use substrait_explain::parser::Parser;
+/// use substrait_explain::Parser;
 ///
 /// let invalid_plan = r#"
 /// === Plan
@@ -775,7 +775,7 @@ impl<'a> RelationParser<'a> {
 /// - Use custom types and type variations
 ///
 /// ```rust
-/// use substrait_explain::parser::Parser;
+/// use substrait_explain::Parser;
 ///
 /// let plan_with_extensions = r#"
 /// === Extensions
@@ -831,7 +831,7 @@ impl<'a> Parser<'a> {
     ///
     /// Simple parsing:
     /// ```rust
-    /// use substrait_explain::parser::Parser;
+    /// use substrait_explain::Parser;
     ///
     /// let plan_text = r#"
     /// === Plan

--- a/src/types_tests.rs
+++ b/src/types_tests.rs
@@ -1,10 +1,11 @@
 use substrait::proto::expression::{FieldReference, Literal, ScalarFunction};
 use substrait::proto::{Expression, Type};
-use substrait_explain::extensions::SimpleExtensions;
-use substrait_explain::extensions::simple::ExtensionKind;
-use substrait_explain::fixtures::TestContext;
-use substrait_explain::parser::{Parse, ScopedParse};
-use substrait_explain::textify::{ErrorQueue, OutputOptions, Textify};
+
+use crate::extensions::SimpleExtensions;
+use crate::extensions::simple::ExtensionKind;
+use crate::fixtures::TestContext;
+use crate::parser::{Parse, ScopedParse};
+use crate::textify::{ErrorQueue, OutputOptions, Textify};
 
 /// Helper function to parse and check for errors, panicking if either fails
 fn must_parse<T, E: std::fmt::Display>(result: Result<T, E>, input: &str) -> T {

--- a/tests/adv_extension_roundtrip.rs
+++ b/tests/adv_extension_roundtrip.rs
@@ -3,14 +3,15 @@
 //! Tests parse → textify round-trips for `+ Enh:` and `+ Opt:` annotations
 //! on standard relations, using [`PartitionHint`] as the concrete example.
 
+mod common;
+
+use common::parse_type;
 use substrait::proto::plan_rel;
 use substrait::proto::rel::RelType;
 use substrait_explain::extensions::ExtensionRegistry;
 use substrait_explain::extensions::examples::{PartitionHint, PartitionStrategy};
 use substrait_explain::extensions::registry::ExtensionError;
-use substrait_explain::fixtures::parse_type;
-use substrait_explain::parser::Parser;
-use substrait_explain::{FormatError, format_with_registry};
+use substrait_explain::{FormatError, Parser, format_with_registry};
 
 fn make_registry() -> ExtensionRegistry {
     let mut registry = ExtensionRegistry::new();
@@ -587,7 +588,7 @@ Root[result]
   Project[$0, $1, 42]
     ExtensionLeaf:TwoColumnScan[_ => col0:i64, col1:i32]"#;
 
-    let parser = substrait_explain::parser::Parser::new().with_extension_registry(registry.clone());
+    let parser = Parser::new().with_extension_registry(registry.clone());
     let plan = parser.parse_plan(plan_text).expect("parse failed");
 
     // --- proto-level: verify emit mapping on ProjectRel ---

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,54 @@
+#![allow(dead_code)]
+
+use substrait::proto;
+use substrait::proto::{plan_rel, rel};
+use substrait_explain::{Parser, format, parse};
+
+/// Roundtrip a plan and verify that the output is the same as the input, after
+/// being parsed to a Substrait plan and then back to text.
+pub fn roundtrip_plan(input: &str) {
+    let plan = Parser::parse(input).unwrap_or_else(|e| {
+        println!("Error parsing plan:\n{e}");
+        panic!("{e}");
+    });
+
+    let (actual, errors) = format(&plan);
+
+    if !errors.is_empty() {
+        println!("Formatting errors:");
+        for error in errors {
+            println!("  {error}");
+        }
+        panic!("Formatting errors occurred");
+    }
+
+    assert_eq!(
+        actual.trim(),
+        input.trim(),
+        "Expected:\n---\n{}\n---\nActual:\n---\n{}\n---",
+        input.trim(),
+        actual.trim()
+    );
+}
+
+/// Parse a built-in type string (e.g. `"i64"`, `"string?"`) into a
+/// `proto::Type`. Panics on invalid type names.
+pub fn parse_type(s: &str) -> proto::Type {
+    let plan = parse(&format!("=== Plan\nRoot[x]\n  Read[types => x:{s}]"))
+        .unwrap_or_else(|e| panic!("failed to parse type '{s}': {e}"));
+    let plan_rel = plan.relations.first().expect("expected one relation");
+    let root = match plan_rel.rel_type.as_ref() {
+        Some(plan_rel::RelType::Root(root)) => root,
+        other => panic!("expected Root relation, got {other:?}"),
+    };
+    let read = match root.input.as_ref().and_then(|rel| rel.rel_type.as_ref()) {
+        Some(rel::RelType::Read(read)) => read,
+        other => panic!("expected Read input, got {other:?}"),
+    };
+    read.base_schema
+        .as_ref()
+        .and_then(|schema| schema.r#struct.as_ref())
+        .and_then(|schema| schema.types.first())
+        .unwrap_or_else(|| panic!("parsed plan did not contain a type for '{s}'"))
+        .clone()
+}

--- a/tests/extension_roundtrip.rs
+++ b/tests/extension_roundtrip.rs
@@ -1,5 +1,8 @@
 //! Integration test for custom extension handlers with roundtrip parsing and formatting
 
+mod common;
+
+use common::parse_type;
 use prost::{Message, Name};
 use substrait::proto;
 use substrait::proto::expression::RexType;
@@ -10,9 +13,7 @@ use substrait_explain::extensions::{
     EnumValue, Explainable, Expr, ExtensionArgs, ExtensionColumn, ExtensionError,
     ExtensionProtoConvert, ExtensionRegistry, ExtensionValue, TupleValue,
 };
-use substrait_explain::fixtures::parse_type;
-use substrait_explain::format_with_registry;
-use substrait_explain::parser::Parser;
+use substrait_explain::{Parser, format_with_registry};
 
 /// A custom extension configuration for a hypothetical "UserTable" data source.
 /// This differs from the file-based scan in the example by using logical table properties.

--- a/tests/extension_table.rs
+++ b/tests/extension_table.rs
@@ -4,8 +4,7 @@ use prost::{Message, Name};
 use substrait_explain::extensions::{
     Explainable, ExtensionArgs, ExtensionError, ExtensionRegistry, examples,
 };
-use substrait_explain::format_with_registry;
-use substrait_explain::parser::Parser;
+use substrait_explain::{Parser, format_with_registry};
 
 #[derive(Clone, PartialEq, Message)]
 struct UserTable {

--- a/tests/json_parsing.rs
+++ b/tests/json_parsing.rs
@@ -11,8 +11,7 @@ use substrait_explain::extensions::{
     Explainable, ExtensionArgs, ExtensionColumn, ExtensionError, ExtensionRegistry,
 };
 use substrait_explain::json::{build_descriptor_pool, parse_json};
-use substrait_explain::parser::Parser;
-use substrait_explain::{OutputOptions, format_with_registry};
+use substrait_explain::{OutputOptions, Parser, format_with_registry};
 
 // ParquetScanConfig struct + impl prost::Name — generated from parquet_scan.proto by build.rs.
 include!(concat!(env!("OUT_DIR"), "/example.rs"));

--- a/tests/literal_roundtrip.rs
+++ b/tests/literal_roundtrip.rs
@@ -1,6 +1,8 @@
 //! Test roundtrip functionality for literal parsing and formatting
 
-use substrait_explain::fixtures::roundtrip_plan;
+mod common;
+
+use common::roundtrip_plan;
 
 #[test]
 fn test_float_literal_roundtrip() {

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -5,9 +5,10 @@
 //! rare, and more likely a reflection of the author's misunderstanding of the
 //! Substrait plan format.
 
-use substrait_explain::fixtures::roundtrip_plan;
-use substrait_explain::format;
-use substrait_explain::parser::{ParseError, Parser};
+mod common;
+
+use common::roundtrip_plan;
+use substrait_explain::{ParseError, Parser, format};
 
 /// Assert that both canonical and equivalent plans parse and pretty-print to the canonical form.
 fn assert_roundtrip_canonical(canonical: &str, equivalent: &str) {
@@ -324,7 +325,7 @@ Root[result]
 
 #[test]
 fn test_malformed_input_error_handling() {
-    use substrait_explain::parser::Parser;
+    use substrait_explain::Parser;
 
     // Test malformed input: unclosed bracket in extension relation
     let malformed_plan = r#"=== Plan


### PR DESCRIPTION
## Summary

- Move integration tests and examples onto the intended public API surface.
- Add `tests/common` helpers for integration-test-local shared setup.
- Move type parser coverage into crate unit tests so parser internals can become private later.

## Review guide

This PR is mostly test organization, but the reason matters: each file in `tests/` is compiled as a separate integration-test crate, so those tests should exercise the public crate API. Shared helpers that integration tests need live in `tests/common`, and each integration test imports them with `mod common;`.

The moved type parser tests are different. They validate internal parser/textifier traits, so they become crate unit tests in `src/types_tests.rs` instead of forcing those traits to stay public for integration tests.

This PR should not change the library API by itself; it prepares the test and example surface for the final privatization PR.

## Stack

1. #138
2. This PR
3. `wendell/api-private-parser-textifier`

## Validation

- `just test`
- `just check`
- `cargo clippy --examples --tests --all-features -- -D warnings`
