### PR TITLE
refactor!(api): privatize parser and textifier internals

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -64,7 +64,7 @@ This document uses **PEG (Parsing Expression Grammar)** notation:
 ## Basic Example
 
 ```rust
-# use substrait_explain::parser::Parser;
+# use substrait_explain::Parser;
 #
 # let plan_text = r#"
 === Extensions
@@ -126,7 +126,7 @@ Relations use indentation to show the query plan hierarchy:
 #### Example
 
 ```rust
-# use substrait_explain::parser::Parser;
+# use substrait_explain::Parser;
 #
 # let plan_text = r#"
 === Extensions
@@ -250,7 +250,7 @@ From [official Substrait grammar](https://raw.githubusercontent.com/substrait-io
 ##### Examples:
 
 ```rust
-# use substrait_explain::parser::Parser;
+# use substrait_explain::Parser;
 
 let plan_text = r#"
 === Plan
@@ -272,7 +272,7 @@ Compound types follow the same syntax as standard Substrait parameterized types.
 // TODO: This example uses `map` type, which is not yet implemented in the parser.
 
 ```text
-use substrait_explain::parser::Parser;
+use substrait_explain::Parser;
 
 let plan_text = r#"
 === Plan
@@ -302,7 +302,7 @@ User-defined types extend the standard Substrait UDT syntax to support anchors a
 #### Examples
 
 ```rust
-# use substrait_explain::parser::Parser;
+# use substrait_explain::Parser;
 #
 # let plan_text = r#"
 === Extensions
@@ -349,7 +349,7 @@ Currently, only references to fields in the Relations' input are supported.
 #### Examples
 
 ```rust
-# use substrait_explain::parser::Parser;
+# use substrait_explain::Parser;
 # 
 # let plan_text = r#"
 === Plan
@@ -405,7 +405,7 @@ An IfThen expression is a conditional function or logical operator that evaluate
 #### Examples
 
 ```rust
-# use substrait_explain::parser::Parser;
+# use substrait_explain::Parser;
 # 
 # let plan_text = r#"
 === Plan
@@ -493,7 +493,7 @@ form a 1-element tuple: `(x,)`. For 2+ elements the trailing comma is optional: 
 #### Example
 
 ```rust
-# use substrait_explain::parser::Parser;
+# use substrait_explain::Parser;
 #
 # let plan_text = r#"
 === Plan
@@ -520,7 +520,7 @@ Root[c, d]           // root with output columns c and d
 #### Example
 
 ```rust
-# use substrait_explain::parser::Parser;
+# use substrait_explain::Parser;
 #
 # let plan_text = r#"
 === Plan
@@ -559,7 +559,7 @@ Where `virtual_row := "(" (expression ("," expression)*)? ")"` — a parenthesiz
 Inline form with two rows:
 
 ```rust
-# use substrait_explain::parser::Parser;
+# use substrait_explain::Parser;
 #
 # let plan_text = r#"
 === Plan
@@ -574,7 +574,7 @@ Root[id, name]
 Empty virtual table (no rows):
 
 ```rust
-# use substrait_explain::parser::Parser;
+# use substrait_explain::Parser;
 #
 # let plan_text = r#"
 === Plan
@@ -610,7 +610,7 @@ The `+ Ext:` line is indented one level deeper than the `Read:Extension` line. I
 ```rust
 # use substrait_explain::extensions::examples;
 # use substrait_explain::format_with_registry;
-# use substrait_explain::parser::Parser;
+# use substrait_explain::Parser;
 #
 # let registry = examples::registry();
 # let parser = Parser::new().with_extension_registry(registry.clone());
@@ -633,7 +633,7 @@ Relation-level advanced extensions can still be attached to the same read relati
 ```rust
 # use substrait_explain::extensions::examples;
 # use substrait_explain::format_with_registry;
-# use substrait_explain::parser::Parser;
+# use substrait_explain::Parser;
 #
 # let registry = examples::registry();
 # let parser = Parser::new().with_extension_registry(registry.clone());
@@ -667,7 +667,7 @@ Root[id]
 #### Example
 
 ```rust
-# use substrait_explain::parser::Parser;
+# use substrait_explain::Parser;
 #
 # let plan_text = r#"
 === Extensions
@@ -700,7 +700,7 @@ Root[result]
 #### Example
 
 ```rust
-# use substrait_explain::parser::Parser;
+# use substrait_explain::Parser;
 #
 # let plan_text = r#"
 === Plan
@@ -730,7 +730,7 @@ Root[result]
 #### Example
 
 ```rust
-# use substrait_explain::parser::Parser;
+# use substrait_explain::Parser;
 #
 # let plan_text = r#"
 === Extensions
@@ -791,7 +791,7 @@ For joins, field references map to the combined schema of left and right inputs:
 **Example**:
 
 ```rust
-# use substrait_explain::parser::Parser;
+# use substrait_explain::Parser;
 #
 # let plan_text = r#"
 === Extensions
@@ -924,7 +924,7 @@ enum_value := "&" identifier
 ```rust
 # use substrait_explain::extensions::examples;
 # use substrait_explain::format_with_registry;
-# use substrait_explain::parser::Parser;
+# use substrait_explain::Parser;
 #
 # let registry = examples::registry();
 # let parser = Parser::new().with_extension_registry(registry.clone());
@@ -947,7 +947,7 @@ Root[result]
 ```rust
 # use substrait_explain::extensions::examples;
 # use substrait_explain::format_with_registry;
-# use substrait_explain::parser::Parser;
+# use substrait_explain::Parser;
 #
 # let registry = examples::registry();
 # let parser = Parser::new().with_extension_registry(registry.clone());
@@ -1014,7 +1014,7 @@ The `Read` line and everything else in the plan are textified normally; only the
 A complete query that joins users and orders tables, calculates total order value, filters for high-value orders, and groups by user to show total revenue per customer:
 
 ```rust
-# use substrait_explain::parser::Parser;
+# use substrait_explain::Parser;
 #
 # let plan_text = r#"
 === Extensions

--- a/src/extensions/examples.rs
+++ b/src/extensions/examples.rs
@@ -11,6 +11,9 @@
 //! Each positional argument is a [`PartitionStrategy`] variant rendered with
 //! the `&` enum prefix.  The optional named argument `count` gives the target
 //! number of partitions (`0` / absent means "let the executor decide").
+//!
+//! This hidden module is crate-owned example support for doctests and
+//! integration tests, not a stable extension API.
 
 use crate::extensions::args::{EnumValue, ExtensionArgs, ExtensionValue};
 use crate::extensions::registry::{Explainable, ExtensionError, ExtensionRegistry};

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -10,9 +10,11 @@
 
 pub mod any;
 pub mod args;
-pub mod examples;
 pub mod registry;
 pub mod simple;
+
+#[doc(hidden)]
+pub mod examples;
 
 pub use any::{Any, AnyRef};
 pub(crate) use args::AddendumKind;

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -4,10 +4,9 @@ use substrait::proto;
 
 use crate::extensions::simple::ExtensionKind;
 use crate::extensions::{ExtensionRegistry, SimpleExtensions};
-use crate::format;
-use crate::parser::{MessageParseError, Parser, ScopedParse};
-use crate::textify::foundation::{ErrorAccumulator, ErrorList};
-use crate::textify::{ErrorQueue, OutputOptions, Scope, ScopedContext, Textify};
+use crate::parser::common::test_support::ScopedParse;
+use crate::textify::foundation::{ErrorAccumulator, ErrorList, ErrorQueue};
+use crate::textify::{OutputOptions, Scope, ScopedContext, Textify};
 
 pub struct TestContext {
     pub options: OutputOptions,
@@ -91,42 +90,8 @@ impl TestContext {
         assert!(errs.is_empty(), "{} Errors: {}", errs.0.len(), errs.0[0]);
         s
     }
-
-    pub fn parse<T: ScopedParse>(&self, input: &str) -> Result<T, MessageParseError> {
-        T::parse(&self.extensions, input)
-    }
 }
 
-/// Roundtrip a plan and verify that the output is the same as the input, after
-/// being parsed to a Substrait plan and then back to text.
-pub fn roundtrip_plan(input: &str) {
-    // Parse the plan using the simplified interface
-    let plan = Parser::parse(input).unwrap_or_else(|e| {
-        println!("Error parsing plan:\n{e}");
-        panic!("{e}");
-    });
-
-    // Format the plan back to text using the simplified interface
-    let (actual, errors) = format(&plan);
-
-    // Check for formatting errors
-    if !errors.is_empty() {
-        println!("Formatting errors:");
-        for error in errors {
-            println!("  {error}");
-        }
-        panic!("Formatting errors occurred");
-    }
-
-    // Compare the output with the input, printing the difference.
-    assert_eq!(
-        actual.trim(),
-        input.trim(),
-        "Expected:\n---\n{}\n---\nActual:\n---\n{}\n---",
-        input.trim(),
-        actual.trim()
-    );
-}
 /// Parse a built-in type string (e.g. `"i64"`, `"string?"`) into a
 /// `proto::Type`. Panics on invalid type names.
 pub fn parse_type(s: &str) -> proto::Type {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,12 @@
 pub use extensions::{AnyConvertible, Explainable, ExtensionRegistry};
 
 pub mod extensions;
-pub mod fixtures;
 pub mod grammar;
-pub mod parser;
-pub mod textify;
+mod parser;
+mod textify;
+
+#[cfg(test)]
+mod fixtures;
 
 #[cfg(test)]
 mod types_tests;
@@ -19,7 +21,10 @@ pub mod cli;
 pub mod json;
 
 // Re-export commonly used types for easier access
-pub use parser::{ExtensionParseError, MessageParseError, ParseContext, ParseError, Parser};
+pub use parser::{
+    ExpectedExtensionLine, ExtensionParseError, MessageParseError, ParseContext, ParseError,
+    ParseResult, Parser,
+};
 use substrait::proto::Plan;
 use textify::foundation::ErrorQueue;
 pub use textify::foundation::{FormatError, FormatErrorType, OutputOptions, PlanError, Visibility};
@@ -167,17 +172,25 @@ pub fn format_with_options(plan: &Plan, options: &OutputOptions) -> (String, Vec
 /// Format a Substrait plan with custom options and an extension registry.
 ///
 /// This function allows you to provide a custom extension registry for handling
-/// ExtensionLeaf, ExtensionSingle, and ExtensionMulti relations.
+/// extension relations, enhancement addenda, and optimization addenda.
 ///
 /// # Example
-/// ```rust,ignore
-/// use substrait_explain::{parse, format_with_registry, OutputOptions, ExtensionRegistry};
+/// ```rust
+/// use substrait_explain::extensions::examples;
+/// use substrait_explain::{format_with_registry, OutputOptions, Parser};
 ///
-/// let mut registry = ExtensionRegistry::new();
-/// // Register custom extensions...
+/// let registry = examples::registry();
+/// let parser = Parser::new().with_extension_registry(registry.clone());
+/// let plan = parser.parse_plan(r#"
+/// === Plan
+/// Root[id, payload]
+///   Read:Extension[id:i64, payload:string]
+///     + Ext:BlobStoreRead['path/to/file', limit=100]
+/// "#).unwrap();
 ///
-/// let plan = parse("...").unwrap();
 /// let (text, errors) = format_with_registry(&plan, &OutputOptions::default(), &registry);
+/// assert!(errors.is_empty());
+/// assert!(text.contains("BlobStoreRead"));
 /// ```
 pub fn format_with_registry(
     plan: &Plan,

--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -1,6 +1,5 @@
 use std::fmt;
 
-use pest::Parser as PestParser;
 use pest_derive::Parser as PestDeriveParser;
 use thiserror::Error;
 
@@ -181,20 +180,6 @@ pub(crate) trait ParsePair: Sized {
     }
 }
 
-/// A trait for types that can be directly parsed from a string input,
-/// regardless of context.
-pub trait Parse {
-    fn parse(input: &str) -> Result<Self, MessageParseError>
-    where
-        Self: Sized;
-}
-
-impl<T: ParsePair> Parse for T {
-    fn parse(input: &str) -> Result<Self, MessageParseError> {
-        T::parse_str(input)
-    }
-}
-
 /// A trait for types that are parsed from a `pest::iterators::Pair<Rule>` that
 /// depends on the context - e.g. extension lookups or other contextual
 /// information. This is used for types that are not directly parsed from the
@@ -213,23 +198,6 @@ pub(crate) trait ScopedParsePair: Sized {
         extensions: &SimpleExtensions,
         pair: pest::iterators::Pair<Rule>,
     ) -> Result<Self, MessageParseError>;
-}
-
-pub trait ScopedParse: Sized {
-    fn parse(extensions: &SimpleExtensions, input: &str) -> Result<Self, MessageParseError>
-    where
-        Self: Sized;
-}
-
-impl<T: ScopedParsePair> ScopedParse for T {
-    fn parse(extensions: &SimpleExtensions, input: &str) -> Result<Self, MessageParseError> {
-        let mut pairs = ExpressionParser::parse(Self::rule(), input)
-            .map_err(|e| MessageParseError::new(Self::message(), ErrorKind::Syntax, Box::new(e)))?;
-        assert_eq!(pairs.as_str(), input);
-        let pair = pairs.next().unwrap();
-        assert_eq!(pairs.next(), None);
-        Self::parse_pair(extensions, pair)
-    }
 }
 
 pub(crate) fn iter_pairs(pair: pest::iterators::Pairs<'_, Rule>) -> RuleIter<'_> {
@@ -337,5 +305,50 @@ impl Drop for RuleIter<'_> {
         }
         // If the iterator is not done, something probably went wrong.
         assert_eq!(self.iter.next(), None);
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use pest::Parser as PestParser;
+
+    use super::{ErrorKind, ExpressionParser, MessageParseError, ParsePair, ScopedParsePair};
+    use crate::extensions::SimpleExtensions;
+
+    /// Test-only adapter for parsing individual grammar fragments from strings.
+    ///
+    /// Production parsing goes through [`ParsePair`] and the structural [`Parser`](crate::Parser).
+    pub(crate) trait Parse {
+        fn parse(input: &str) -> Result<Self, MessageParseError>
+        where
+            Self: Sized;
+    }
+
+    impl<T: ParsePair> Parse for T {
+        fn parse(input: &str) -> Result<Self, MessageParseError> {
+            T::parse_str(input)
+        }
+    }
+
+    /// Test-only adapter for parsing context-dependent grammar fragments from strings.
+    ///
+    /// Production parsing goes through [`ScopedParsePair`] and the structural
+    /// [`Parser`](crate::Parser).
+    pub(crate) trait ScopedParse: Sized {
+        fn parse(extensions: &SimpleExtensions, input: &str) -> Result<Self, MessageParseError>
+        where
+            Self: Sized;
+    }
+
+    impl<T: ScopedParsePair> ScopedParse for T {
+        fn parse(extensions: &SimpleExtensions, input: &str) -> Result<Self, MessageParseError> {
+            let mut pairs = ExpressionParser::parse(Self::rule(), input).map_err(|e| {
+                MessageParseError::new(Self::message(), ErrorKind::Syntax, Box::new(e))
+            })?;
+            assert_eq!(pairs.as_str(), input);
+            let pair = pairs.next().unwrap();
+            assert_eq!(pairs.next(), None);
+            Self::parse_pair(extensions, pair)
+        }
     }
 }

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -18,17 +18,19 @@ use crate::parser::structural::IndentedLine;
 #[derive(Debug, Clone, Error)]
 pub enum ExtensionParseError {
     #[error("Unexpected line, expected {0}")]
-    UnexpectedLine(ExtensionParserState),
+    UnexpectedLine(ExpectedExtensionLine),
     #[error("Error adding extension: {0}")]
     ExtensionError(#[from] InsertError),
     #[error("Error parsing message: {0}")]
     Message(#[from] super::MessageParseError),
 }
 
-/// The state of the extension parser - tracking what section of extension
-/// parsing we are in.
+/// The kind of extension-section line expected next.
+///
+/// `ExtensionParser` also uses this as its internal state, since each parser
+/// state corresponds directly to the next accepted line shape.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ExtensionParserState {
+pub enum ExpectedExtensionLine {
     // The extensions section, after parsing the 'Extensions:' header, before
     // parsing any subsection headers.
     Extensions,
@@ -40,12 +42,12 @@ pub enum ExtensionParserState {
     ExtensionDeclarations(ExtensionKind),
 }
 
-impl fmt::Display for ExtensionParserState {
+impl fmt::Display for ExpectedExtensionLine {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ExtensionParserState::Extensions => write!(f, "Subsection Header, e.g. 'URNs:'"),
-            ExtensionParserState::ExtensionUrns => write!(f, "Extension URNs"),
-            ExtensionParserState::ExtensionDeclarations(kind) => {
+            ExpectedExtensionLine::Extensions => write!(f, "Subsection Header, e.g. 'URNs:'"),
+            ExpectedExtensionLine::ExtensionUrns => write!(f, "Extension URNs"),
+            ExpectedExtensionLine::ExtensionDeclarations(kind) => {
                 write!(f, "Extension Declaration for {kind}")
             }
         }
@@ -60,14 +62,14 @@ impl fmt::Display for ExtensionParserState {
 /// SimpleExtensions::write method.
 #[derive(Debug)]
 pub struct ExtensionParser {
-    state: ExtensionParserState,
+    state: ExpectedExtensionLine,
     extensions: SimpleExtensions,
 }
 
 impl Default for ExtensionParser {
     fn default() -> Self {
         Self {
-            state: ExtensionParserState::Extensions,
+            state: ExpectedExtensionLine::Extensions,
             extensions: SimpleExtensions::new(),
         }
     }
@@ -78,14 +80,14 @@ impl ExtensionParser {
         if line.1.is_empty() {
             // Blank lines are allowed between subsections, so if we see
             // one, we revert out of the subsection.
-            self.state = ExtensionParserState::Extensions;
+            self.state = ExpectedExtensionLine::Extensions;
             return Ok(());
         }
 
         match self.state {
-            ExtensionParserState::Extensions => self.parse_subsection(line),
-            ExtensionParserState::ExtensionUrns => self.parse_extension_urns(line),
-            ExtensionParserState::ExtensionDeclarations(extension_kind) => {
+            ExpectedExtensionLine::Extensions => self.parse_subsection(line),
+            ExpectedExtensionLine::ExtensionUrns => self.parse_extension_urns(line),
+            ExpectedExtensionLine::ExtensionDeclarations(extension_kind) => {
                 self.parse_declarations(line, extension_kind)
             }
         }
@@ -94,20 +96,20 @@ impl ExtensionParser {
     fn parse_subsection(&mut self, line: IndentedLine) -> Result<(), ExtensionParseError> {
         match line {
             IndentedLine(0, simple::EXTENSION_URNS_HEADER) => {
-                self.state = ExtensionParserState::ExtensionUrns;
+                self.state = ExpectedExtensionLine::ExtensionUrns;
                 Ok(())
             }
             IndentedLine(0, simple::EXTENSION_FUNCTIONS_HEADER) => {
-                self.state = ExtensionParserState::ExtensionDeclarations(ExtensionKind::Function);
+                self.state = ExpectedExtensionLine::ExtensionDeclarations(ExtensionKind::Function);
                 Ok(())
             }
             IndentedLine(0, simple::EXTENSION_TYPES_HEADER) => {
-                self.state = ExtensionParserState::ExtensionDeclarations(ExtensionKind::Type);
+                self.state = ExpectedExtensionLine::ExtensionDeclarations(ExtensionKind::Type);
                 Ok(())
             }
             IndentedLine(0, simple::EXTENSION_TYPE_VARIATIONS_HEADER) => {
                 self.state =
-                    ExtensionParserState::ExtensionDeclarations(ExtensionKind::TypeVariation);
+                    ExpectedExtensionLine::ExtensionDeclarations(ExtensionKind::TypeVariation);
                 Ok(())
             }
             _ => Err(ExtensionParseError::UnexpectedLine(self.state)),
@@ -153,7 +155,7 @@ impl ExtensionParser {
     }
 
     #[cfg(test)]
-    pub(crate) fn state(&self) -> ExtensionParserState {
+    pub(crate) fn state(&self) -> ExpectedExtensionLine {
         self.state
     }
 }
@@ -609,7 +611,8 @@ mod tests {
     use crate::OutputOptions;
     use crate::extensions::{Expr, ExtensionValue};
     use crate::fixtures::TestContext;
-    use crate::parser::{Parser, ScopedParse};
+    use crate::parser::Parser;
+    use crate::parser::common::test_support::ScopedParse;
 
     fn parse_extension_value(text: &str) -> ExtensionValue {
         ExtensionValue::parse(&SimpleExtensions::default(), text).unwrap()

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6,13 +6,13 @@ pub(crate) mod relations;
 pub(crate) mod structural;
 pub(crate) mod types;
 
+pub use common::MessageParseError;
 pub(crate) use common::{
     ErrorKind, ExpressionParser, ParsePair, Rule, RuleIter, ScopedParsePair, iter_pairs,
     unescape_string, unwrap_single_pair,
 };
-pub use common::{MessageParseError, Parse, ScopedParse};
 pub use errors::{ParseContext, ParseError, ParseResult};
-pub use extensions::ExtensionParseError;
+pub use extensions::{ExpectedExtensionLine, ExtensionParseError};
 pub(crate) use relations::RelationParsePair;
 pub(crate) use structural::PLAN_HEADER;
 pub use structural::Parser;

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -978,7 +978,7 @@ mod tests {
 
     use super::*;
     use crate::extensions::simple::ExtensionKind;
-    use crate::parser::extensions::ExtensionParserState;
+    use crate::parser::extensions::ExpectedExtensionLine;
 
     #[test]
     fn test_parse_basic_block() {
@@ -1037,12 +1037,12 @@ Type Variations:
         // The last significant line in input_block is a TypeVariation declaration.
         assert_eq!(
             parser.state(),
-            ExtensionParserState::ExtensionDeclarations(ExtensionKind::TypeVariation)
+            ExpectedExtensionLine::ExtensionDeclarations(ExtensionKind::TypeVariation)
         );
 
         // Check that a subsequent blank line correctly resets state to Extensions.
         parser.parse_line(IndentedLine(0, "")).unwrap();
-        assert_eq!(parser.state(), ExtensionParserState::Extensions);
+        assert_eq!(parser.state(), ExpectedExtensionLine::Extensions);
     }
 
     /// Test that we can parse a larger extensions block and it matches the input.

--- a/src/textify/expressions.rs
+++ b/src/textify/expressions.rs
@@ -63,11 +63,6 @@ pub fn textify_enum<S: Scope, W: fmt::Write>(s: &str, _ctx: &S, w: &mut W) -> fm
     write!(w, "&{}", Name(s))
 }
 
-pub fn timestamp_to_string(t: i64) -> String {
-    let ts = chrono::DateTime::from_timestamp_nanos(t);
-    ts.to_rfc3339()
-}
-
 /// Convert days since Unix epoch to date string
 fn days_to_date_string(days: i32) -> String {
     let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();

--- a/src/textify/foundation.rs
+++ b/src/textify/foundation.rs
@@ -11,7 +11,7 @@ use crate::extensions::registry::ExtensionError;
 use crate::extensions::simple::MissingReference;
 use crate::extensions::{ExtensionRegistry, InsertError, SimpleExtensions};
 
-pub const NONSPECIFIC: Option<&'static str> = None;
+pub(crate) const NONSPECIFIC: Option<&'static str> = None;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Visibility {
@@ -91,12 +91,12 @@ impl OutputOptions {
         }
     }
 }
-pub trait ErrorAccumulator: Clone {
+pub(crate) trait ErrorAccumulator: Clone {
     fn push(&self, e: FormatError);
 }
 
 #[derive(Debug, Clone)]
-pub struct ErrorQueue {
+pub(crate) struct ErrorQueue {
     sender: mpsc::Sender<FormatError>,
     receiver: Rc<mpsc::Receiver<FormatError>>,
 }
@@ -137,7 +137,8 @@ impl fmt::Display for ErrorQueue {
 }
 
 impl ErrorQueue {
-    pub fn errs(self) -> Result<(), ErrorList> {
+    #[cfg(test)]
+    pub(crate) fn errs(self) -> Result<(), ErrorList> {
         let errors: Vec<FormatError> = self.receiver.try_iter().collect();
         if errors.is_empty() {
             Ok(())
@@ -148,20 +149,23 @@ impl ErrorQueue {
 }
 
 // A list of errors, used to return errors from textify operations.
-pub struct ErrorList(pub Vec<FormatError>);
+#[cfg(test)]
+pub(crate) struct ErrorList(pub(crate) Vec<FormatError>);
 
+#[cfg(test)]
 impl ErrorList {
-    pub fn first(&self) -> &FormatError {
+    pub(crate) fn first(&self) -> &FormatError {
         self.0
             .first()
             .expect("Expected at least one error in ErrorList")
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 }
 
+#[cfg(test)]
 impl fmt::Display for ErrorList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for (i, e) in self.0.iter().enumerate() {
@@ -174,6 +178,7 @@ impl fmt::Display for ErrorList {
     }
 }
 
+#[cfg(test)]
 impl fmt::Debug for ErrorList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for (i, e) in self.0.iter().enumerate() {
@@ -186,6 +191,7 @@ impl fmt::Debug for ErrorList {
     }
 }
 
+#[cfg(test)]
 impl std::error::Error for ErrorList {}
 
 impl<'e> IntoIterator for &'e ErrorQueue {
@@ -197,7 +203,7 @@ impl<'e> IntoIterator for &'e ErrorQueue {
     }
 }
 
-pub trait IndentTracker {
+pub(crate) trait IndentTracker {
     // TODO: Use this and remove the allow(dead_code)
     #[allow(dead_code)]
     fn indent<W: fmt::Write>(&self, w: &mut W) -> fmt::Result;
@@ -205,7 +211,7 @@ pub trait IndentTracker {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub struct IndentStack<'a> {
+pub(crate) struct IndentStack<'a> {
     count: u32,
     indent: &'a str,
 }
@@ -220,7 +226,7 @@ impl<'a> fmt::Display for IndentStack<'a> {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub struct ScopedContext<'a, Err: ErrorAccumulator> {
+pub(crate) struct ScopedContext<'a, Err: ErrorAccumulator> {
     errors: &'a Err,
     options: &'a OutputOptions,
     extensions: &'a SimpleExtensions,
@@ -229,7 +235,7 @@ pub struct ScopedContext<'a, Err: ErrorAccumulator> {
 }
 
 impl<'a> IndentStack<'a> {
-    pub fn new(indent: &'a str) -> Self {
+    pub(crate) fn new(indent: &'a str) -> Self {
         Self { count: 0, indent }
     }
 }
@@ -249,7 +255,7 @@ impl<'a> IndentTracker for IndentStack<'a> {
 }
 
 impl<'a, Err: ErrorAccumulator> ScopedContext<'a, Err> {
-    pub fn new(
+    pub(crate) fn new(
         options: &'a OutputOptions,
         errors: &'a Err,
         extensions: &'a SimpleExtensions,
@@ -386,7 +392,7 @@ impl fmt::Display for PlanError {
 
 #[derive(Debug, Copy, Clone)]
 /// A token used to represent an error in the textified output.
-pub struct ErrorToken(
+pub(crate) struct ErrorToken(
     /// The kind of item this is in place of.
     pub &'static str,
 );
@@ -398,7 +404,7 @@ impl fmt::Display for ErrorToken {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub struct MaybeToken<V: fmt::Display>(pub Result<V, ErrorToken>);
+pub(crate) struct MaybeToken<V: fmt::Display>(pub(crate) Result<V, ErrorToken>);
 
 impl<V: fmt::Display> fmt::Display for MaybeToken<V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -413,7 +419,7 @@ impl<V: fmt::Display> fmt::Display for MaybeToken<V> {
 ///
 /// This trait is used to convert a Substrait type into a string representation
 /// that can be written to a text writer.
-pub trait Textify {
+pub(crate) trait Textify {
     fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result;
 
     // TODO: Prost can give this to us if substrait was generated with `enable_type_names`
@@ -431,7 +437,7 @@ pub trait Textify {
 /// - Indent (`&`[`IndentTracker`]) for tracking the current indent level
 ///
 /// The `Scope` trait is used to provide the context for textifying a plan.
-pub trait Scope: Sized {
+pub(crate) trait Scope: Sized {
     /// The type of errors that can occur when textifying a plan.
     type Errors: ErrorAccumulator;
     type Indent: IndentTracker;
@@ -479,16 +485,6 @@ pub trait Scope: Sized {
         }
     }
 
-    fn expect_ok<'a, T: Textify, E: Into<FormatError>>(
-        &'a self,
-        result: Result<&'a T, E>,
-    ) -> MaybeToken<impl fmt::Display + 'a> {
-        MaybeToken(match result {
-            Ok(t) => Ok(self.display(t)),
-            Err(e) => Err(self.failure(e)),
-        })
-    }
-
     fn display<'a, T: Textify>(&'a self, value: &'a T) -> Displayable<'a, Self, T> {
         Displayable { scope: self, value }
     }
@@ -514,10 +510,6 @@ pub trait Scope: Sized {
         }
     }
 
-    fn option<'a, T: Textify>(&'a self, value: Option<&'a T>) -> OptionalDisplayable<'a, Self, T> {
-        OptionalDisplayable { scope: self, value }
-    }
-
     fn optional<'a, T: Textify>(
         &'a self,
         value: &'a T,
@@ -529,7 +521,7 @@ pub trait Scope: Sized {
 }
 
 #[derive(Clone)]
-pub struct Separated<'a, S: Scope, T: Textify + 'a, I: IntoIterator<Item = &'a T> + Clone> {
+pub(crate) struct Separated<'a, S: Scope, T: Textify + 'a, I: IntoIterator<Item = &'a T> + Clone> {
     scope: &'a S,
     items: I,
     separator: &'static str,
@@ -562,7 +554,7 @@ impl<'a, S: Scope, T: Textify, I: IntoIterator<Item = &'a T> + Clone + fmt::Debu
 }
 
 #[derive(Copy, Clone)]
-pub struct Displayable<'a, S: Scope, T: Textify> {
+pub(crate) struct Displayable<'a, S: Scope, T: Textify> {
     scope: &'a S,
     value: &'a T,
 }
@@ -573,21 +565,6 @@ impl<'a, S: Scope, T: Textify + fmt::Debug> fmt::Debug for Displayable<'a, S, T>
     }
 }
 
-impl<'a, S: Scope, T: Textify> Displayable<'a, S, T> {
-    pub fn new(scope: &'a S, value: &'a T) -> Self {
-        Self { scope, value }
-    }
-
-    /// Display only if the option is true, otherwise, do not display anything.
-    pub fn optional(self, option: bool) -> OptionalDisplayable<'a, S, T> {
-        let value = if option { Some(self.value) } else { None };
-        OptionalDisplayable {
-            scope: self.scope,
-            value,
-        }
-    }
-}
-
 impl<'a, S: Scope, T: Textify> fmt::Display for Displayable<'a, S, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.value.textify(self.scope, f)
@@ -595,7 +572,7 @@ impl<'a, S: Scope, T: Textify> fmt::Display for Displayable<'a, S, T> {
 }
 
 #[derive(Copy, Clone)]
-pub struct OptionalDisplayable<'a, S: Scope, T: Textify> {
+pub(crate) struct OptionalDisplayable<'a, S: Scope, T: Textify> {
     scope: &'a S,
     value: Option<&'a T>,
 }

--- a/src/textify/mod.rs
+++ b/src/textify/mod.rs
@@ -1,14 +1,13 @@
 //! Output a plan in text format.
 
 mod addenda;
-pub mod expressions;
-pub mod extensions;
-pub mod foundation;
-pub mod plan;
-pub mod rels;
-pub mod types;
+pub(crate) mod expressions;
+pub(crate) mod extensions;
+pub(crate) mod foundation;
+pub(crate) mod plan;
+pub(crate) mod rels;
+pub(crate) mod types;
 
-pub use foundation::{
-    ErrorQueue, FormatErrorType, OutputOptions, PlanError, Scope, ScopedContext, Textify,
-    Visibility,
-};
+#[cfg(test)]
+pub(crate) use foundation::ErrorQueue;
+pub(crate) use foundation::{OutputOptions, PlanError, Scope, ScopedContext, Textify, Visibility};

--- a/src/textify/plan.rs
+++ b/src/textify/plan.rs
@@ -9,7 +9,7 @@ use crate::textify::foundation::ErrorAccumulator;
 use crate::textify::{OutputOptions, ScopedContext};
 
 #[derive(Debug, Clone)]
-pub struct PlanWriter<'a, E: ErrorAccumulator + Default> {
+pub(crate) struct PlanWriter<'a, E: ErrorAccumulator + Default> {
     options: &'a OutputOptions,
     extensions: SimpleExtensions,
     relations: &'a [proto::PlanRel],
@@ -18,7 +18,7 @@ pub struct PlanWriter<'a, E: ErrorAccumulator + Default> {
 }
 
 impl<'a, E: ErrorAccumulator + Default + Clone> PlanWriter<'a, E> {
-    pub fn new(
+    pub(crate) fn new(
         options: &'a OutputOptions,
         plan: &'a proto::Plan,
         extension_registry: &'a ExtensionRegistry,
@@ -45,7 +45,7 @@ impl<'a, E: ErrorAccumulator + Default + Clone> PlanWriter<'a, E> {
         )
     }
 
-    pub fn scope(&'a self) -> ScopedContext<'a, E> {
+    pub(crate) fn scope(&'a self) -> ScopedContext<'a, E> {
         ScopedContext::new(
             self.options,
             &self.errors,
@@ -54,11 +54,11 @@ impl<'a, E: ErrorAccumulator + Default + Clone> PlanWriter<'a, E> {
         )
     }
 
-    pub fn write_extensions(&self, w: &mut impl fmt::Write) -> fmt::Result {
+    pub(crate) fn write_extensions(&self, w: &mut impl fmt::Write) -> fmt::Result {
         self.extensions.write(w, &self.options.indent)
     }
 
-    pub fn write_relations(&self, w: &mut impl fmt::Write) -> fmt::Result {
+    pub(crate) fn write_relations(&self, w: &mut impl fmt::Write) -> fmt::Result {
         // We always write the plan header, even if there are no relations.
         writeln!(w, "{PLAN_HEADER}")?;
         let scope = self.scope();

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -88,11 +88,9 @@ pub struct NamedArg<'a> {
 
 #[derive(Debug, Clone)]
 pub enum Value<'a> {
-    Name(Name<'a>),
     TableName(Vec<Name<'a>>),
     Field(Option<Name<'a>>, Option<&'a Type>),
     Tuple(Vec<Value<'a>>),
-    List(Vec<Value<'a>>),
     Reference(i32),
     Expression(&'a Expression),
     AggregateFunction(&'a AggregateFunction),
@@ -102,10 +100,8 @@ pub enum Value<'a> {
     Enum(Cow<'a, str>),
     EmptyGroup,
     Integer(i64),
-    Float(f64),
-    Boolean(bool),
     /// A decoded extension argument value.
-    ExtValue(ExtensionValue),
+    ExtensionArgument(ExtensionValue),
     /// A decoded extension output column.
     ExtColumn(ExtensionColumn),
 }
@@ -135,13 +131,11 @@ impl<'a> Textify for Value<'a> {
 
     fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
         match self {
-            Value::Name(name) => write!(w, "{}", ctx.display(name)),
             Value::TableName(names) => write!(w, "{}", ctx.separated(names, ".")),
             Value::Field(name, typ) => {
                 write!(w, "{}:{}", ctx.expect(name.as_ref()), ctx.expect(*typ))
             }
             Value::Tuple(values) => write!(w, "({})", ctx.separated(values, ", ")),
-            Value::List(values) => write!(w, "[{}]", ctx.separated(values, ", ")),
             Value::Reference(i) => write!(w, "{}", Reference(*i)),
             Value::Expression(e) => write!(w, "{}", ctx.display(*e)),
             Value::AggregateFunction(agg_fn) => agg_fn.textify(ctx, w),
@@ -149,9 +143,7 @@ impl<'a> Textify for Value<'a> {
             Value::Enum(res) => write!(w, "&{res}"),
             Value::Integer(i) => write!(w, "{i}"),
             Value::EmptyGroup => write!(w, "_"),
-            Value::Float(f) => write!(w, "{f}"),
-            Value::Boolean(b) => write!(w, "{b}"),
-            Value::ExtValue(ev) => ev.textify(ctx, w),
+            Value::ExtensionArgument(ev) => ev.textify(ctx, w),
             Value::ExtColumn(ec) => ec.textify(ctx, w),
         }
     }
@@ -342,20 +334,6 @@ impl<'a> Relation<'a> {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
-pub struct TableName<'a>(&'a [String]);
-
-impl<'a> Textify for TableName<'a> {
-    fn name() -> &'static str {
-        "TableName"
-    }
-
-    fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
-        let names = self.0.iter().map(|n| Name(n)).collect::<Vec<_>>();
-        write!(w, "{}", ctx.separated(names.iter(), "."))
-    }
-}
-
 impl<'a> Relation<'a> {
     fn from_read<S: Scope>(rel: &'a ReadRel, ctx: &S) -> Self {
         let columns = read_columns(rel);
@@ -461,18 +439,6 @@ pub fn get_emit(rel: Option<&RelCommon>) -> Option<&EmitKind> {
 }
 
 impl<'a> Relation<'a> {
-    /// Create a vector of values that are references to the emitted outputs of
-    /// this relation. "Emitted" here meaning the outputs of this relation after
-    /// the emit kind has been applied.
-    ///
-    /// This is useful for relations like Filter and Limit whose direct outputs
-    /// are primarily those of its children (direct here meaning before the emit
-    /// has been applied).
-    pub fn input_refs(&self) -> Vec<Value<'a>> {
-        let len = self.emitted();
-        (0..len).map(|i| Value::Reference(i as i32)).collect()
-    }
-
     /// Convert a vector of relation references into their structured form.
     ///
     /// Returns a list of children (with None for ones missing), and a count of input columns.
@@ -619,13 +585,13 @@ impl<'a> Relation<'a> {
                 let (children, _) = Relation::convert_children(child_refs, ctx);
                 let mut positional = vec![];
                 for value in args.positional {
-                    positional.push(Value::ExtValue(value));
+                    positional.push(Value::ExtensionArgument(value));
                 }
                 let mut named = vec![];
                 for (key, value) in args.named {
                     named.push(NamedArg {
                         name: Cow::Owned(key),
-                        value: Value::ExtValue(value),
+                        value: Value::ExtensionArgument(value),
                     });
                 }
                 let mut columns = vec![];

--- a/src/types_tests.rs
+++ b/src/types_tests.rs
@@ -4,8 +4,9 @@ use substrait::proto::{Expression, Type};
 use crate::extensions::SimpleExtensions;
 use crate::extensions::simple::ExtensionKind;
 use crate::fixtures::TestContext;
-use crate::parser::{Parse, ScopedParse};
-use crate::textify::{ErrorQueue, OutputOptions, Textify};
+use crate::parser::common::test_support::{Parse, ScopedParse};
+use crate::textify::foundation::ErrorQueue;
+use crate::textify::{OutputOptions, Textify};
 
 /// Helper function to parse and check for errors, panicking if either fails
 fn must_parse<T, E: std::fmt::Display>(result: Result<T, E>, input: &str) -> T {

--- a/tests/extension_table.rs
+++ b/tests/extension_table.rs
@@ -1,5 +1,7 @@
 //! Integration tests for `Read:Extension` and `+ Ext` parse rules.
 
+mod common;
+
 use prost::{Message, Name};
 use substrait_explain::extensions::{
     Explainable, ExtensionArgs, ExtensionError, ExtensionRegistry, examples,


### PR DESCRIPTION
## Summary

- Make `parser`, `textify`, and crate fixtures private while preserving the crate-root public API.
- Keep extension fixtures available only where they are used by crate tests, and copy integration-test fixtures into `tests/common`.
- Update docs/doctests that previously referenced private fixtures or module paths.
- Clean up the parser child accumulator to move `Rel` values into protobuf boxes only at the generated-field boundary.

Using `cargo public-api -p substrait-explain --omit 'blanket-impls,auto-trait-impls,auto-derived-impls' | wc -l`, this reduces the public API from 1605 to 753 items.

## Review guide

This is the PR where the API boundary actually closes. The supported parser/formatter surface is now at the crate root: `Parser`, `parse`, `format`, `format_with_options`, `format_with_registry`, `OutputOptions`, parse/format errors, and the extension-authoring types under `extensions`.

`PlanWriter` stays private on purpose. The current type is generic over internal error accumulation and exposes formatter-phase methods such as `scope`, `write_extensions`, and `write_relations`. Re-exporting it would either expose more textifier internals or create a public writer API around implementation details. If we need a public writer later, it should be a smaller wrapper designed around stable inputs and outputs.

`extensions::examples` remains `#[doc(hidden)] pub` so doctests and examples can compile as external crates while using real extension handlers. It is crate-owned example support, not a stable extension API.

## Stack

1. #138
2. #139
3. This PR

## Validation

- `just test`
- `just check`
- `cargo clippy --examples --tests --all-features -- -D warnings`
