### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1](https://github.com/DataDog/substrait-explain/compare/v0.5.0...v0.5.1) - 2026-06-01
+
 ## [0.5.0](https://github.com/DataDog/substrait-explain/compare/v0.4.0...v0.5.0) - 2026-05-28
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "substrait-explain"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrait-explain"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 authors = [
     "Wendell Smith <wendell.smith@datadoghq.com>",


### PR DESCRIPTION



## 🤖 New release

* `substrait-explain`: 0.5.0 -> 0.5.1

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).