### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.1](https://github.com/DataDog/substrait-explain/compare/v0.5.0...v0.5.1) - 2026-06-01
+## [0.6.0](https://github.com/DataDog/substrait-explain/compare/v0.5.0...v0.6.0) - 2026-06-01
+
+### Features
+- [**breaking**] upgrading to new substrait dependency required removing support for URIs, and unimplemented "support" for lambda expressions / references (https://github.com/DataDog/substrait-explain/pull/141)
+ 
+### Bug Fixes 
+- adding support for root reference root type on fieldReferences
 
 ## [0.5.0](https://github.com/DataDog/substrait-explain/compare/v0.4.0...v0.5.0) - 2026-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1](https://github.com/DataDog/substrait-explain/compare/v0.5.0...v0.5.1) - 2026-06-01
+
 ## [0.5.0](https://github.com/DataDog/substrait-explain/compare/v0.4.0...v0.5.0) - 2026-05-28
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "substrait-explain"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "substrait-explain"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrait-explain"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 authors = [
     "Wendell Smith <wendell.smith@datadoghq.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrait-explain"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 authors = [
     "Wendell Smith <wendell.smith@datadoghq.com>",


### PR DESCRIPTION

## 🤖 New release

* `substrait-explain`: 0.5.0 -> 0.6.0

<details><summary><i><b>Changelog</b></i></summary><p>

- Removing any support for URIs, as they have been removed from substrait
- Correct handling of RootReference in FieldIndex (which could have been done separately?), with correct unimplemented handling of other references
- #[allow(deprecated)] support for Time / Timestamp; should not affect users
unimplemented "support" for lambda expressions / references

</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).