### PR TITLE
feat: adding precision time compound types

### DIFF
--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -105,10 +105,16 @@ map_type = { ^"map" ~ nullability ~ "<" ~ type ~ "," ~ sp ~ type ~ ">" }
 
 struct_type = { ^"struct" ~ nullability ~ parameters }
 
+// Precision timestamp types take an integer precision parameter.
+// Example: precisiontimestamp<9>, precisiontimestamptz?<6>
+precision_timestamp_tz_type = { ^"precisiontimestamptz" ~ nullability ~ "<" ~ integer ~ ">" }
+precision_timestamp_type    = { ^"precisiontimestamp"   ~ nullability ~ "<" ~ integer ~ ">" }
+precision_time_type         = { ^"precisiontime"        ~ nullability ~ "<" ~ integer ~ ">" }
+
 // A compound type expression, composed of a name, optional parameters, and optional nullability.
 // Example: LIST?<fp64?>, MAP<i64, string>
-// TODO: precisiontime types, interval_day
-compound_type = { list_type | map_type | struct_type }
+// TODO: interval_day
+compound_type = { list_type | map_type | struct_type | precision_timestamp_tz_type | precision_timestamp_type | precision_time_type }
 
 // A user-defined type expression.
 // 
@@ -166,7 +172,7 @@ cast_failure_behavior = { "?" | "!" }
 cast_expression = { "(" ~ sp ~ expression ~ sp ~ ")" ~ sp ~ "::" ~ sp ~ cast_failure_behavior? ~ sp ~ type }
 
 // Top-level Expression Rule
-// Order matters for PEGs: Since an identifer can be a function call, we put that first.
+// Order matters for PEGs: Since an identifier can be a function call, we put that first.
 // cast_expression must come before literal/function_call since it starts with "("
 expression = { if_then | cast_expression | function_call | reference | literal }
 

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -189,8 +189,42 @@ fn parse_compound_type(
         Rule::list_type => parse_list_type(extensions, inner),
         // Rule::map_type => parse_map_type(inner),
         // Rule::struct_type => parse_struct_type(inner),
+        Rule::precision_timestamp_tz_type
+        | Rule::precision_timestamp_type
+        | Rule::precision_time_type => Ok(parse_precision_type(inner)),
         _ => unimplemented!("{:?}", inner.as_rule()),
     }
+}
+
+fn parse_precision_type(pair: Pair<Rule>) -> Type {
+    let rule = pair.as_rule();
+    let mut iter = iter_pairs(pair.into_inner());
+    let nullability = iter.parse_next::<Nullability>();
+    let precision = iter.pop(Rule::integer).as_str().parse::<i32>().unwrap();
+    iter.done();
+    let kind = match rule {
+        Rule::precision_timestamp_type => {
+            Kind::PrecisionTimestamp(proto::r#type::PrecisionTimestamp {
+                precision,
+                nullability: nullability.into(),
+                type_variation_reference: 0,
+            })
+        }
+        Rule::precision_timestamp_tz_type => {
+            Kind::PrecisionTimestampTz(proto::r#type::PrecisionTimestampTz {
+                precision,
+                nullability: nullability.into(),
+                type_variation_reference: 0,
+            })
+        }
+        Rule::precision_time_type => Kind::PrecisionTime(proto::r#type::PrecisionTime {
+            precision,
+            nullability: nullability.into(),
+            type_variation_reference: 0,
+        }),
+        _ => unreachable!("parse_precision_type called with rule {:?}", rule),
+    };
+    Type { kind: Some(kind) }
 }
 
 fn parse_list_type(

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -191,16 +191,25 @@ fn parse_compound_type(
         // Rule::struct_type => parse_struct_type(inner),
         Rule::precision_timestamp_tz_type
         | Rule::precision_timestamp_type
-        | Rule::precision_time_type => Ok(parse_precision_type(inner)),
+        | Rule::precision_time_type => parse_precision_type(inner),
         _ => unimplemented!("{:?}", inner.as_rule()),
     }
 }
 
-fn parse_precision_type(pair: Pair<Rule>) -> Type {
+fn parse_precision_type(pair: Pair<Rule>) -> Result<Type, MessageParseError> {
     let rule = pair.as_rule();
     let mut iter = iter_pairs(pair.into_inner());
     let nullability = iter.parse_next::<Nullability>();
-    let precision = iter.pop(Rule::integer).as_str().parse::<i32>().unwrap();
+    let precision_pair = iter.pop(Rule::integer);
+    let precision_span = precision_pair.as_span();
+    let precision = precision_pair.as_str().parse::<i32>().unwrap();
+    if !(0..=12).contains(&precision) {
+        return Err(MessageParseError::invalid(
+            "precision time type",
+            precision_span,
+            format!("precision must be between 0 and 12, got {precision}"),
+        ));
+    }
     iter.done();
     let kind = match rule {
         Rule::precision_timestamp_type => {
@@ -224,7 +233,7 @@ fn parse_precision_type(pair: Pair<Rule>) -> Type {
         }),
         _ => unreachable!("parse_precision_type called with rule {:?}", rule),
     };
-    Type { kind: Some(kind) }
+    Ok(Type { kind: Some(kind) })
 }
 
 fn parse_list_type(

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -242,6 +242,14 @@ Root[a, b]
 }
 
 #[test]
+fn test_precision_time_types_roundtrip() {
+    let plan = r#"=== Plan
+Root[ts, ts_tz, pt]
+  Read[events => ts:precisiontimestamp<9>, ts_tz:precisiontimestamptz?<6>, pt:precisiontime<3>]"#;
+    roundtrip_plan(plan);
+}
+
+#[test]
 fn test_join_relation_roundtrip() {
     let plan = r#"=== Extensions
 URNs:

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -109,6 +109,13 @@ fn test_types() {
 
     assert_roundtrip::<Type>(&ctx, "MyType#12<i32, string?>");
     assert_roundtrip::<Type>(&ctx, "MyType#12?<i32, string?>");
+
+    assert_roundtrip::<Type>(&ctx, "precisiontimestamp<9>");
+    assert_roundtrip::<Type>(&ctx, "precisiontimestamp?<9>");
+    assert_roundtrip::<Type>(&ctx, "precisiontimestamptz<6>");
+    assert_roundtrip::<Type>(&ctx, "precisiontimestamptz?<6>");
+    assert_roundtrip::<Type>(&ctx, "precisiontime<3>");
+    assert_roundtrip::<Type>(&ctx, "precisiontime?<3>");
 }
 
 #[test]


### PR DESCRIPTION

## Description
- Add precisionTimestamp, precisionTimestamptz, and precisionTime as compound types

### Why compound, not simple
The precision time types require a mandatory integer precision parameter (e.g. <9>). Simple types are parameterless — only a name and optional nullability. Compound types carry structure.

## Test plan
- tests/types.rs: 6 new assert_roundtrip::<Type> assertions — all three types, required and nullable
- tests/plan_roundtrip.rs: test_precision_time_types_roundtrip — a full text→proto→text cycle with all three types as read schema columns

## Type of Change
- [x] New feature


Closes #89
