### PR TITLE
fix: zero arg textification and parsing fix

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -366,15 +366,41 @@ Root[result]
 
 #### Syntax
 
-`function_call := name anchor? urn_anchor? "(" (expression ("," expression)*)? ")" (":" type)?`
+`function_call := compound_name anchor? urn_anchor? "(" (expression ("," expression)*)? ")" (":" type)?`
+
+`compound_name := identifier (":" identifier?)?`
 
 #### Components
 
-- `name` - function name
+- `compound_name` - function name, optionally including a type-signature suffix (see below)
 - `anchor` - optional anchor (e.g., `#10`)
 - `urn_anchor` - optional URN anchor (e.g., `@1`)
 - `expression` - as above
 - `type` - optional output type
+
+#### Function Name Resolution
+
+A compound name is either *simple* (no colon, e.g. `add`) or *full* (has a colon, e.g. `add:i64_i64` or `count:`). These resolve differently:
+
+- **Simple** (`add`): matches any registered function whose base name is `add`, regardless of type signature. Succeeds only if the base name is unambiguous (exactly one registered function has that base name).
+- **Full** (`add:i64_i64`, `count:`): exact match only — the written name must match the registered name exactly.
+
+An `anchor` explicitly identifies which registered function is meant. When present:
+- A simple name validates that the anchor's registered name shares the same base.
+- A full name validates that the anchor's registered name matches exactly.
+
+The type signature and anchor are each optional, but either or both may be required to make the reference unambiguous.
+
+#### Examples
+
+```text
+add($0, $1)              // Simple: resolves if "add" is unambiguous
+add:i64_i64($0, $1)      // Full: resolves only if "add:i64_i64" is registered
+add#1($0, $1)            // Anchor: resolves anchor 1, validates base name "add"
+add:i64_i64#1($0, $1)    // Anchor + full name: exact consistency check
+count()                  // Simple: resolves if "count" base name is unambiguous
+count:()                 // Full: resolves only if "count:" is registered exactly
+```
 
 ### Aggregate Measures
 

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -380,11 +380,11 @@ Root[result]
 
 #### Function Name Resolution
 
-Within the plan, a function name has three parts: a `base` name (e.g. `abs`), a type signature (prefixed with a colon, e.g. `abs:i64`), and anchor (prefixed with `#`, e.g. `#4`).
+Within the plan, a function name has three parts: a `base` name (e.g. `abs`), a type signature (prefixed with a colon, e.g. `:i64`), and anchor (prefixed with `#`, e.g. `#4`).
 
-Both type signature and anchor are separably optional if the reference is unambiguous; either or both may be required to make the reference unambiguous. A function name (base, signature if present, and anchor if present) must  to exactly one function named in the `Extensions` section.
+Both type signature and anchor are separably optional if the reference is unambiguous; either or both may be required to make the reference unambiguous. A function name (base, signature if present, and anchor if present) must map to exactly one function named in the `Extensions` section.
 
-Where unambiguous, signature and anchor may both be left off (`abs($0)`), used separately (e.g. `abs:i64($0)`, `abs$4($0)`), or together for completeness (`abs:i64#4($0)`).
+Where unambiguous, signature and anchor may both be left off (`abs($0)`), used separately (e.g. `abs:i64($0)`, `abs#4($0)`), or together for completeness (`abs:i64#4($0)`).
 
 #### Examples
 
@@ -392,17 +392,17 @@ Where unambiguous, signature and anchor may both be left off (`abs($0)`), used s
 // Simple: resolves if there is exactly one function named `add`
 add($0, $1)
 // Signature: resolves only if exactly one function named `add` is registered,
-// with signature `:i64_i64`
+// with type signature `:i64_i64`
 add:i64_i64($0, $1)
 // Anchor: resolves if anchor 1 exists with base name `add`
 add#1($0, $1)            
 // Anchor + full name: resolves if anchor 1 exists with name `add` and 
-// signature `i64_i64`
+// type signature `i64_i64`
 add:i64_i64#1($0, $1)
 // Simple: resolves if there is exactly one function named `count`
 count()
 // Signature: resolves if "count:" is registered exactly once with
-// signature "" (zero arguments)
+// type signature "" (zero arguments)
 count:()
 ```
 

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -380,26 +380,30 @@ Root[result]
 
 #### Function Name Resolution
 
-A compound name is either *simple* (no colon, e.g. `add`) or *full* (has a colon, e.g. `add:i64_i64` or `count:`). These resolve differently:
+Within the plan, a function name has three parts: a `base` name (e.g. `abs`), a type signature (prefixed with a colon, e.g. `abs:i64`), and anchor (prefixed with `#`, e.g. `#4`).
 
-- **Simple** (`add`): matches any registered function whose base name is `add`, regardless of type signature. Succeeds only if the base name is unambiguous (exactly one registered function has that base name).
-- **Full** (`add:i64_i64`, `count:`): exact match only — the written name must match the registered name exactly.
+Both type signature and anchor are separably optional if the reference is unambiguous; either or both may be required to make the reference unambiguous. A function name (base, signature if present, and anchor if present) must  to exactly one function named in the `Extensions` section.
 
-An `anchor` explicitly identifies which registered function is meant. When present:
-- A simple name validates that the anchor's registered name shares the same base.
-- A full name validates that the anchor's registered name matches exactly.
-
-The type signature and anchor are each optional, but either or both may be required to make the reference unambiguous.
+Where unambiguous, signature and anchor may both be left off (`abs($0)`), used separately (e.g. `abs:i64($0)`, `abs$4($0)`), or together for completeness (`abs:i64#4($0)`).
 
 #### Examples
 
 ```text
-add($0, $1)              // Simple: resolves if "add" is unambiguous
-add:i64_i64($0, $1)      // Full: resolves only if "add:i64_i64" is registered
-add#1($0, $1)            // Anchor: resolves anchor 1, validates base name "add"
-add:i64_i64#1($0, $1)    // Anchor + full name: exact consistency check
-count()                  // Simple: resolves if "count" base name is unambiguous
-count:()                 // Full: resolves only if "count:" is registered exactly
+// Simple: resolves if there is exactly one function named `add`
+add($0, $1)
+// Signature: resolves only if exactly one function named `add` is registered,
+// with signature `:i64_i64`
+add:i64_i64($0, $1)
+// Anchor: resolves if anchor 1 exists with base name `add`
+add#1($0, $1)            
+// Anchor + full name: resolves if anchor 1 exists with name `add` and 
+// signature `i64_i64`
+add:i64_i64#1($0, $1)
+// Simple: resolves if there is exactly one function named `count`
+count()
+// Signature: resolves if "count:" is registered exactly once with
+// signature "" (zero arguments)
+count:()
 ```
 
 ### Aggregate Measures

--- a/src/extensions/simple.rs
+++ b/src/extensions/simple.rs
@@ -1028,7 +1028,7 @@ Type Variations:
 
     #[test]
     fn test_resolve_function_with_anchor() {
-        // Explicit anchor: exact compound name, zero-arg base match, and mismatched name.
+        // Explicit anchor: exact compound name and mismatch errors.
         let exts = make_resolve_extensions();
 
         // Exact compound name matches stored name → resolves.
@@ -1038,12 +1038,6 @@ Type Variations:
                 .anchor,
             1
         );
-
-        // Zero-arg form "equal:" matches stored "equal:any_any" by base name → resolves.
-        assert_eq!(exts.resolve_function("equal:", Some(1)).unwrap().anchor, 1);
-
-        // No-sig form "add" matches stored "add:i64_i64" by base name when anchor is supplied.
-        assert_eq!(exts.resolve_function("add", Some(3)).unwrap().anchor, 3);
 
         // "add" (base "add") does not match stored "equal:any_any" (base "equal") → error.
         assert!(exts.resolve_function("add", Some(1)).is_err());
@@ -1056,11 +1050,24 @@ Type Variations:
     }
 
     #[test]
+    fn test_resolve_function_with_anchor_zero_arg() {
+        // Zero-arg form ("name:") with explicit anchor matches by base name.
+        let exts = make_resolve_extensions();
+        assert_eq!(exts.resolve_function("equal:", Some(1)).unwrap().anchor, 1);
+    }
+
+    #[test]
+    fn test_resolve_function_with_anchor_no_sig() {
+        // No-signature form ("name" without colon) with explicit anchor matches by base name.
+        let exts = make_resolve_extensions();
+        assert_eq!(exts.resolve_function("add", Some(3)).unwrap().anchor, 3);
+    }
+
+    #[test]
     fn test_resolve_function_without_anchor() {
-        // No anchor: exact compound, unique zero-arg (base fallback), and ambiguous base.
+        // No anchor: exact compound name resolution.
         let exts = make_resolve_extensions();
 
-        // Exact compound names resolve directly.
         assert_eq!(
             exts.resolve_function("equal:any_any", None).unwrap().anchor,
             1
@@ -1069,12 +1076,30 @@ Type Variations:
             exts.resolve_function("equal:str_str", None).unwrap().anchor,
             2
         );
+    }
 
-        // "add:" (zero-arg form) is the only overload → base-name fallback finds anchor 3.
+    #[test]
+    fn test_resolve_function_without_anchor_zero_arg() {
+        // Zero-arg form ("name:") without anchor: falls back to base-name search.
+        let exts = make_resolve_extensions();
+
+        // Unique base name → resolves.
         assert_eq!(exts.resolve_function("add:", None).unwrap().anchor, 3);
 
-        // "equal:" has two overloads → DuplicateName error.
+        // Ambiguous base name → error.
         assert!(exts.resolve_function("equal:", None).is_err());
+    }
+
+    #[test]
+    fn test_resolve_function_without_anchor_no_sig() {
+        // No-signature form ("name" without colon) without anchor: always uses base-name search.
+        let exts = make_resolve_extensions();
+
+        // Unique base name → resolves.
+        assert_eq!(exts.resolve_function("add", None).unwrap().anchor, 3);
+
+        // Ambiguous base name → error.
+        assert!(exts.resolve_function("equal", None).is_err());
     }
 
     #[test]

--- a/src/extensions/simple.rs
+++ b/src/extensions/simple.rs
@@ -82,11 +82,14 @@ pub enum InsertError {
     },
 }
 
-/// A Substrait compound function name, e.g. `"equal:any_any"` or `"add"`.
+/// A Substrait compound function name, e.g. `"equal:any_any"`, `"count:"`, or `"add"`.
 ///
-/// The name before the first `:` is the *base name*; the part after is the
-/// *type-signature suffix*.  For plain names with no `:` the base name is the
-/// full name and `has_signature` returns `false`.
+/// The name before the `:` is the *base name*; the part after is the
+/// *type-signature suffix* (empty for zero-argument functions like `"count:"`).
+/// Function compound names may or may not contain a `:`:
+/// - `"add"` — no type signature
+/// - `"count:"` — conventionally used for zero-argument functions
+/// - `"equal:any_any"` — colon with a type-signature suffix
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompoundName {
     /// Full name including the signature suffix, e.g. `"equal:any_any"`.
@@ -98,12 +101,6 @@ pub struct CompoundName {
 impl CompoundName {
     pub fn new(name: impl Into<String>) -> Self {
         let name = name.into();
-        // A trailing colon with no signature suffix (e.g. "count:") is
-        // normalized to the bare base name ("count") for textification.
-        let name = match name.strip_suffix(':') {
-            Some(base) => base.to_owned(),
-            None => name,
-        };
         let index = name.find(':').unwrap_or(name.len());
         Self { name, index }
     }
@@ -113,12 +110,22 @@ impl CompoundName {
         &self.name[..self.index]
     }
 
-    /// The full compound name, e.g. `"equal:any_any"`.
+    /// The full compound name, e.g. `"equal:any_any"` or `"count:"`.
     pub fn full(&self) -> &str {
         &self.name
     }
 
-    /// `true` when the name includes a signature suffix (contains `:`).
+    /// `true` when the name uses the zero-argument form: a colon with nothing
+    /// after it (e.g. `"count:"`). Distinct from no signature at all (`"count"`).
+    pub fn is_zero_arg(&self) -> bool {
+        self.index + 1 == self.name.len()
+    }
+
+    #[deprecated(
+        since = "0.7.0",
+        note = "use is_zero_arg() for the trailing-colon (zero-argument) form, \
+                or check !full().contains(':') for the no-colon form"
+    )]
     pub fn has_signature(&self) -> bool {
         self.index < self.name.len()
     }
@@ -285,13 +292,7 @@ impl SimpleExtensions {
                         pext::simple_extension_declaration::ExtensionFunction {
                             extension_urn_reference: *urn_ref,
                             function_anchor: *anchor,
-                            // Substrait compound names always include the colon
-                            // separator, even for zero-argument functions (e.g. "count:").
-                            name: if name.has_signature() {
-                                name.full().to_string()
-                            } else {
-                                format!("{}:", name.full())
-                            },
+                            name: name.full().to_string(),
                         },
                     ),
                     ExtensionKind::Type => MappingType::ExtensionType(
@@ -504,26 +505,35 @@ impl SimpleExtensions {
         })
     }
 
-    /// Resolve a function name (plain or compound) with an optional explicit
-    /// anchor to a [`ResolvedFunction`].
-    /// the caller has a text name and an optional anchor
-    /// from the plan source and needs the canonical anchor plus uniqueness info.
+    /// Resolve a [`CompoundName`] written in the plan to a [`ResolvedFunction`].
     ///
-    /// * `anchor = Some(a)` — validates that `name` matches the stored name
-    ///   (exact compound-name match **or** base-name match, e.g. `"equal"`
-    ///   matches stored `"equal:any_any"`).
-    /// * `anchor = None` — tries an exact match first; if not found and
-    ///   `name` contains no `:`, falls back to base-name search so that
-    ///   `equal(…)` resolves when `equal:any_any` is the only overload.
+    /// * `anchor = Some(a)` — the anchor identifies the function; the name is
+    ///   validated for consistency. An exact compound-name match is always
+    ///   accepted; no-signature and zero-argument forms also match on base name
+    ///   alone (the signature is redundant when an anchor is present).
+    /// * `anchor = None` — the name must be unambiguous on its own:
+    ///   - No signature: base-name search; fails if more than one function
+    ///     shares that base name.
+    ///   - Zero-argument: exact match first, then base-name fallback so that
+    ///     `add:()` resolves `add:i64_i64` when it is the only overload.
+    ///   - Full signature: exact match only.
     pub fn resolve_function(
         &self,
         name: &str,
         anchor: Option<u32>,
     ) -> Result<ResolvedFunction<'_>, MissingReference> {
-        let resolved_anchor = match anchor {
+        let lookup = CompoundName::new(name);
+        let no_signature = !lookup.full().contains(':');
+        // True for "add" (no signature) and "add:" (zero-argument) — the caller supplied
+        // no type signature, so when an anchor is present we accept a match on
+        // the function name alone ("add" or "add:" written, "add:i64_i64" stored).
+        let sig_optional = no_signature || lookup.is_zero_arg();
+        let resolved_anchor: u32 = match anchor {
             Some(a) => {
                 let (_, stored) = self.find_by_anchor(ExtensionKind::Function, a)?;
-                if stored.full() == name || stored.base() == name {
+                if stored.full() == lookup.full()
+                    || (sig_optional && stored.base() == lookup.base())
+                {
                     a
                 } else {
                     return Err(MissingReference::Mismatched(
@@ -533,13 +543,27 @@ impl SimpleExtensions {
                     ));
                 }
             }
-            None => match self.find_by_name(ExtensionKind::Function, name) {
-                Ok(a) => a,
-                Err(MissingReference::MissingName(_, _)) if !name.contains(':') => {
-                    self.find_by_base_name(ExtensionKind::Function, name)?
+            None => {
+                if no_signature {
+                    // No-colon form: always use base-name search so that both a
+                    // stored "add" (no colon) and a stored "add:i64_i64" (compact
+                    // display) resolve, and so that the presence of multiple
+                    // functions with the same base name is correctly reported as
+                    // ambiguous.
+                    self.find_by_base_name(ExtensionKind::Function, lookup.base())?
+                } else {
+                    // Has a colon: try exact compound-name match first.
+                    match self.find_by_name(ExtensionKind::Function, lookup.full()) {
+                        Ok(a) => a,
+                        // Empty-sig fallback: "add:" resolves "add:i64_i64" when
+                        // it is the only overload.
+                        Err(MissingReference::MissingName(_, _)) if lookup.is_zero_arg() => {
+                            self.find_by_base_name(ExtensionKind::Function, lookup.base())?
+                        }
+                        Err(e) => return Err(e),
+                    }
                 }
-                Err(e) => return Err(e),
-            },
+            }
         };
         self.lookup_function(resolved_anchor)
     }
@@ -895,15 +919,14 @@ Type Variations:
     }
 
     #[test]
-    fn test_compound_name_plain() {
-        let n = CompoundName::new("add");
-        assert_eq!(n.full(), "add");
+    fn test_compound_name_zero_arg() {
+        // The zero-argument form has a trailing colon and nothing after it.
+        let n = CompoundName::new("add:");
+        assert_eq!(n.full(), "add:");
         assert_eq!(n.base(), "add");
-        assert!(!n.has_signature());
-
-        let n2 = CompoundName::new("coalesce");
-        assert_eq!(n2.full(), "coalesce");
-        assert_eq!(n2.base(), "coalesce");
+        assert!(n.is_zero_arg());
+        // A name with a type signature is not the zero-argument form.
+        assert!(!CompoundName::new("add:i64_i64").is_zero_arg());
     }
 
     #[test]
@@ -911,24 +934,13 @@ Type Variations:
         let n = CompoundName::new("equal:any_any");
         assert_eq!(n.full(), "equal:any_any");
         assert_eq!(n.base(), "equal");
-        assert!(n.has_signature());
 
         let n2 = CompoundName::new("regexp_match_substring:str_str_i64");
         assert_eq!(n2.base(), "regexp_match_substring");
         assert_eq!(n2.full(), "regexp_match_substring:str_str_i64");
-        assert!(n2.has_signature());
 
         let n3 = CompoundName::new("add:i64_i64");
         assert_eq!(n3.base(), "add");
-    }
-
-    #[test]
-    fn test_compound_name_trailing_colon() {
-        // A trailing colon with no signature is normalized to the bare base name for textification.
-        let n = CompoundName::new("foo:");
-        assert_eq!(n.base(), "foo");
-        assert_eq!(n.full(), "foo");
-        assert!(!n.has_signature());
     }
 
     // ---- Tests for lookup_function ----
@@ -1016,7 +1028,7 @@ Type Variations:
 
     #[test]
     fn test_resolve_function_with_anchor() {
-        // Explicit anchor: exact compound name, base name, and mismatched name.
+        // Explicit anchor: exact compound name, zero-arg base match, and mismatched name.
         let exts = make_resolve_extensions();
 
         // Exact compound name matches stored name → resolves.
@@ -1027,16 +1039,25 @@ Type Variations:
             1
         );
 
-        // Base name "equal" matches stored "equal:any_any" → resolves.
-        assert_eq!(exts.resolve_function("equal", Some(1)).unwrap().anchor, 1);
+        // Zero-arg form "equal:" matches stored "equal:any_any" by base name → resolves.
+        assert_eq!(exts.resolve_function("equal:", Some(1)).unwrap().anchor, 1);
 
-        // "like" does not match stored "equal:any_any" → error.
-        assert!(exts.resolve_function("like", Some(1)).is_err());
+        // No-sig form "add" matches stored "add:i64_i64" by base name when anchor is supplied.
+        assert_eq!(exts.resolve_function("add", Some(3)).unwrap().anchor, 3);
+
+        // "add" (base "add") does not match stored "equal:any_any" (base "equal") → error.
+        assert!(exts.resolve_function("add", Some(1)).is_err());
+
+        // Same base name, different overload: "equal:any_any" against anchor 2 (equal:str_str) → error.
+        assert!(exts.resolve_function("equal:any_any", Some(2)).is_err());
+
+        // "like:" does not match stored "equal:any_any" → error.
+        assert!(exts.resolve_function("like:", Some(1)).is_err());
     }
 
     #[test]
     fn test_resolve_function_without_anchor() {
-        // No anchor: exact compound, unique base (fallback), and ambiguous base.
+        // No anchor: exact compound, unique zero-arg (base fallback), and ambiguous base.
         let exts = make_resolve_extensions();
 
         // Exact compound names resolve directly.
@@ -1049,11 +1070,11 @@ Type Variations:
             2
         );
 
-        // "add" is the only overload → base-name fallback finds anchor 3.
-        assert_eq!(exts.resolve_function("add", None).unwrap().anchor, 3);
+        // "add:" (zero-arg form) is the only overload → base-name fallback finds anchor 3.
+        assert_eq!(exts.resolve_function("add:", None).unwrap().anchor, 3);
 
-        // "equal" has two overloads → DuplicateName error.
-        assert!(exts.resolve_function("equal", None).is_err());
+        // "equal:" has two overloads → DuplicateName error.
+        assert!(exts.resolve_function("equal:", None).is_err());
     }
 
     #[test]

--- a/src/extensions/simple.rs
+++ b/src/extensions/simple.rs
@@ -122,7 +122,7 @@ impl CompoundName {
     }
 
     #[deprecated(
-        since = "0.7.0",
+        since = "0.6.0",
         note = "use is_zero_arg() for the trailing-colon (zero-argument) form, \
                 or check !full().contains(':') for the no-colon form"
     )]

--- a/src/extensions/simple.rs
+++ b/src/extensions/simple.rs
@@ -84,12 +84,10 @@ pub enum InsertError {
 
 /// A Substrait compound function name, e.g. `"equal:any_any"`, `"count:"`, or `"add"`.
 ///
-/// The name before the `:` is the *base name*; the part after is the
-/// *type-signature suffix* (empty for zero-argument functions like `"count:"`).
-/// Function compound names may or may not contain a `:`:
-/// - `"add"` — no type signature
-/// - `"count:"` — conventionally used for zero-argument functions
-/// - `"equal:any_any"` — colon with a type-signature suffix
+/// A name is either *simple* (no `:`, e.g. `"add"`) or *full* (has a `:`,
+/// e.g. `"count:"` or `"equal:any_any"`). The part after the `:` is the
+/// type-signature suffix, which encodes the argument types (`"i64_i64"`) or
+/// zero argument types (`"count:"`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompoundName {
     /// Full name including the signature suffix, e.g. `"equal:any_any"`.
@@ -115,19 +113,16 @@ impl CompoundName {
         &self.name
     }
 
-    /// `true` when the name uses the zero-argument form: a colon with nothing
-    /// after it (e.g. `"count:"`). Distinct from no signature at all (`"count"`).
-    pub fn is_zero_arg(&self) -> bool {
-        self.index + 1 == self.name.len()
-    }
-
-    #[deprecated(
-        since = "0.7.0",
-        note = "use is_zero_arg() for the trailing-colon (zero-argument) form, \
-                or check !full().contains(':') for the no-colon form"
-    )]
-    pub fn has_signature(&self) -> bool {
-        self.index < self.name.len()
+    /// Returns `true` if `self` (a stored name) is matched by `pattern` (a written name).
+    ///
+    /// - Simple pattern (no `:`): matches any stored name with the same base.
+    /// - Full pattern (has `:`): exact match only.
+    pub fn matches(&self, pattern: &str) -> bool {
+        if pattern.contains(':') {
+            self.full() == pattern
+        } else {
+            self.base() == pattern
+        }
     }
 }
 
@@ -508,32 +503,20 @@ impl SimpleExtensions {
     /// Resolve a [`CompoundName`] written in the plan to a [`ResolvedFunction`].
     ///
     /// * `anchor = Some(a)` — the anchor identifies the function; the name is
-    ///   validated for consistency. An exact compound-name match is always
-    ///   accepted; no-signature and zero-argument forms also match on base name
-    ///   alone (the signature is redundant when an anchor is present).
+    ///   validated for consistency using [`CompoundName::matches`].
     /// * `anchor = None` — the name must be unambiguous on its own:
-    ///   - No signature: base-name search; fails if more than one function
+    ///   - Simple (no `:`): base-name search; fails if more than one function
     ///     shares that base name.
-    ///   - Zero-argument: exact match first, then base-name fallback so that
-    ///     `add:()` resolves `add:i64_i64` when it is the only overload.
-    ///   - Full signature: exact match only.
+    ///   - Full (has `:`): exact match only.
     pub fn resolve_function(
         &self,
         name: &str,
         anchor: Option<u32>,
     ) -> Result<ResolvedFunction<'_>, MissingReference> {
-        let lookup = CompoundName::new(name);
-        let no_signature = !lookup.full().contains(':');
-        // True for "add" (no signature) and "add:" (zero-argument) — the caller supplied
-        // no type signature, so when an anchor is present we accept a match on
-        // the function name alone ("add" or "add:" written, "add:i64_i64" stored).
-        let sig_optional = no_signature || lookup.is_zero_arg();
         let resolved_anchor: u32 = match anchor {
             Some(a) => {
                 let (_, stored) = self.find_by_anchor(ExtensionKind::Function, a)?;
-                if stored.full() == lookup.full()
-                    || (sig_optional && stored.base() == lookup.base())
-                {
+                if stored.matches(name) {
                     a
                 } else {
                     return Err(MissingReference::Mismatched(
@@ -544,24 +527,10 @@ impl SimpleExtensions {
                 }
             }
             None => {
-                if no_signature {
-                    // No-colon form: always use base-name search so that both a
-                    // stored "add" (no colon) and a stored "add:i64_i64" (compact
-                    // display) resolve, and so that the presence of multiple
-                    // functions with the same base name is correctly reported as
-                    // ambiguous.
-                    self.find_by_base_name(ExtensionKind::Function, lookup.base())?
+                if name.contains(':') {
+                    self.find_by_name(ExtensionKind::Function, name)?
                 } else {
-                    // Has a colon: try exact compound-name match first.
-                    match self.find_by_name(ExtensionKind::Function, lookup.full()) {
-                        Ok(a) => a,
-                        // Empty-sig fallback: "add:" resolves "add:i64_i64" when
-                        // it is the only overload.
-                        Err(MissingReference::MissingName(_, _)) if lookup.is_zero_arg() => {
-                            self.find_by_base_name(ExtensionKind::Function, lookup.base())?
-                        }
-                        Err(e) => return Err(e),
-                    }
+                    self.find_by_base_name(ExtensionKind::Function, name)?
                 }
             }
         };
@@ -588,7 +557,7 @@ impl SimpleExtensions {
         let mut matches = self
             .extensions
             .iter()
-            .filter(|&(&(_a, k), (_, n))| k == kind && n.base() == base)
+            .filter(|&(&(_a, k), (_, n))| k == kind && n.matches(base))
             .map(|(&(anchor, _), _)| anchor);
 
         let anchor = matches
@@ -919,14 +888,16 @@ Type Variations:
     }
 
     #[test]
-    fn test_compound_name_zero_arg() {
-        // The zero-argument form has a trailing colon and nothing after it.
+    fn test_compound_name_full_zero_arg_type_signature() {
+        // A Full name whose type signature encodes zero argument types (nothing after the colon).
         let n = CompoundName::new("add:");
         assert_eq!(n.full(), "add:");
         assert_eq!(n.base(), "add");
-        assert!(n.is_zero_arg());
-        // A name with a type signature is not the zero-argument form.
-        assert!(!CompoundName::new("add:i64_i64").is_zero_arg());
+        // Full pattern: exact match only.
+        assert!(n.matches("add:"));
+        assert!(!n.matches("add:i64_i64"));
+        // Simple pattern: base match.
+        assert!(n.matches("add"));
     }
 
     #[test]
@@ -1016,12 +987,12 @@ Type Variations:
     // ---- Tests for resolve_function ----
 
     fn make_resolve_extensions() -> SimpleExtensions {
-        // Mirrors the fixture used in the old parser/types.rs tests.
         let urns = vec![new_urn(1, "test_urn")];
         let extensions = vec![
             new_ext_fn(1, 1, "equal:any_any"),
             new_ext_fn(2, 1, "equal:str_str"),
             new_ext_fn(3, 1, "add:i64_i64"),
+            new_ext_fn(4, 1, "add:"),
         ];
         unwrap_new_extensions(&urns, &extensions)
     }
@@ -1039,28 +1010,18 @@ Type Variations:
             1
         );
 
-        // "add" (base "add") does not match stored "equal:any_any" (base "equal") → error.
+        // Simple (no-sig) form matches any stored name with the same base.
+        assert_eq!(exts.resolve_function("add", Some(3)).unwrap().anchor, 3);
+        assert_eq!(exts.resolve_function("add", Some(4)).unwrap().anchor, 4);
+
+        // Full form requires exact match — "add:" does not match anchor 3 (stored "add:i64_i64").
+        assert!(exts.resolve_function("add:", Some(3)).is_err());
+
+        // "add" does not match stored "equal:any_any" (different base) → error.
         assert!(exts.resolve_function("add", Some(1)).is_err());
 
-        // Same base name, different overload: "equal:any_any" against anchor 2 (equal:str_str) → error.
+        // Same base name, different overload → error.
         assert!(exts.resolve_function("equal:any_any", Some(2)).is_err());
-
-        // "like:" does not match stored "equal:any_any" → error.
-        assert!(exts.resolve_function("like:", Some(1)).is_err());
-    }
-
-    #[test]
-    fn test_resolve_function_with_anchor_zero_arg() {
-        // Zero-arg form ("name:") with explicit anchor matches by base name.
-        let exts = make_resolve_extensions();
-        assert_eq!(exts.resolve_function("equal:", Some(1)).unwrap().anchor, 1);
-    }
-
-    #[test]
-    fn test_resolve_function_with_anchor_no_sig() {
-        // No-signature form ("name" without colon) with explicit anchor matches by base name.
-        let exts = make_resolve_extensions();
-        assert_eq!(exts.resolve_function("add", Some(3)).unwrap().anchor, 3);
     }
 
     #[test]
@@ -1079,26 +1040,27 @@ Type Variations:
     }
 
     #[test]
-    fn test_resolve_function_without_anchor_zero_arg() {
-        // Zero-arg form ("name:") without anchor: falls back to base-name search.
+    fn test_resolve_function_without_anchor_full_sig() {
+        // Full form (has colon) resolves by exact match only — no fallback.
         let exts = make_resolve_extensions();
 
-        // Unique base name → resolves.
-        assert_eq!(exts.resolve_function("add:", None).unwrap().anchor, 3);
+        assert_eq!(exts.resolve_function("add:", None).unwrap().anchor, 4);
+        assert_eq!(
+            exts.resolve_function("add:i64_i64", None).unwrap().anchor,
+            3
+        );
 
-        // Ambiguous base name → error.
+        // "equal:" is not registered → error (no fallback to base-name search).
         assert!(exts.resolve_function("equal:", None).is_err());
     }
 
     #[test]
     fn test_resolve_function_without_anchor_no_sig() {
-        // No-signature form ("name" without colon) without anchor: always uses base-name search.
+        // No-signature form (no colon) without anchor: base-name search.
         let exts = make_resolve_extensions();
 
-        // Unique base name → resolves.
-        assert_eq!(exts.resolve_function("add", None).unwrap().anchor, 3);
-
         // Ambiguous base name → error.
+        assert!(exts.resolve_function("add", None).is_err());
         assert!(exts.resolve_function("equal", None).is_err());
     }
 

--- a/src/extensions/simple.rs
+++ b/src/extensions/simple.rs
@@ -98,6 +98,12 @@ pub struct CompoundName {
 impl CompoundName {
     pub fn new(name: impl Into<String>) -> Self {
         let name = name.into();
+        // A trailing colon with no signature suffix (e.g. "count:") is
+        // normalized to the bare base name ("count") for textification.
+        let name = match name.strip_suffix(':') {
+            Some(base) => base.to_owned(),
+            None => name,
+        };
         let index = name.find(':').unwrap_or(name.len());
         Self { name, index }
     }
@@ -279,7 +285,13 @@ impl SimpleExtensions {
                         pext::simple_extension_declaration::ExtensionFunction {
                             extension_urn_reference: *urn_ref,
                             function_anchor: *anchor,
-                            name: name.full().to_string(),
+                            // Substrait compound names always include the colon
+                            // separator, even for zero-argument functions (e.g. "count:").
+                            name: if name.has_signature() {
+                                name.full().to_string()
+                            } else {
+                                format!("{}:", name.full())
+                            },
                         },
                     ),
                     ExtensionKind::Type => MappingType::ExtensionType(
@@ -912,11 +924,11 @@ Type Variations:
 
     #[test]
     fn test_compound_name_trailing_colon() {
-        // Edge case: trailing colon → empty signature suffix, base is the prefix
+        // A trailing colon with no signature is normalized to the bare base name for textification.
         let n = CompoundName::new("foo:");
         assert_eq!(n.base(), "foo");
-        assert_eq!(n.full(), "foo:");
-        assert!(n.has_signature());
+        assert_eq!(n.full(), "foo");
+        assert!(!n.has_signature());
     }
 
     // ---- Tests for lookup_function ----

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -32,10 +32,13 @@ quoted_name = @{
 name = { identifier | quoted_name }
 
 // A compound name is a Substrait function compound name: base identifier followed by an optional
-// colon-delimited signature (e.g. "equal:any_any", "regexp_match_substring:str_str_i64").
+// colon-delimited signature (e.g. "equal:any_any", "count:").
+// The signature after the colon is an optional identifier: present for "equal:any_any", absent
+// for the zero-argument form "count:". Using identifier? (not identifier+) allows the trailing
+// colon with nothing after it, while keeping the same character constraints as the base name.
 // The rule is atomic so no whitespace is allowed around the colon, making it unambiguous
 // with the output-type annotation which always follows the closing parenthesis.
-compound_name = @{ identifier ~ (":" ~ identifier)? }
+compound_name = @{ identifier ~ (":" ~ identifier?)? }
 
 // Expression Components
 // Field reference
@@ -166,7 +169,7 @@ cast_failure_behavior = { "?" | "!" }
 cast_expression = { "(" ~ sp ~ expression ~ sp ~ ")" ~ sp ~ "::" ~ sp ~ cast_failure_behavior? ~ sp ~ type }
 
 // Top-level Expression Rule
-// Order matters for PEGs: Since an identifer can be a function call, we put that first.
+// Order matters for PEGs: Since an identifier can be a function call, we put that first.
 // cast_expression must come before literal/function_call since it starts with "("
 expression = { if_then | cast_expression | function_call | reference | literal }
 

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -1127,6 +1127,7 @@ mod tests {
 
     #[test]
     fn test_compound_name_plain() {
+        // The grammar accepts a bare identifier (compact display form); stored as-is.
         assert_eq!(parse_compound_name("add").full(), "add");
     }
 

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -1131,13 +1131,14 @@ mod tests {
     }
 
     #[test]
-    fn test_compound_name_zero_arg() {
-        // The zero-argument form has a trailing colon and nothing after it.
+    fn test_compound_name_full_zero_arg_type_signature() {
+        // A Full name whose type signature encodes zero argument types (nothing after the colon).
         let n = parse_compound_name("add:");
         assert_eq!(n.full(), "add:");
         assert_eq!(n.base(), "add");
-        assert!(n.is_zero_arg());
-        assert!(!parse_compound_name("add:i64_i64").is_zero_arg());
+        assert!(n.matches("add:"));
+        assert!(!n.matches("add:i64_i64"));
+        assert!(n.matches("add"));
     }
 
     #[test]

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -1127,8 +1127,17 @@ mod tests {
 
     #[test]
     fn test_compound_name_plain() {
-        // The grammar accepts a bare identifier (compact display form); stored as-is.
         assert_eq!(parse_compound_name("add").full(), "add");
+    }
+
+    #[test]
+    fn test_compound_name_zero_arg() {
+        // The zero-argument form has a trailing colon and nothing after it.
+        let n = parse_compound_name("add:");
+        assert_eq!(n.full(), "add:");
+        assert_eq!(n.base(), "add");
+        assert!(n.is_zero_arg());
+        assert!(!parse_compound_name("add:i64_i64").is_zero_arg());
     }
 
     #[test]

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -1281,7 +1281,7 @@ Project[$0, $1, 42, 84]
             Some(MappingType::ExtensionFunction(f)) => {
                 assert_eq!(f.function_anchor, 10);
                 assert_eq!(f.extension_urn_reference, 1);
-                assert_eq!(f.name, "func_a");
+                assert_eq!(f.name, "func_a:");
             }
             other => panic!("Expected ExtensionFunction, got {other:?}"),
         }
@@ -1291,7 +1291,7 @@ Project[$0, $1, 42, 84]
             Some(MappingType::ExtensionFunction(f)) => {
                 assert_eq!(f.function_anchor, 11);
                 assert_eq!(f.extension_urn_reference, 2);
-                assert_eq!(f.name, "func_b_special");
+                assert_eq!(f.name, "func_b_special:");
             }
             other => panic!("Expected ExtensionFunction, got {other:?}"),
         }

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -1281,7 +1281,7 @@ Project[$0, $1, 42, 84]
             Some(MappingType::ExtensionFunction(f)) => {
                 assert_eq!(f.function_anchor, 10);
                 assert_eq!(f.extension_urn_reference, 1);
-                assert_eq!(f.name, "func_a:");
+                assert_eq!(f.name, "func_a");
             }
             other => panic!("Expected ExtensionFunction, got {other:?}"),
         }
@@ -1291,7 +1291,7 @@ Project[$0, $1, 42, 84]
             Some(MappingType::ExtensionFunction(f)) => {
                 assert_eq!(f.function_anchor, 11);
                 assert_eq!(f.extension_urn_reference, 2);
-                assert_eq!(f.name, "func_b_special:");
+                assert_eq!(f.name, "func_b_special");
             }
             other => panic!("Expected ExtensionFunction, got {other:?}"),
         }

--- a/src/textify/types.rs
+++ b/src/textify/types.rs
@@ -126,7 +126,7 @@ impl Textify for Anchor {
 
 #[derive(Debug, Copy, Clone)]
 pub struct NamedAnchor<'a> {
-    /// The full stored compound name, e.g. `"equal:any_any"` or `"add"`.
+    /// The full stored compound name, e.g. `"equal:any_any"` or `"count:"`.
     pub name: MaybeToken<&'a CompoundName>,
     pub anchor: u32,
     /// True if the compound name is unique across all URNs for this extension
@@ -198,7 +198,9 @@ impl<'a> Textify for NamedAnchor<'a> {
 
         match &self.name.0 {
             Ok(n) => {
-                if show_signature {
+                // Zero-arg functions use the "count:" form — always write full() so
+                // the trailing colon is preserved and round-trips correctly.
+                if show_signature || n.is_zero_arg() {
                     write!(w, "{}", n.full())?;
                 } else {
                     write!(w, "{}", n.base())?;
@@ -207,7 +209,18 @@ impl<'a> Textify for NamedAnchor<'a> {
             Err(e) => write!(w, "{e}")?,
         }
 
-        let anchor = Anchor::new(self.anchor, !self.unique);
+        // Show the anchor when:
+        // - The compound name is not unique (another URN uses the same name), OR
+        // - The compound name has no colon (no-sig form like "add") and the base
+        //   name is not unique — without an anchor the written token is
+        //   indistinguishable from the compact display of other "add:*" functions
+        //   and would be parsed as an ambiguous base-name lookup.
+        let needs_anchor = !self.unique
+            || match &self.name.0 {
+                Ok(n) if !n.full().contains(':') => !self.base_name_unique,
+                _ => false,
+            };
+        let anchor = Anchor::new(self.anchor, needs_anchor);
         write!(w, "{}", ctx.display(&anchor))
     }
 }
@@ -1026,6 +1039,40 @@ mod tests {
 
         let s = ctx.textify_no_errors(&na);
         assert_eq!(s, "equal:any_any#1");
+    }
+
+    #[test]
+    fn named_anchor_zero_arg_compact_unique_shows_trailing_colon() {
+        // Zero-arg "count:" is the only function with base "count".
+        // Compact mode: trailing colon is preserved; base name unique → no anchor.
+        let ctx = TestContext::new()
+            .with_urn(1, "urn")
+            .with_function(1, 5, "count:");
+
+        let eq = crate::textify::ErrorQueue::default();
+        let scope = ctx.scope(&eq);
+        let na = NamedAnchor::lookup(&scope, ExtensionKind::Function, 5);
+        assert!(na.base_name_unique);
+        assert!(na.unique);
+
+        let s = ctx.textify_no_errors(&na);
+        assert_eq!(s, "count:");
+    }
+
+    #[test]
+    fn named_anchor_verbose_zero_arg_shows_trailing_colon_and_anchor() {
+        // Verbose mode: zero-arg "count:" always writes full() (trailing colon preserved) + anchor.
+        let mut ctx = TestContext::new()
+            .with_urn(1, "urn")
+            .with_function(1, 5, "count:");
+        ctx.options.show_simple_extension_anchors = Visibility::Always;
+
+        let eq = crate::textify::ErrorQueue::default();
+        let scope = ctx.scope(&eq);
+        let na = NamedAnchor::lookup(&scope, ExtensionKind::Function, 5);
+
+        let s = ctx.textify_no_errors(&na);
+        assert_eq!(s, "count:#5");
     }
 
     #[test]

--- a/src/textify/types.rs
+++ b/src/textify/types.rs
@@ -198,9 +198,7 @@ impl<'a> Textify for NamedAnchor<'a> {
 
         match &self.name.0 {
             Ok(n) => {
-                // Zero-arg functions use the "count:" form — always write full() so
-                // the trailing colon is preserved and round-trips correctly.
-                if show_signature || n.is_zero_arg() {
+                if show_signature {
                     write!(w, "{}", n.full())?;
                 } else {
                     write!(w, "{}", n.base())?;
@@ -211,10 +209,9 @@ impl<'a> Textify for NamedAnchor<'a> {
 
         // Show the anchor when:
         // - The compound name is not unique (another URN uses the same name), OR
-        // - The compound name has no colon (no-sig form like "add") and the base
-        //   name is not unique — without an anchor the written token is
-        //   indistinguishable from the compact display of other "add:*" functions
-        //   and would be parsed as an ambiguous base-name lookup.
+        // - The name is simple (no colon, e.g. "add") and the base name is not
+        //   unique — without an anchor, "add" would be parsed as a base-name
+        //   lookup and fail as ambiguous.
         let needs_anchor = !self.unique
             || match &self.name.0 {
                 Ok(n) if !n.full().contains(':') => !self.base_name_unique,
@@ -1042,9 +1039,11 @@ mod tests {
     }
 
     #[test]
-    fn named_anchor_zero_arg_compact_unique_shows_trailing_colon() {
-        // Zero-arg "count:" is the only function with base "count".
-        // Compact mode: trailing colon is preserved; base name unique → no anchor.
+    fn named_anchor_compact_unique_full_name_zero_arg_type_signature() {
+        // "count:" is the only function with base "count".
+        // Compact mode: base name unique → write base name only, no anchor.
+        // "count:" and "count:i64" are not conceptually different;
+        // both write just the base name when unambiguous.
         let ctx = TestContext::new()
             .with_urn(1, "urn")
             .with_function(1, 5, "count:");
@@ -1056,12 +1055,12 @@ mod tests {
         assert!(na.unique);
 
         let s = ctx.textify_no_errors(&na);
-        assert_eq!(s, "count:");
+        assert_eq!(s, "count");
     }
 
     #[test]
-    fn named_anchor_verbose_zero_arg_shows_trailing_colon_and_anchor() {
-        // Verbose mode: zero-arg "count:" always writes full() (trailing colon preserved) + anchor.
+    fn named_anchor_verbose_full_name_shows_signature_and_anchor() {
+        // Verbose mode: always writes full() + anchor.
         let mut ctx = TestContext::new()
             .with_urn(1, "urn")
             .with_function(1, 5, "count:");

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -242,7 +242,7 @@ Root[a, b]
 }
 
 #[test]
-fn test_zero_arg_function_roundtrip() {
+fn test_full_name_zero_arg_type_signature_roundtrip() {
     let plan = r#"=== Extensions
 URNs:
   @  1: extension:io.substrait:functions_aggregate_generic
@@ -251,7 +251,7 @@ Functions:
 
 === Plan
 Root[n]
-  Project[count:()]
+  Project[count()]
     Read[events => n:i64]"#;
     roundtrip_plan(plan);
 }
@@ -292,9 +292,9 @@ Root[result]
     assert!(Parser::parse(plan).is_err());
 }
 
-/// `add` (no-signature) and `add:` (zero-argument) registered under the same
-/// URN.  The zero-argument form is unambiguous so it needs no anchor; the
-/// no-signature form requires an anchor because the base name `add` is shared.
+/// `add` (simple) and `add:` (full, zero-argument type signature) registered under the same
+/// URN. `add:` is unambiguous so it needs no anchor; `add` requires an anchor
+/// because the base name is shared.
 #[test]
 fn test_no_sig_and_zero_arg_disambiguate_without_anchor() {
     let plan = r#"=== Extensions
@@ -311,7 +311,7 @@ Root[result]
     roundtrip_plan(plan);
 }
 
-/// `add` (no-sig) from one URN and `add:` (zero-arg) from two different URNs.
+/// `add` (simple) from one URN and `add:` (full, zero-argument type signature) from two different URNs.
 /// The compound name `add:` is no longer unique, so all three functions require
 /// an anchor in the plan text.
 #[test]

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -242,6 +242,97 @@ Root[a, b]
 }
 
 #[test]
+fn test_zero_arg_function_roundtrip() {
+    let plan = r#"=== Extensions
+URNs:
+  @  1: extension:io.substrait:functions_aggregate_generic
+Functions:
+  #  1 @  1: count:
+
+=== Plan
+Root[n]
+  Project[count:()]
+    Read[events => n:i64]"#;
+    roundtrip_plan(plan);
+}
+
+/// One no-signature `add` registration — base name is unique so the function
+/// is written without an anchor or type signature in compact mode.
+#[test]
+fn test_no_sig_function_unique_no_anchor() {
+    let plan = r#"=== Extensions
+URNs:
+  @  1: urn:substrait:vendor_a
+Functions:
+  #  1 @  1: add
+
+=== Plan
+Root[result]
+  Project[$0, $1, add($0, $1)]
+    Read[t => a:i64, b:i64]"#;
+    roundtrip_plan(plan);
+}
+
+/// `add` and `add:` share the base name, so `add(…)` (no colon, no anchor)
+/// is ambiguous and must be rejected.
+#[test]
+fn test_ambiguous_base_name_fails() {
+    let plan = r#"=== Extensions
+URNs:
+  @  1: urn:substrait:vendor_a
+Functions:
+  #  1 @  1: add
+  #  2 @  1: add:
+
+=== Plan
+Root[result]
+  Project[add($0, $1)]
+    Read[t => a:i64, b:i64]"#;
+
+    assert!(Parser::parse(plan).is_err());
+}
+
+/// `add` (no-signature) and `add:` (zero-argument) registered under the same
+/// URN.  The zero-argument form is unambiguous so it needs no anchor; the
+/// no-signature form requires an anchor because the base name `add` is shared.
+#[test]
+fn test_no_sig_and_zero_arg_disambiguate_without_anchor() {
+    let plan = r#"=== Extensions
+URNs:
+  @  1: urn:substrait:vendor_a
+Functions:
+  #  1 @  1: add
+  #  2 @  1: add:
+
+=== Plan
+Root[result]
+  Project[$0, $1, add#1($0, $1), add:($0, $1)]
+    Read[t => a:i64, b:i64]"#;
+    roundtrip_plan(plan);
+}
+
+/// `add` (no-sig) from one URN and `add:` (zero-arg) from two different URNs.
+/// The compound name `add:` is no longer unique, so all three functions require
+/// an anchor in the plan text.
+#[test]
+fn test_three_add_variants_all_require_anchors() {
+    let plan = r#"=== Extensions
+URNs:
+  @  1: urn:substrait:vendor_a
+  @  2: urn:substrait:vendor_b
+Functions:
+  #  1 @  1: add
+  #  2 @  1: add:
+  #  3 @  2: add:
+
+=== Plan
+Root[result]
+  Project[$0, $1, add#1($0, $1), add:#2($0, $1), add:#3($0, $1)]
+    Read[t => a:i64, b:i64]"#;
+    roundtrip_plan(plan);
+}
+
+#[test]
 fn test_join_relation_roundtrip() {
     let plan = r#"=== Extensions
 URNs:


### PR DESCRIPTION
## Description

Substrait encodes function names in extension declarations as compound names — a base name and a type-signature suffix joined by a colon (e.g. "add:i64_i64"). For zero-argument functions, the signature is empty, so the proto contains a trailing colon with nothing after it: "count:".

This form was not roundtrippable through the text format:

1. Proto → text: the text formatter wrote count: verbatim into the Extensions section
2. Text → proto: the grammar's compound_name rule requires an identifier after the colon, so count: failed to parse

We also wanted to retain support for functions without a signature(no colon to declare the list of arguments). 

## Type of Change

- [x] Bug fix

## Testing

- [x] Added tests for new functionality
- [x] All existing tests pass

## Related Issues
Closes #144
