### PR TITLE
fix: require output type on scalar and aggregate function calls

### DIFF
--- a/API.md
+++ b/API.md
@@ -33,7 +33,7 @@ Functions:
   ## 10 @  1: add
 
 === Plan
-Project[$0, $1, add($0, $1)]
+Project[$0, $1, add($0, $1):i32?]
   Read[table1 => col1:i32?, col2:i32?]
 "#;
 
@@ -240,8 +240,8 @@ Functions:
   # 12 @  2: count
 === Plan
 Root[result]
-  Aggregate[$0 => $0, sum($1), count($1)]
-    Project[$0, add($1, $2)]
+  Aggregate[$0 => $0, sum($1):i32?, count($1):i64]
+    Project[$0, add($1, $2):i32?]
       Read[table1 => category:string, col1:i32?, col2:i32?]
 ```
 
@@ -258,7 +258,7 @@ Each relation is displayed on a single line with the format:
 
 - **Field references**: `$0`, `$1`, etc.
 - **Literals**: `42`, `'hello'`, `true`
-- **Function calls**: `add($0, $1)`, `sum($2)` (scalar and aggregate functions)
+- **Function calls**: `add($0, $1):i64`, `sum($2):i64`
 - **Types**: `i32`, `string?`, `list<i64>`
 
 ## Configuration Options

--- a/API.md
+++ b/API.md
@@ -338,7 +338,6 @@ cat plan.substrait | substrait-explain convert -f text -t json > plan.json
 - `-i, --input <FILE>` - Input file (default: stdin)
 - `-o, --output <FILE>` - Output file (default: stdout)
 - `--show-literal-types` - Show type annotations on literals
-- `--show-expression-types` - Show type annotations on expressions
 - `--verbose` - Show detailed progress information
 
 #### Validate Command
@@ -370,7 +369,7 @@ substrait-explain validate -i example-plans/basic.substrait
 substrait-explain validate -i example-plans/simple.substrait
 
 # Convert with verbose output and type information
-substrait-explain convert -f text -t json --show-literal-types --show-expression-types --verbose -i example-plans/basic.substrait
+substrait-explain convert -f text -t json --show-literal-types --verbose -i example-plans/basic.substrait
 
 # Roundtrip test: text → protobuf → text
 substrait-explain convert -f text -t protobuf -i plan.substrait -o plan.pb

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -76,7 +76,7 @@ Functions:
 
 === Plan
 Root[result]
-  Project[$0, $1, add($0, $1)]
+  Project[$0, $1, add($0, $1):i64]
     Read[orders => quantity:i32?, price:i64]
 # "#;
 #
@@ -138,7 +138,7 @@ Functions:
 === Plan
 Root[result]                   // Level 0 (no indentation)
   Project[$0, $1]              // Level 1 (2 spaces)
-    Filter[gt($0, 10) => $0]   // Level 2 (4 spaces)
+    Filter[gt($0, 10):boolean => $0]   // Level 2 (4 spaces)
       Read[data => a:i64]      // Level 3 (6 spaces)
 # "#;
 #
@@ -334,8 +334,8 @@ Root[result]
 ### Examples
 
 ```text
-add($3, 10)            // Simple function call
-add#10@2(#3, 10):int   // Function call with anchors and type
+add($3, 10):i64              // Simple function call with required output type
+add#10@2($3, 10):i64         // Function call with anchors and output type
 ```
 
 ### Field References
@@ -366,7 +366,7 @@ Root[result]
 
 #### Syntax
 
-`function_call := name anchor? urn_anchor? "(" (expression ("," expression)*)? ")" (":" type)?`
+`function_call := name anchor? urn_anchor? "(" (expression ("," expression)*)? ")" ":" type`
 
 #### Components
 
@@ -374,7 +374,7 @@ Root[result]
 - `anchor` - optional anchor (e.g., `#10`)
 - `urn_anchor` - optional URN anchor (e.g., `@1`)
 - `expression` - as above
-- `type` - optional output type
+- `type` - required output type
 
 ### Aggregate Measures
 
@@ -382,13 +382,13 @@ Aggregate measures are used in the output of Aggregate relations. They can be ei
 
 #### Syntax
 
-- `aggregate_measure := name anchor? urn_anchor? "(" expression ")" (":" type)?` - aggregate function call with optional extension anchors and output type
+- `aggregate_measure := name anchor? urn_anchor? "(" expression ")" ":" type` - aggregate function call with optional extension anchors and required output type
 - Field references: `$0`, `$1`, ...
 
 #### Examples
 
-- `sum($2)`
-- `count($1)`
+- `sum($2):i64`
+- `count($1):i64`
 - `avg($3):fp64`
 - `$0` (field reference to grouping field)
 
@@ -678,7 +678,7 @@ Functions:
 
 === Plan
 Root[result]
-  Filter[gt($2, 100) => $0, $1, $2]
+  Filter[gt($2, 100):boolean => $0, $1, $2]
     Project[$0, $1, $2]
       Read[data => a:i64, b:string, c:i32]
 # "#;
@@ -742,7 +742,7 @@ Functions:
 
 === Plan
 Root[result]
-  Aggregate[($0), ($0, $1) => $0, $1, sum($2), count($2)]           // Group by field 0, and ($0, $1)
+  Aggregate[($0), ($0, $1) => $0, $1, sum($2):i64, count($2):i64]           // Group by field 0, and ($0, $1)
     Read[orders => category:string, region:string?,  amount:i64]
 # "#;
 #
@@ -802,7 +802,7 @@ Functions:
 
 === Plan
 Root[user_orders]
-  Join[&Inner, eq($0, $2) => $0, $1, $3]
+  Join[&Inner, eq($0, $2):boolean => $0, $1, $3]
     Read[users => id:i64, name:string]        // Fields $0, $1
     Read[orders => user_id:i64, amount:i32]   // Fields $2, $3
 # "#;
@@ -1030,10 +1030,10 @@ Functions:
 
 === Plan
 Root[customer_revenue]
-  Aggregate[$0, $1 => $0, $1, sum($3)]
-    Filter[gt($3, 100) => $0, $1, $2, $3]
-      Project[$0, $1, $2, multiply($4, $5)]
-        Join[&Inner, eq($0, $3) => $0, $1, $2, $3, $4, $5]
+  Aggregate[$0, $1 => $0, $1, sum($3):i64]
+    Filter[gt($3, 100):boolean => $0, $1, $2, $3]
+      Project[$0, $1, $2, multiply($4, $5):i64]
+        Join[&Inner, eq($0, $3):boolean => $0, $1, $2, $3, $4, $5]
           Read[users => id:i64, name:string, region:string]
           Read[orders => user_id:i64, quantity:i32, price:i64]
 # "#;

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -366,7 +366,7 @@ Root[result]
 
 #### Syntax
 
-`function_call := compound_name anchor? urn_anchor? "(" (expression ("," expression)*)? ")" (":" type)?`
+`function_call := compound_name anchor? urn_anchor? "(" (expression ("," expression)*)? ")" ":" type`
 
 `compound_name := identifier (":" identifier?)?`
 

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -382,7 +382,7 @@ Aggregate measures are used in the output of Aggregate relations. They can be ei
 
 #### Syntax
 
-- `aggregate_measure := name anchor? urn_anchor? "(" expression ")" ":" type` - aggregate function call with optional extension anchors and required output type
+- `aggregate_measure := name anchor? urn_anchor? "(" (expression ("," expression)*)? ")" ":" type` - aggregate function call with optional extension anchors and required output type
 - Field references: `$0`, `$1`, ...
 
 #### Examples

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -376,7 +376,7 @@ Root[result]
 - `anchor` - optional anchor (e.g., `#10`)
 - `urn_anchor` - optional URN anchor (e.g., `@1`)
 - `expression` - as above
-- `type` - optional output type
+- `type` - required output type
 
 #### Function Name Resolution
 
@@ -384,26 +384,26 @@ Within the plan, a function name has three parts: a `base` name (e.g. `abs`), a 
 
 Both type signature and anchor are separably optional if the reference is unambiguous; either or both may be required to make the reference unambiguous. A function name (base, signature if present, and anchor if present) must map to exactly one function named in the `Extensions` section.
 
-Where unambiguous, signature and anchor may both be left off (`abs($0)`), used separately (e.g. `abs:i64($0)`, `abs#4($0)`), or together for completeness (`abs:i64#4($0)`).
+Where unambiguous, signature and anchor may both be left off, used separately, or together for completeness (`abs:i64#4($0):fp64`).
 
 #### Examples
 
 ```text
 // Simple: resolves if there is exactly one function named `add`
-add($0, $1)
+add($0, $1):i64
 // Signature: resolves only if exactly one function named `add` is registered,
 // with type signature `:i64_i64`
-add:i64_i64($0, $1)
+add:i64_i64($0, $1):i64
 // Anchor: resolves if anchor 1 exists with base name `add`
-add#1($0, $1)            
-// Anchor + full name: resolves if anchor 1 exists with name `add` and 
+add#1($0, $1):i64
+// Anchor + full name: resolves if anchor 1 exists with name `add` and
 // type signature `i64_i64`
-add:i64_i64#1($0, $1)
+add:i64_i64#1($0, $1):i64
 // Simple: resolves if there is exactly one function named `count`
-count()
+count():i64
 // Signature: resolves if "count:" is registered exactly once with
 // type signature "" (zero arguments)
-count:()
+count:():i64
 ```
 
 ### Aggregate Measures

--- a/Justfile
+++ b/Justfile
@@ -20,6 +20,9 @@ fmt:
 # Run the tests.
 test:
     cargo test --all-features
+    cargo run --example basic_usage --features protoc
+    cargo run --example advanced_usage --features serde,protoc
+    cargo run --example extensions --features cli,protoc
     cargo run --features cli,protoc -- validate -i example-plans/basic.substrait
     cargo run --features cli,protoc -- validate -i example-plans/simple.substrait
 

--- a/example-plans/simple.substrait
+++ b/example-plans/simple.substrait
@@ -12,21 +12,21 @@ Functions:
 
 === Plan
 Root[c, d]
-  Filter[eq($0, 0) => $0, $1]
-    Project[$1, abs($0)]
+  Filter[eq($0, 0):boolean => $0, $1]
+    Project[$1, abs($0):fp64?]
       Read[schema.table => a:fp64?, b:i64]
 
 Root[c, d, e]
-  Aggregate[$0 => $0, sum($1), count($1)]
+  Aggregate[$0 => $0, sum($1):fp64?, count($1):i64]
     Read[schema.table => name:string?, num:fp64?, id:i64]
 
 Root[name, num]
-  Project[$1, coalesce($1, $2)]
+  Project[$1, coalesce($1, $2):fp64?]
     Read[schema.table => name:string?, num:fp64?, other_num:fp64?, id:i64]
 
 Root[name, parent, sum, count]
-  Join[&Inner, eq($0, $4) => $0, $3, $1, $2]
-    Aggregate[$0 => $0, sum($1), count($1)]
+  Join[&Inner, eq($0, $4):boolean => $0, $3, $1, $2]
+    Aggregate[$0 => $0, sum($1):fp64?, count($1):i64]
       Read[schema.table => name:string?, num:fp64?, id:i64]
     Read[schema.table2 => parent:string?, name:string?]
 
@@ -36,7 +36,7 @@ Root[name, num, id]
 
 Root[result]
   Project[$0, $1, $2]
-    Filter[eq($2, 100) => $0, $1, $2]
+    Filter[eq($2, 100):boolean => $0, $1, $2]
       Read[orders => customer:string, amount:fp64, order_id:i64]
 
 Root[name, count]

--- a/examples/advanced_usage.rs
+++ b/examples/advanced_usage.rs
@@ -41,8 +41,8 @@ Functions:
   # 11 @  1: multiply
 === Plan
 Root[revenue]
-  Filter[gt($2, 100) => $0, $1]
-    Project[$0, $1, multiply($0, $1)]
+  Filter[gt($2, 100):boolean => $0, $1]
+    Project[$0, $1, multiply($0, $1):fp64?]
       Read[orders => quantity:i32?, price:fp64?]
 "#;
 

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -17,8 +17,8 @@ Functions:
   # 11 @  1: multiply
 === Plan
 Root[revenue]
-  Filter[gt($2, 100) => $0, $1]
-    Project[$0, $1, multiply($0, $1)]
+  Filter[gt($2, 100):boolean => $0, $1]
+    Project[$0, $1, multiply($0, $1):fp64?]
       Read[orders => quantity:i32?, price:fp64?]
 "#;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,15 +73,13 @@ impl Cli {
                 from,
                 to,
                 show_literal_types,
-                show_expression_types,
                 verbose,
             } => {
                 let reader = get_reader(input)
                     .with_context(|| format!("Failed to open input file: {input}"))?;
                 let writer = get_writer(output)
                     .with_context(|| format!("Failed to create output file: {output}"))?;
-                let options =
-                    self.create_output_options(*show_literal_types, *show_expression_types);
+                let options = self.create_output_options(*show_literal_types);
                 let from_format = self.resolve_input_format(from, input)?;
                 let to_format = self.resolve_output_format(to, output)?;
                 self.run_convert_with_io(
@@ -123,12 +121,10 @@ impl Cli {
                 from,
                 to,
                 show_literal_types,
-                show_expression_types,
                 verbose,
                 ..
             } => {
-                let options =
-                    self.create_output_options(*show_literal_types, *show_expression_types);
+                let options = self.create_output_options(*show_literal_types);
                 let from_format = self.resolve_input_format(from, input)?;
                 let to_format = self.resolve_output_format(to, output)?;
                 self.run_convert_with_io(
@@ -148,19 +144,11 @@ impl Cli {
         }
     }
 
-    fn create_output_options(
-        &self,
-        show_literal_types: bool,
-        show_expression_types: bool,
-    ) -> OutputOptions {
+    fn create_output_options(&self, show_literal_types: bool) -> OutputOptions {
         let mut options = OutputOptions::default();
 
         if show_literal_types {
             options.literal_types = Visibility::Always;
-        }
-
-        if show_expression_types {
-            options.fn_types = true;
         }
 
         options
@@ -287,9 +275,6 @@ pub enum Commands {
         /// Show literal types (text output only)
         #[arg(long)]
         show_literal_types: bool,
-        /// Show expression types (text output only)
-        #[arg(long)]
-        show_expression_types: bool,
         /// Verbose output
         #[arg(short, long)]
         verbose: bool,
@@ -511,7 +496,7 @@ Functions:
 
 === Plan
 Root[result]
-  Filter[gt($2, 100) => $0, $1, $2]
+  Filter[gt($2, 100):boolean => $0, $1, $2]
     Project[$0, $1, $2]
       Read[data => a:i64, b:string, c:i32]
 "#;
@@ -528,7 +513,6 @@ Root[result]
                 from: Some(Format::Text),
                 to: Some(Format::Text),
                 show_literal_types: false,
-                show_expression_types: false,
                 verbose: false,
             },
         };
@@ -555,7 +539,6 @@ Root[result]
                 from: Some(Format::Text),
                 to: Some(Format::Json),
                 show_literal_types: false,
-                show_expression_types: false,
                 verbose: false,
             },
         };
@@ -583,7 +566,6 @@ Root[result]
                 from: Some(Format::Text),
                 to: Some(Format::Json),
                 show_literal_types: false,
-                show_expression_types: false,
                 verbose: false,
             },
         };
@@ -603,7 +585,6 @@ Root[result]
                 from: Some(Format::Json),
                 to: Some(Format::Text),
                 show_literal_types: false,
-                show_expression_types: false,
                 verbose: false,
             },
         };
@@ -629,7 +610,6 @@ Root[result]
                 from: Some(Format::Text),
                 to: Some(Format::Protobuf),
                 show_literal_types: false,
-                show_expression_types: false,
                 verbose: false,
             },
         };
@@ -688,7 +668,7 @@ Root[result]
         assert!(output_content.contains("=== Extensions"));
         assert!(output_content.contains("=== Plan"));
         assert!(output_content.contains("Root[result]"));
-        assert!(output_content.contains("Filter[gt($2, 100)"));
+        assert!(output_content.contains("Filter[gt($2, 100):boolean"));
     }
 
     #[test]
@@ -703,7 +683,6 @@ Root[result]
                 from: Some(Format::Text),
                 to: Some(Format::Text),
                 show_literal_types: true,
-                show_expression_types: true,
                 verbose: false,
             },
         };
@@ -757,7 +736,6 @@ Root[result]
                 from: None, // Auto-detect from extension
                 to: None,   // Auto-detect from extension
                 show_literal_types: false,
-                show_expression_types: false,
                 verbose: false,
             },
         };
@@ -784,7 +762,6 @@ Root[result]
                 from: None, // Should fail auto-detection
                 to: None,
                 show_literal_types: false,
-                show_expression_types: false,
                 verbose: false,
             },
         };
@@ -811,7 +788,6 @@ Root[result]
                 from: None,
                 to: None, // Should fail auto-detection
                 show_literal_types: false,
-                show_expression_types: false,
                 verbose: false,
             },
         };
@@ -838,7 +814,6 @@ Root[result]
                 from: Some(Format::Text),        // Explicit override
                 to: Some(Format::Text),          // Explicit override
                 show_literal_types: false,
-                show_expression_types: false,
                 verbose: false,
             },
         };
@@ -864,7 +839,6 @@ Root[result]
                 from: Some(Format::Text),
                 to: Some(Format::Protobuf),
                 show_literal_types: false,
-                show_expression_types: false,
                 verbose: false,
             },
         };
@@ -884,7 +858,6 @@ Root[result]
                 from: Some(Format::Protobuf),
                 to: Some(Format::Text),
                 show_literal_types: false,
-                show_expression_types: false,
                 verbose: false,
             },
         };
@@ -975,7 +948,6 @@ Root[val]
                 from: Some(Format::Text),
                 to: Some(Format::Text),
                 show_literal_types: false,
-                show_expression_types: false,
                 verbose: false,
             },
         };
@@ -999,7 +971,6 @@ Root[val]
                 from: Some(Format::Text),
                 to: Some(Format::Json),
                 show_literal_types: false,
-                show_expression_types: false,
                 verbose: false,
             },
         };
@@ -1043,7 +1014,6 @@ Root[val]
                 from: Some(Format::Text),
                 to: Some(Format::Text),
                 show_literal_types: false,
-                show_expression_types: false,
                 verbose: false,
             },
         };
@@ -1062,7 +1032,7 @@ Functions:
 
 === Plan
 Root[result]
-  Filter[equal($0, 42:i32) => $0]
+  Filter[equal($0, 42:i32):boolean => $0]
     Read[data => a:i32]
 "#;
 

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -143,10 +143,10 @@ argument_list = { "(" ~ (expression ~ (sp ~ "," ~ sp ~ expression)*)? ~ ")" }
 // - Optional Anchor, e.g. #1
 // - Optional URN Anchor, e.g. @1
 // - Arguments `()` are required, e.g. (1, 2, 3)
-// - Optional output type annotation after closing paren, e.g. :i64
+// - Required output type annotation after closing paren, e.g. :i64
 //   (unambiguous because compound_name is atomic and ends before the opening paren)
 function_call = {
-    compound_name ~ sp ~ anchor? ~ sp ~ urn_anchor? ~ sp ~ argument_list ~ (":" ~ sp ~ type)?
+    compound_name ~ sp ~ anchor? ~ sp ~ urn_anchor? ~ sp ~ argument_list ~ ":" ~ sp ~ type
 }
 
 if_clause = {

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -414,11 +414,8 @@ impl ScopedParsePair for ScalarFunction {
             });
         }
 
-        // Parse optional output type (e.g., :i64)
-        let output_type = match iter.try_pop(Rule::r#type) {
-            Some(t) => Some(Type::parse_pair(extensions, t)?),
-            None => None,
-        };
+        // Parse required output type (e.g., :i64)
+        let output_type = Some(Type::parse_pair(extensions, iter.pop(Rule::r#type))?);
 
         iter.done();
         let anchor = get_and_validate_anchor(
@@ -1142,7 +1139,7 @@ mod tests {
     fn test_scalar_function_full_compound_name() {
         // Full compound name without anchor
         let exts = make_extensions_for_fn_tests();
-        let pair = parse_exact(Rule::function_call, "equal:any_any($0, $1)");
+        let pair = parse_exact(Rule::function_call, "equal:any_any($0, $1):boolean");
         let f = ScalarFunction::parse_pair(&exts, pair).unwrap();
         assert_eq!(f.function_reference, 1);
         assert_eq!(f.arguments.len(), 2);
@@ -1151,7 +1148,7 @@ mod tests {
     #[test]
     fn test_scalar_function_second_overload() {
         let exts = make_extensions_for_fn_tests();
-        let pair = parse_exact(Rule::function_call, "equal:str_str($0, $1)");
+        let pair = parse_exact(Rule::function_call, "equal:str_str($0, $1):boolean");
         let f = ScalarFunction::parse_pair(&exts, pair).unwrap();
 
         assert_eq!(f.arguments.len(), 2);
@@ -1162,7 +1159,7 @@ mod tests {
     fn test_scalar_function_base_name_unique_overload() {
         // "add" has only one overload; base-name lookup should succeed
         let exts = make_extensions_for_fn_tests();
-        let pair = parse_exact(Rule::function_call, "add($0, $1)");
+        let pair = parse_exact(Rule::function_call, "add($0, $1):i64");
         let f = ScalarFunction::parse_pair(&exts, pair).unwrap();
 
         assert_eq!(f.arguments.len(), 2);
@@ -1173,7 +1170,7 @@ mod tests {
     fn test_scalar_function_base_name_ambiguous_fails() {
         // "equal" has two overloads; base-name lookup should fail
         let exts = make_extensions_for_fn_tests();
-        let pair = parse_exact(Rule::function_call, "equal($0, $1)");
+        let pair = parse_exact(Rule::function_call, "equal($0, $1):boolean");
         let result = ScalarFunction::parse_pair(&exts, pair);
         assert!(result.is_err(), "ambiguous base name should fail");
     }
@@ -1181,7 +1178,7 @@ mod tests {
     #[test]
     fn test_scalar_function_compound_name_with_anchor() {
         let exts = make_extensions_for_fn_tests();
-        let pair = parse_exact(Rule::function_call, "equal:any_any#1($0, $1)");
+        let pair = parse_exact(Rule::function_call, "equal:any_any#1($0, $1):boolean");
         let f = ScalarFunction::parse_pair(&exts, pair).unwrap();
         assert_eq!(f.function_reference, 1);
         assert_eq!(f.arguments.len(), 2);
@@ -1191,7 +1188,7 @@ mod tests {
     fn test_scalar_function_base_name_with_anchor() {
         // Base name + explicit anchor should resolve (anchor 1 stores equal:any_any)
         let exts = make_extensions_for_fn_tests();
-        let pair = parse_exact(Rule::function_call, "equal#1($0, $1)");
+        let pair = parse_exact(Rule::function_call, "equal#1($0, $1):boolean");
         let f = ScalarFunction::parse_pair(&exts, pair).unwrap();
         assert_eq!(f.function_reference, 1);
         assert_eq!(f.arguments.len(), 2);
@@ -1200,7 +1197,7 @@ mod tests {
     #[test]
     fn test_scalar_function_wrong_name_for_anchor_fails() {
         let exts = make_extensions_for_fn_tests();
-        let pair = parse_exact(Rule::function_call, "like#1($0)");
+        let pair = parse_exact(Rule::function_call, "like#1($0):boolean");
         let result = ScalarFunction::parse_pair(&exts, pair);
         assert!(result.is_err(), "mismatched name/anchor should fail");
     }

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -414,7 +414,8 @@ impl ScopedParsePair for ScalarFunction {
             });
         }
 
-        // Parse required output type (e.g., :i64)
+        // Parse required output type (e.g., :i64). pop is safe here because
+        // the grammar guarantees the type token is always present.
         let output_type = Some(Type::parse_pair(extensions, iter.pop(Rule::r#type))?);
 
         iter.done();
@@ -1143,6 +1144,10 @@ mod tests {
         let f = ScalarFunction::parse_pair(&exts, pair).unwrap();
         assert_eq!(f.function_reference, 1);
         assert_eq!(f.arguments.len(), 2);
+        assert!(
+            f.output_type.is_some(),
+            "output_type must be set after parsing"
+        );
     }
 
     #[test]
@@ -1164,6 +1169,10 @@ mod tests {
 
         assert_eq!(f.arguments.len(), 2);
         assert_eq!(f.function_reference, 3);
+        assert!(
+            f.output_type.is_some(),
+            "output_type must be set after parsing"
+        );
     }
 
     #[test]
@@ -1200,6 +1209,16 @@ mod tests {
         let pair = parse_exact(Rule::function_call, "like#1($0):boolean");
         let result = ScalarFunction::parse_pair(&exts, pair);
         assert!(result.is_err(), "mismatched name/anchor should fail");
+    }
+
+    #[test]
+    fn test_scalar_function_missing_type_fails_to_parse() {
+        // The grammar requires a type annotation; "add($0, $1)" without ":i64" must fail.
+        let result = ExpressionParser::parse(Rule::function_call, "add($0, $1)");
+        assert!(
+            result.is_err(),
+            "function call without type annotation should fail to parse"
+        );
     }
 
     #[test]

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -1342,7 +1342,7 @@ mod tests {
             &extensions,
             parse_exact(
                 Rule::aggregate_relation,
-                "Aggregate[($0, $1), _ => sum($2), $0, count($2)]",
+                "Aggregate[($0, $1), _ => sum($2):i64, $0, count($2):i64]",
             ),
             vec![example_read_relation().into_rel(None)],
             3,
@@ -1384,7 +1384,7 @@ mod tests {
             &extensions,
             parse_exact(
                 Rule::aggregate_relation,
-                "Aggregate[$0 => sum($1), $0, count($1)]",
+                "Aggregate[$0 => sum($1):i64, $0, count($1):i64]",
             ),
             vec![example_read_relation().into_rel(None)],
             3,
@@ -1421,7 +1421,7 @@ mod tests {
 
         let aggregate = AggregateRel::parse_pair_with_context(
             &extensions,
-            parse_exact(Rule::aggregate_relation, "Aggregate[$2, $0 => sum($1)]"),
+            parse_exact(Rule::aggregate_relation, "Aggregate[$2, $0 => sum($1):i64]"),
             vec![example_read_relation().into_rel(None)],
             3,
         )
@@ -1446,7 +1446,7 @@ mod tests {
             &extensions,
             parse_exact(
                 Rule::aggregate_relation,
-                "Aggregate[_ => sum($0), count($1)]",
+                "Aggregate[_ => sum($0):i64, count($1):i64]",
             ),
             vec![example_read_relation().into_rel(None)],
             3,
@@ -1497,7 +1497,7 @@ mod tests {
             &extensions,
             parse_exact(
                 Rule::aggregate_relation,
-                "Aggregate[($0, $1, $2), ($2, $0), ($1), _ => $0, $1, $2, count($3)]",
+                "Aggregate[($0, $1, $2), ($2, $0), ($1), _ => $0, $1, $2, count($3):i64]",
             ),
             vec![read_rel.into_rel(None)],
             4,
@@ -1617,7 +1617,7 @@ mod tests {
             &extensions,
             parse_exact(
                 Rule::join_relation,
-                "Join[&Inner, eq($0, $3) => $0, $1, $3, $4]",
+                "Join[&Inner, eq($0, $3):boolean => $0, $1, $3, $4]",
             ),
             vec![left_rel, right_rel],
             6, // left (3) + right (3) = 6 total input fields
@@ -1656,7 +1656,10 @@ mod tests {
 
         let join = JoinRel::parse_pair_with_context(
             &extensions,
-            parse_exact(Rule::join_relation, "Join[&Left, eq($0, $3) => $0, $1, $2]"),
+            parse_exact(
+                Rule::join_relation,
+                "Join[&Left, eq($0, $3):boolean => $0, $1, $2]",
+            ),
             vec![left_rel, right_rel],
             6,
         )
@@ -1687,7 +1690,10 @@ mod tests {
 
         let join = JoinRel::parse_pair_with_context(
             &extensions,
-            parse_exact(Rule::join_relation, "Join[&LeftSemi, eq($0, $3) => $0, $1]"),
+            parse_exact(
+                Rule::join_relation,
+                "Join[&LeftSemi, eq($0, $3):boolean => $0, $1]",
+            ),
             vec![left_rel, right_rel],
             6,
         )
@@ -1713,7 +1719,10 @@ mod tests {
         // Test with 0 children
         let result = JoinRel::parse_pair_with_context(
             &extensions,
-            parse_exact(Rule::join_relation, "Join[&Inner, eq($0, $1) => $0, $1]"),
+            parse_exact(
+                Rule::join_relation,
+                "Join[&Inner, eq($0, $1):boolean => $0, $1]",
+            ),
             vec![],
             0,
         );
@@ -1722,7 +1731,10 @@ mod tests {
         // Test with 1 child
         let result = JoinRel::parse_pair_with_context(
             &extensions,
-            parse_exact(Rule::join_relation, "Join[&Inner, eq($0, $1) => $0, $1]"),
+            parse_exact(
+                Rule::join_relation,
+                "Join[&Inner, eq($0, $1):boolean => $0, $1]",
+            ),
             vec![example_read_relation().into_rel(None)],
             3,
         );
@@ -1731,7 +1743,10 @@ mod tests {
         // Test with 3 children
         let result = JoinRel::parse_pair_with_context(
             &extensions,
-            parse_exact(Rule::join_relation, "Join[&Inner, eq($0, $1) => $0, $1]"),
+            parse_exact(
+                Rule::join_relation,
+                "Join[&Inner, eq($0, $1):boolean => $0, $1]",
+            ),
             vec![
                 example_read_relation().into_rel(None),
                 example_read_relation().into_rel(None),

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -785,7 +785,7 @@ impl<'a> RelationParser<'a> {
 ///   ## 10 @  1: my_custom_function
 /// === Plan
 /// Root[result]
-///   Project[my_custom_function($0, $1)]
+///   Project[my_custom_function($0, $1):i32]
 ///     Read[table => col1:i32, col2:i32]
 /// "#;
 ///

--- a/src/textify/expressions.rs
+++ b/src/textify/expressions.rs
@@ -417,7 +417,7 @@ impl Textify for ScalarFunction {
         };
 
         let output = OutputType(self.output_type.as_ref());
-        let output_type = ctx.optional(&output, ctx.options().fn_types);
+        let output_type = ctx.display(&output);
 
         write!(
             w,
@@ -655,7 +655,7 @@ impl Textify for AggregateFunction {
         };
 
         let output = OutputType(self.output_type.as_ref());
-        let output_type = ctx.optional(&output, ctx.options().fn_types);
+        let output_type = ctx.display(&output);
 
         write!(
             w,

--- a/src/textify/expressions.rs
+++ b/src/textify/expressions.rs
@@ -668,7 +668,7 @@ impl Textify for AggregateFunction {
 mod tests {
     use substrait::proto::Type;
     use substrait::proto::expression::{cast, if_then};
-    use substrait::proto::r#type::{I16, I32, Kind, Nullability};
+    use substrait::proto::r#type::{Boolean, I16, I32, I64, Kind, Nullability};
 
     use super::*;
     use crate::extensions::simple::{ExtensionKind, MissingReference};
@@ -779,14 +779,15 @@ mod tests {
             function_reference: 1000, // Does not exist
             arguments: vec![],
             options: vec![],
-            output_type: None,
+            output_type: Some(Type {
+                kind: Some(Kind::I64(I64 {
+                    nullability: Nullability::Required as i32,
+                    type_variation_reference: 0,
+                })),
+            }),
             #[allow(deprecated)]
             args: vec![],
         });
-        // With strict=false (default in OutputOptions), it should format as unknown
-        // If strict=true, it would be an error.
-        // Assuming default OutputOptions has strict = false.
-        // ScopedContext.options() has strict. Default OutputOptions has strict: false.
         let (s, errq) = ctx.textify(&func);
         let errs: Vec<_> = errq.0;
         match errs[0] {
@@ -796,19 +797,24 @@ mod tests {
             }
             _ => panic!("Expected Lookup MissingAnchor: {}", errs[0]),
         }
-        assert_eq!(s, "!{function}#1000()");
+        assert_eq!(s, "!{function}#1000():i64");
 
         let ctx = ctx.with_urn(1, "first").with_function(1, 100, "first");
         let func = RexType::ScalarFunction(ScalarFunction {
             function_reference: 100,
             arguments: vec![],
             options: vec![],
-            output_type: None,
+            output_type: Some(Type {
+                kind: Some(Kind::I64(I64 {
+                    nullability: Nullability::Required as i32,
+                    type_variation_reference: 0,
+                })),
+            }),
             #[allow(deprecated)]
             args: vec![],
         });
         let s = ctx.textify_no_errors(&func);
-        assert_eq!(s, "first()");
+        assert_eq!(s, "first():i64");
 
         // Test for duplicated function name requiring anchor
         let options_show_anchor = Default::default();
@@ -832,12 +838,17 @@ mod tests {
                 })),
             }],
             options: vec![],
-            output_type: None,
+            output_type: Some(Type {
+                kind: Some(Kind::Bool(Boolean {
+                    nullability: Nullability::Required as i32,
+                    type_variation_reference: 0,
+                })),
+            }),
             #[allow(deprecated)]
             args: vec![],
         });
         let s = ctx.textify_no_errors(&rex_dup);
-        assert_eq!(s, "duplicated#231(true)");
+        assert_eq!(s, "duplicated#231(true):boolean");
     }
 
     #[test]

--- a/src/textify/foundation.rs
+++ b/src/textify/foundation.rs
@@ -506,6 +506,7 @@ pub(crate) trait Scope: Sized {
         }
     }
 
+    // TODO: this was last used on 2026-06-15, before a refactor removed it; if its not used again, perhaps we should drop it?
     #[allow(dead_code)]
     fn optional<'a, T: Textify>(
         &'a self,

--- a/src/textify/foundation.rs
+++ b/src/textify/foundation.rs
@@ -44,8 +44,6 @@ pub struct OutputOptions {
     /// Show the types for literals. If `Required`, the type is shown for anything other than
     /// `i64`, `fp64`, `boolean`, or `string`.
     pub literal_types: Visibility,
-    /// Show the output types for functions
-    pub fn_types: bool,
     /// Show the nullability of types
     pub nullability: bool,
     /// The indent to use for nested types
@@ -64,7 +62,6 @@ impl Default for OutputOptions {
             literal_types: Visibility::Required,
             show_emit: false,
             read_types: false,
-            fn_types: false,
             nullability: false,
             indent: "  ".to_string(),
             show_literal_binaries: false,
@@ -84,7 +81,6 @@ impl OutputOptions {
             // Emits are not required for a complete plan - just not a precise one.
             show_emit: false,
             read_types: true,
-            fn_types: true,
             nullability: true,
             indent: "  ".to_string(),
             show_literal_binaries: true,
@@ -510,6 +506,7 @@ pub(crate) trait Scope: Sized {
         }
     }
 
+    #[allow(dead_code)]
     fn optional<'a, T: Textify>(
         &'a self,
         value: &'a T,
@@ -572,6 +569,7 @@ impl<'a, S: Scope, T: Textify> fmt::Display for Displayable<'a, S, T> {
 }
 
 #[derive(Copy, Clone)]
+#[allow(dead_code)]
 pub(crate) struct OptionalDisplayable<'a, S: Scope, T: Textify> {
     scope: &'a S,
     value: Option<&'a T>,

--- a/src/textify/plan.rs
+++ b/src/textify/plan.rs
@@ -93,7 +93,7 @@ mod tests {
     use substrait::proto::expression::{RexType, ScalarFunction};
     use substrait::proto::function_argument::ArgType;
     use substrait::proto::read_rel::{NamedTable, ReadType};
-    use substrait::proto::r#type::{Kind, Nullability, Struct};
+    use substrait::proto::r#type::{I64, Kind, Nullability, Struct};
     use substrait::proto::{
         Expression, FunctionArgument, NamedStruct, ReadRel, Type, extensions as pext,
     };
@@ -174,7 +174,12 @@ mod tests {
                 },
             ],
             options: vec![],
-            output_type: None,
+            output_type: Some(Type {
+                kind: Some(Kind::I64(I64 {
+                    nullability: Nullability::Required as i32,
+                    type_variation_reference: 0,
+                })),
+            }),
             #[allow(deprecated)]
             args: vec![],
         };
@@ -215,7 +220,7 @@ Functions:
   # 10 @  1: add
 
 === Plan
-Project[$0, $1, add($0, $1)]
+Project[$0, $1, add($0, $1):i64]
   Read[table1 => col1:i32?, col2:i32?]
 "#
         .trim_start();

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -1112,7 +1112,7 @@ mod tests {
     use substrait::proto::function_argument::ArgType;
     use substrait::proto::read_rel::{NamedTable, ReadType};
     use substrait::proto::rel_common::{Direct, Emit};
-    use substrait::proto::r#type::{self as ptype, Kind, Nullability, Struct};
+    use substrait::proto::r#type::{self as ptype, Boolean, I64, Kind, Nullability, Struct};
     use substrait::proto::{
         Expression, FunctionArgument, NamedStruct, ReadRel, Type, aggregate_rel,
     };
@@ -1229,7 +1229,12 @@ mod tests {
                     },
                 ],
                 options: vec![],
-                output_type: None,
+                output_type: Some(Type {
+                    kind: Some(Kind::Bool(Boolean {
+                        nullability: Nullability::Required as i32,
+                        type_variation_reference: 0,
+                    })),
+                }),
                 #[allow(deprecated)]
                 args: vec![],
             })),
@@ -1251,7 +1256,7 @@ mod tests {
         let (result, errors) = ctx.textify(&rel);
         assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
         let expected = r#"
-Filter[gt($0, 10:i32) => $0, $1]
+Filter[gt($0, 10:i32):boolean => $0, $1]
   Read[test_table => col1:i32?, col2:i32?]"#
             .trim_start();
         assert_eq!(result, expected);
@@ -1271,7 +1276,7 @@ Filter[gt($0, 10:i32) => $0, $1]
         let (result, errors) = ctx.textify(&value);
 
         assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
-        assert_eq!(result, "sum($1)");
+        assert_eq!(result, "sum($1):i64");
     }
 
     #[test]
@@ -1317,8 +1322,8 @@ Filter[gt($0, 10:i32) => $0, $1]
         let (result, errors) = ctx.textify(&rel);
 
         assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
-        // Expected: Aggregate[_ => sum($1), count($1)] we chose to emit only measures
-        assert!(result.contains("Aggregate[_ => sum($1), count($1)]"));
+        // Expected: Aggregate[_ => sum($1):i64, count($1):i64] we chose to emit only measures
+        assert!(result.contains("Aggregate[_ => sum($1):i64, count($1):i64]"));
     }
 
     #[test]
@@ -1395,7 +1400,7 @@ Filter[gt($0, 10:i32) => $0, $1]
         let (result, errors) = ctx.textify(&rel);
 
         assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
-        assert!(result.contains("($0), ($0, $1) => $0, $1, count($2)"));
+        assert!(result.contains("($0), ($0, $1) => $0, $1, count($2):i64"));
     }
 
     #[test]
@@ -1462,8 +1467,9 @@ Filter[gt($0, 10:i32) => $0, $1]
 
         assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
         assert!(
-            result
-                .contains("Aggregate[($0, $1), ($0, $1), ($1), ($1, $1), _ => $0, $1, count($2)]")
+            result.contains(
+                "Aggregate[($0, $1), ($0, $1), ($1), ($1, $1), _ => $0, $1, count($2):i64]"
+            )
         );
     }
 
@@ -1644,7 +1650,12 @@ Filter[gt($0, 10:i32) => $0, $1]
                 })),
             }],
             options: vec![],
-            output_type: None,
+            output_type: Some(Type {
+                kind: Some(Kind::I64(I64 {
+                    nullability: Nullability::Required as i32,
+                    type_variation_reference: 0,
+                })),
+            }),
             invocation: 0,
             phase: 0,
             sorts: vec![],

--- a/src/textify/types.rs
+++ b/src/textify/types.rs
@@ -224,7 +224,15 @@ impl<T: Deref<Target = proto::Type>> Textify for OutputType<T> {
     fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
         match self.0 {
             Some(ref t) => write!(w, ":{}", ctx.display(t.deref())),
-            None => Ok(()),
+            None => write!(
+                w,
+                "{}",
+                ctx.failure(PlanError::invalid(
+                    "OutputType",
+                    None::<&str>,
+                    "function output_type must be set",
+                ))
+            ),
         }
     }
 }

--- a/src/textify/types.rs
+++ b/src/textify/types.rs
@@ -212,10 +212,7 @@ impl<'a> Textify for NamedAnchor<'a> {
     }
 }
 
-/// The type desciptor of the output of a function call.
-///
-/// This is optional, and if present, it must be the last argument in the
-/// function call.
+/// The output type of a function call, rendered as `:type` after the argument list.
 #[derive(Debug, Copy, Clone)]
 pub struct OutputType<T: Deref<Target = proto::Type>>(pub Option<T>);
 

--- a/src/types_tests.rs
+++ b/src/types_tests.rs
@@ -143,10 +143,10 @@ fn test_expression() {
     assert_roundtrip::<Literal>(&ctx, "12");
     assert_roundtrip::<Literal>(&ctx, "12:i32");
     roundtrip_parse::<FieldReference>(&ctx, "$1");
-    assert_roundtrip::<ScalarFunction>(&ctx, "foo()");
-    assert_roundtrip::<Expression>(&ctx, "bar(12)");
-    assert_roundtrip::<Expression>(&ctx, "foo(bar(12:i16, 18), -4:i16)");
-    assert_roundtrip::<Expression>(&ctx, "foo($2, bar($5, 18), -4:i16)");
+    assert_roundtrip::<ScalarFunction>(&ctx, "foo():i64");
+    assert_roundtrip::<Expression>(&ctx, "bar(12):i64");
+    assert_roundtrip::<Expression>(&ctx, "foo(bar(12:i16, 18):i64, -4:i16):i64");
+    assert_roundtrip::<Expression>(&ctx, "foo($2, bar($5, 18):i64, -4:i16):i64");
 }
 
 #[test]
@@ -162,16 +162,16 @@ fn test_verbose_and_simple_output() {
         .add_extension(ExtensionKind::Function, 4, 14, "bar".to_string())
         .unwrap();
 
-    roundtrip_with_simple_output::<ScalarFunction>(extensions.clone(), "foo#12():i64", "foo()");
-    // Check type is included in verbose output
+    roundtrip_with_simple_output::<ScalarFunction>(extensions.clone(), "foo#12():i64", "foo():i64");
+    // Check type is always included in output
     roundtrip_with_simple_output::<ScalarFunction>(
         extensions.clone(),
         "foo#12(3:i32, 5:i64):i64",
-        "foo(3:i32, 5)",
+        "foo(3:i32, 5):i64",
     );
     roundtrip_with_simple_output::<ScalarFunction>(
         extensions.clone(),
-        "foo#12(bar#14(5:i64, $2)):i64",
-        "foo(bar(5, $2))",
+        "foo#12(bar#14(5:i64, $2):i64):i64",
+        "foo(bar(5, $2):i64):i64",
     );
 }

--- a/tests/json_parsing.rs
+++ b/tests/json_parsing.rs
@@ -184,7 +184,6 @@ fn make_cli(from: Format) -> Cli {
             from: Some(from),
             to: Some(Format::Text),
             show_literal_types: false,
-            show_expression_types: false,
             verbose: false,
         },
     }

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -252,7 +252,7 @@ Functions:
 
 === Plan
 Root[n]
-  Project[count()]
+  Project[count():i64]
     Read[events => n:i64]"#;
     roundtrip_plan(plan);
 }
@@ -269,7 +269,7 @@ Functions:
 
 === Plan
 Root[result]
-  Project[$0, $1, add($0, $1)]
+  Project[$0, $1, add($0, $1):i64]
     Read[t => a:i64, b:i64]"#;
     roundtrip_plan(plan);
 }
@@ -307,7 +307,7 @@ Functions:
 
 === Plan
 Root[result]
-  Project[$0, $1, add#1($0, $1), add:($0, $1)]
+  Project[$0, $1, add#1($0, $1):i64, add:($0, $1):i64]
     Read[t => a:i64, b:i64]"#;
     roundtrip_plan(plan);
 }
@@ -328,7 +328,7 @@ Functions:
 
 === Plan
 Root[result]
-  Project[$0, $1, add#1($0, $1), add:#2($0, $1), add:#3($0, $1)]
+  Project[$0, $1, add#1($0, $1):i64, add:#2($0, $1):i64, add:#3($0, $1):i64]
     Read[t => a:i64, b:i64]"#;
     roundtrip_plan(plan);
 }

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -63,7 +63,7 @@ Functions:
 
 === Plan
 Root[result]
-  Project[$0, $1, add($0, $1)]
+  Project[$0, $1, add($0, $1):i32?]
     Read[table1 => col1:i32?, col2:i32?]"#;
 
     roundtrip_plan(plan);
@@ -98,7 +98,7 @@ Functions:
 
 === Plan
 Root[name, num]
-  Project[$1, coalesce($1, $2)]
+  Project[$1, coalesce($1, $2):fp64?]
     Read[schema.table => name:string?, num:fp64?, other_num:fp64?, id:i64]"#;
 
     let verbose_plan = r#"=== Extensions
@@ -109,7 +109,7 @@ Functions:
 
 === Plan
 Root[name, num]
-  Project[$1, coalesce#10($1, $2)]
+  Project[$1, coalesce#10($1, $2):fp64?]
     Read[schema.table => name:string?, num:fp64?, other_num:fp64?, id:i64]"#;
 
     assert_roundtrip_canonical(simple_plan, verbose_plan);
@@ -160,7 +160,7 @@ Functions:
 
 === Plan
 Root[category, total, count]
-  Aggregate[$0 => sum($1), count($1)]
+  Aggregate[$0 => sum($1):fp64?, count($1):i64]
     Read[orders => category:string?, amount:fp64?]"#;
 
     roundtrip_plan(plan);
@@ -177,7 +177,7 @@ Functions:
 
 === Plan
 Root[sum, category, count]
-  Aggregate[($0, $1), ($0), _ => sum($2), $0, count($2)]
+  Aggregate[($0, $1), ($0), _ => sum($2):fp64?, $0, count($2):i64]
     Read[orders => category:string?, region:string?, amount:fp64?]"#;
 
     roundtrip_plan(plan);
@@ -194,7 +194,7 @@ Functions:
 
 === Plan
 Root[sum, count]
-  Aggregate[_ => sum($2), count($2)]
+  Aggregate[_ => sum($2):fp64?, count($2):i64]
     Read[orders => category:string?, region:string?, amount:fp64?]"#;
 
     roundtrip_plan(plan);
@@ -260,7 +260,7 @@ Functions:
 
 === Plan
 Root[id, name, amount]
-  Join[&Inner, eq($0, $2) => $0, $1, $3]
+  Join[&Inner, eq($0, $2):boolean => $0, $1, $3]
     Read[users => id:i64, name:string]
     Read[orders => user_id:i64, amount:i32]"#;
 
@@ -278,7 +278,7 @@ Functions:
 
 === Plan
 Root[a, b]
-  Join[&LeftSemi, eq($0, $2) => $0, $1]
+  Join[&LeftSemi, eq($0, $2):boolean => $0, $1]
     Read[left_table => a:i32, b:string]
     Read[right_table => c:i32, d:string]"#;
     roundtrip_plan(plan_semi);
@@ -297,7 +297,7 @@ Functions:
 
 === Plan
 Root[d, mark]
-  Join[&RightMark, eq($0, $2) => $2, $3]
+  Join[&RightMark, eq($0, $2):boolean => $2, $3]
     Read[left_table => a:i32, b:string]
     Read[right_table => c:i32, d:string, e:boolean]"#;
     roundtrip_plan(plan_right_mark);
@@ -369,7 +369,7 @@ Functions:
 
 === Plan
 Root[result]
-  Project[$0, equal:any_any($0, $1), equal:str_str($0, $1)]
+  Project[$0, equal:any_any($0, $1):boolean, equal:str_str($0, $1):boolean]
     Read[t => a:i64, b:i64, c:string]"#;
 
     // Verbose output always shows signatures and anchors for all functions,
@@ -383,7 +383,7 @@ Functions:
 
 === Plan
 Root[result]
-  Project[$0, equal:any_any#1($0, $1), equal:str_str#2($0, $1)]
+  Project[$0, equal:any_any#1($0, $1):boolean, equal:str_str#2($0, $1):boolean]
     Read[t => a:i64, b:i64, c:string]"#;
 
     roundtrip_plan(simple);
@@ -405,7 +405,7 @@ Functions:
 
 === Plan
 Root[result]
-  Project[$0, add($0, $1)]
+  Project[$0, add($0, $1):i64]
     Read[t => a:i64, b:i64]"#;
 
     // Explicit compound name in input resolves to the same canonical output
@@ -417,7 +417,7 @@ Functions:
 
 === Plan
 Root[result]
-  Project[$0, add:i64_i64($0, $1)]
+  Project[$0, add:i64_i64($0, $1):i64]
     Read[t => a:i64, b:i64]"#;
 
     // Verbose output always shows the full compound name and anchor
@@ -429,7 +429,7 @@ Functions:
 
 === Plan
 Root[result]
-  Project[$0, add:i64_i64#1($0, $1)]
+  Project[$0, add:i64_i64#1($0, $1):i64]
     Read[t => a:i64, b:i64]"#;
 
     assert_roundtrip_canonical(compact, compound);
@@ -451,7 +451,7 @@ Functions:
 
 === Plan
 Root[result]
-  Project[$0, equal:any_any($0, $1), equal:str_str($0, $2), like($0, $2)]
+  Project[$0, equal:any_any($0, $1):boolean, equal:str_str($0, $2):boolean, like($0, $2):boolean]
     Read[t => id:i64, score:i64, name:string]"#;
 
     roundtrip_plan(simple);
@@ -471,7 +471,7 @@ Functions:
 
 === Plan
 Root[result]
-  Project[$0, equal:any_any#1($0, $1), equal:any_any#2($0, $1)]
+  Project[$0, equal:any_any#1($0, $1):boolean, equal:any_any#2($0, $1):boolean]
     Read[t => a:i64, b:i64]"#;
 
     roundtrip_plan(plan);
@@ -531,7 +531,7 @@ Functions:
 
 === Plan
 Root[name]
-  Filter[gt($0, 1) => $0, $1]
+  Filter[gt($0, 1):boolean => $0, $1]
     Read:Virtual[(1, 'alice'), (2, 'bob'), (3, 'carol') => id:i64, name:string]"#;
 
     roundtrip_plan(plan);
@@ -583,7 +583,7 @@ Functions:
 
 === Plan
 Root[sum]
-  Project[add($0, $1)]
+  Project[add($0, $1):i64]
     Read[t => a:i64, b:i64]"#;
 
     roundtrip_plan(plan);
@@ -603,8 +603,8 @@ Functions:
 
 === Plan
 Root[sum]
-  Project[add($0, $1)]
-    Filter[gt($2, 0) => $0, $1]
+  Project[add($0, $1):i64]
+    Filter[gt($2, 0):boolean => $0, $1]
       Read[t => a:i64, b:i64, c:i64]"#;
 
     roundtrip_plan(plan);
@@ -622,7 +622,7 @@ Functions:
 
 === Plan
 Root[sum]
-  Project[add($0, $1)]
+  Project[add($0, $1):i64]
     Sort[($0, &AscNullsFirst) => $0, $1]
       Read[t => a:i64, b:i64]"#;
 
@@ -641,7 +641,7 @@ Functions:
 
 === Plan
 Root[sum]
-  Project[add($0, $1)]
+  Project[add($0, $1):i64]
     Fetch[limit=10, offset=0 => $0, $1]
       Read[t => a:i64, b:i64]"#;
 
@@ -662,8 +662,8 @@ Functions:
 
 === Plan
 Root[sum]
-  Project[add($1, $3)]
-    Join[&Inner, eq($0, $2) => $0, $1, $2, $3]
+  Project[add($1, $3):i64]
+    Join[&Inner, eq($0, $2):boolean => $0, $1, $2, $3]
       Read[users => id:i64, age:i64]
       Read[orders => user_id:i64, amount:i64]"#;
 
@@ -684,8 +684,8 @@ Functions:
 
 === Plan
 Root[total]
-  Project[add($0, $1)]
-    Aggregate[$0 => $0, sum($1)]
+  Project[add($0, $1):i64]
+    Aggregate[$0 => $0, sum($1):i64]
       Read[t => category:i64, amount:i64]"#;
 
     roundtrip_plan(plan);
@@ -702,7 +702,7 @@ Functions:
 
 === Plan
 Root[sum]
-  Project[add($0, $1)]
+  Project[add($0, $1):i64]
     Read:Virtual[(1, 2), (3, 4) => a:i64, b:i64]"#;
 
     roundtrip_plan(plan);


### PR DESCRIPTION

## Description

The grammar defined the output type annotation on function_call as optional ((":" type)?), allowing plans like add(1, 1) to be written and parsed without specifying a return type. This produced a ScalarFunction proto with output_type unset, which goes against the substrait semantics and breaks in downstream consumers such as substrait-java, which rejects with `Type is not set"`.

Additionally, the textifier gated output type rendering on the fn_types option (default: off), meaning round-tripped plans would silently drop the type even when it was present in the proto.

### Changes
Grammar & parser (expression_grammar.pest, expressions.rs)
- Made the output type required on function_call: ":" type (no trailing ?)
- Updated the parser to use pop instead of try_pop for the type rule, so output_type is always Some

Textifier (textify/expressions.rs)
- ScalarFunction and AggregateFunction now always render the output type, no longer gated on fn_types

Cleanup
- Removed the show_expression_types CLI flag (--show-expression-types) and the fn_types field from OutputOptions, both of which are now obsolete
- Updated doc comments in foundation.rs, types.rs, and GRAMMAR.md to reflect that output types are required

Tests & examples
- Updated unit tests, integration tests, doc tests, and example plans to include explicit output types on every function call

## Type of Change
- [x] Bug fix

## Testing
- [x] All existing tests pass

## Related Issues
Closes #145
