### PR TITLE
feat: u!-prefix support for user-defined types and function signatures

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -210,13 +210,13 @@ The type syntax in this grammar follows the [standard Substrait type definition 
 All types follow this general pattern:
 
 ```text
-type := "u!"? name anchor? urn_anchor? nullability? parameters?
+type := type_name anchor? urn_anchor? nullability? parameters?
+type_name := "u!" identifier | identifier
 ```
 
 Where:
 
-- **`"u!"`** - Optional prefix for user-defined types
-- **`name`** - Type name (case-insensitive, lowercase preferred)
+- **`type_name`** - Type name(case-insensitive, lowercase preferred), plain (e.g. `i64`, `geo_point`) or with `u!` prefix for user-defined types (e.g. `u!json`). The prefix is part of the name and must match the declaration exactly.
 - **`anchor`**` := "#" integer` - Extension anchor (e.g., `#10`)
 - **`urn_anchor`**` := "@" integer` - URN anchor (e.g., `@1`)
 - **`nullability`**` := "?"` - Optional nullability indicator (defaults to non-nullable)
@@ -291,13 +291,14 @@ User-defined types extend the standard Substrait UDT syntax to support anchors a
 
 #### Syntax
 
-`"u!"? name anchor? urn_anchor? nullability? parameters?`
+`type_name anchor? urn_anchor? nullability? parameters?`
+
+where `type_name` is `"u!" identifier | identifier`.
 
 #### Key differences from standard Substrait
 
-- The `u!` prefix is optional (can be omitted when anchors are present)
 - Adds optional `anchor` and `urn_anchor` for extension references
-- Maintains compatibility with standard Substrait UDT syntax
+- The `u!` prefix is part of the type name: a type declared as `u!json` must be referenced as `u!json`, not bare `json`
 
 #### Examples
 
@@ -311,14 +312,14 @@ URNs:
   @  2: https://example.com/functions
 Types:
   ##  8 @  1: point
-  ##  9 @  1: custom_type
+  ##  9 @  1: u!custom_type
 Functions:
   ## 10 @  2: add
 
 === Plan
 Root[result]
   Project[$0, $1, $2]
-    Read[data => point_field:point#8@1?<i8>, custom_field:custom_type#9, prefixed_field:u!custom_type]
+    Read[data => point_field:point#8@1?<i8>, custom_field:u!custom_type#9, prefixed_field:u!custom_type]
 # "#;
 #
 # let plan = Parser::parse(plan_text).unwrap();
@@ -366,11 +367,24 @@ Root[result]
 
 #### Syntax
 
-`function_call := name anchor? urn_anchor? "(" (expression ("," expression)*)? ")" (":" type)?`
+`function_call := compound_name anchor? urn_anchor? "(" (expression ("," expression)*)? ")" (":" type)?`
+
+where `compound_name` is the base function name with an optional colon-delimited type-signature suffix:
+
+```text
+compound_name := type_name (":" function_args?)?
+function_args := type_arg ("_" type_arg)*
+type_arg      := "u!" type_code | type_code
+type_code     := ASCII_ALPHA ASCII_ALPHANUMERIC*
+```
+
+Examples of compound names: `add`, `equal:any_any`, `count:` (empty signature), `json_extract_path:u!json_str`, `bar:u!arg_u!arg`.
+
+The `u!` prefix may appear in signature argument slots as well as in the base name. Note that `type_code` (used in signatures) does not allow underscores — `_` is the argument separator.
 
 #### Components
 
-- `name` - function name
+- `compound_name` - function name with optional signature suffix (see above)
 - `anchor` - optional anchor (e.g., `#10`)
 - `urn_anchor` - optional URN anchor (e.g., `@1`)
 - `expression` - as above

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -218,7 +218,7 @@ type := ("u!")? identifier anchor? urn_anchor? nullability? parameters?
 
 Where:
 
-- **`identifier`** - The type name (case-insensitive, lowercase preferred), e.g. `geo_point` or `"my type"`. Both `u!json` and `json` refer to the same extension; the `u!` prefix is stripped at storage time.
+- **`identifier`** - The type name (case-insensitive, lowercase preferred), e.g. `geo_point` or `my_type`. `u!my_type` syntax is accepted, but not recommended; the `u!` will be dropped - e.g. both `u!json` and `json` refer to the same extension.
 - **`anchor`**` := "#" integer` - Extension anchor (e.g., `#10`)
 - **`urn_anchor`**` := "@" integer` - URN anchor (e.g., `@1`)
 - **`nullability`**` := "?"` - Optional nullability indicator (defaults to non-nullable)
@@ -368,7 +368,7 @@ Root[result]
 
 #### Syntax
 
-`function_call := compound_function_signature anchor? urn_anchor? "(" (expression ("," expression)*)? ")" ":" type`
+`function_call := function_signature anchor? urn_anchor? "(" (expression ("," expression)*)? ")" ":" type`
 
 where `function_signature` is the function base name with an optional colon-delimited type-signature suffix:
 

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -210,13 +210,12 @@ The type syntax in this grammar follows the [standard Substrait type definition 
 All types follow this general pattern:
 
 ```text
-type := type_name anchor? urn_anchor? nullability? parameters?
-type_name := "u!" identifier | identifier
+user_defined_type := ("u!")? (identifier | quoted_name) anchor? urn_anchor? nullability? parameters?
 ```
 
 Where:
 
-- **`type_name`** - Type name(case-insensitive, lowercase preferred), plain (e.g. `i64`, `geo_point`) or with `u!` prefix for user-defined types (e.g. `u!json`). The prefix is part of the name and must match the declaration exactly.
+- **`identifier | quoted_name`** - The type name (case-insensitive, lowercase preferred), e.g. `geo_point` or `"my type"`. Both `u!json` and `json` refer to the same extension; the `u!` prefix is stripped at storage time.
 - **`anchor`**` := "#" integer` - Extension anchor (e.g., `#10`)
 - **`urn_anchor`**` := "@" integer` - URN anchor (e.g., `@1`)
 - **`nullability`**` := "?"` - Optional nullability indicator (defaults to non-nullable)
@@ -291,14 +290,13 @@ User-defined types extend the standard Substrait UDT syntax to support anchors a
 
 #### Syntax
 
-`type_name anchor? urn_anchor? nullability? parameters?`
-
-where `type_name` is `"u!" identifier | identifier`.
+`("u!")? (identifier | quoted_name) anchor? urn_anchor? nullability? parameters?`
 
 #### Key differences from standard Substrait
 
 - Adds optional `anchor` and `urn_anchor` for extension references
-- The `u!` prefix is part of the type name: a type declared as `u!json` must be referenced as `u!json`, not bare `json`
+- The `u!` prefix is accepted in type declarations but normalized at storage time, so `u!json` and `json` in a declaration refer to the same type. It is an error to use `u!` on function or type-variation declarations.
+- In plan references both `u!json` and `json` are accepted and resolve to the same anchor. The canonical output always uses the bare name.
 
 #### Examples
 
@@ -312,14 +310,14 @@ URNs:
   @  2: https://example.com/functions
 Types:
   ##  8 @  1: point
-  ##  9 @  1: u!custom_type
+  ##  9 @  1: custom_type
 Functions:
   ## 10 @  2: add
 
 === Plan
 Root[result]
   Project[$0, $1, $2]
-    Read[data => point_field:point#8@1?<i8>, custom_field:u!custom_type#9, prefixed_field:u!custom_type]
+    Read[data => point_field:point#8@1?<i8>, custom_field:custom_type#9, prefixed_field:u!custom_type]
 # "#;
 #
 # let plan = Parser::parse(plan_text).unwrap();
@@ -367,24 +365,22 @@ Root[result]
 
 #### Syntax
 
-`function_call := compound_name anchor? urn_anchor? "(" (expression ("," expression)*)? ")" (":" type)?`
+`function_call := function_signature anchor? urn_anchor? "(" (expression ("," expression)*)? ")" (":" type)?`
 
-where `compound_name` is the base function name with an optional colon-delimited type-signature suffix:
+where `function_signature` is the function base name with an optional colon-delimited type-signature suffix:
 
 ```text
-compound_name := type_name (":" function_args?)?
-function_args := type_arg ("_" type_arg)*
-type_arg      := "u!" type_code | type_code
-type_code     := ASCII_ALPHA ASCII_ALPHANUMERIC*
+function_signature := identifier (":" argument_signature?)?
+argument_signature := short_arg_type ("_" short_arg_type)*
+short_arg_type     := "u!" short_arg_name | short_arg_name
+short_arg_name     := ASCII_ALPHA ASCII_ALPHANUMERIC*
 ```
 
-Examples of compound names: `add`, `equal:any_any`, `count:` (empty signature), `json_extract_path:u!json_str`, `bar:u!arg_u!arg`.
-
-The `u!` prefix may appear in signature argument slots as well as in the base name. Note that `type_code` (used in signatures) does not allow underscores — `_` is the argument separator.
+Examples of function signatures: `add`, `equal:any_any`, `count:` (empty signature), `json_extract_path:u!json_str`, `bar:u!arg_u!arg`.
 
 #### Components
 
-- `compound_name` - function name with optional signature suffix (see above)
+- `function_signature` - function name with optional signature suffix (see above)
 - `anchor` - optional anchor (e.g., `#10`)
 - `urn_anchor` - optional URN anchor (e.g., `@1`)
 - `expression` - as above

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -213,12 +213,12 @@ The type syntax in this grammar follows the [standard Substrait type definition 
 All types follow this general pattern:
 
 ```text
-type := ("u!")? (identifier | quoted_name) anchor? urn_anchor? nullability? parameters?
+type := ("u!")? identifier anchor? urn_anchor? nullability? parameters?
 ```
 
 Where:
 
-- **`identifier | quoted_name`** - The type name (case-insensitive, lowercase preferred), e.g. `geo_point` or `"my type"`. Both `u!json` and `json` refer to the same extension; the `u!` prefix is stripped at storage time.
+- **`identifier`** - The type name (case-insensitive, lowercase preferred), e.g. `geo_point` or `"my type"`. Both `u!json` and `json` refer to the same extension; the `u!` prefix is stripped at storage time.
 - **`anchor`**` := "#" integer` - Extension anchor (e.g., `#10`)
 - **`urn_anchor`**` := "@" integer` - URN anchor (e.g., `@1`)
 - **`nullability`**` := "?"` - Optional nullability indicator (defaults to non-nullable)
@@ -293,7 +293,7 @@ User-defined types extend the standard Substrait UDT syntax to support anchors a
 
 #### Syntax
 
-`("u!")? (identifier | quoted_name) anchor? urn_anchor? nullability? parameters?`
+`("u!")? identifier anchor? urn_anchor? nullability? parameters?`
 
 #### Key differences from standard Substrait
 

--- a/src/extensions/simple.rs
+++ b/src/extensions/simple.rs
@@ -116,6 +116,11 @@ impl CompoundName {
         &self.name
     }
 
+    /// `true` when the name includes a `:` signature suffix (e.g. `"equal:any_any"`, `"count:"`).
+    pub fn has_signature(&self) -> bool {
+        self.index < self.name.len()
+    }
+
     /// Returns `true` if `self` (a stored name) is matched by `pattern` (a written name).
     ///
     /// - Simple pattern (no `:`): matches any stored name with the same base.

--- a/src/extensions/simple.rs
+++ b/src/extensions/simple.rs
@@ -80,6 +80,9 @@ pub enum InsertError {
         name: String,
         urn: u32,
     },
+
+    #[error("Invalid {kind} name '{name}': u! prefix is only valid for type names")]
+    InvalidName { kind: ExtensionKind, name: String },
 }
 
 /// A Substrait compound function name, e.g. `"equal:any_any"` or `"add"`.
@@ -220,6 +223,16 @@ impl SimpleExtensions {
         anchor: u32,
         name: String,
     ) -> Result<(), InsertError> {
+        // Normalize type names: strip the optional "u!" prefix so that "u!json" and "json"
+        // are stored identically and resolve to the same anchor.
+        // For other extension kinds, "u!" prefix is invalid per the Substrait spec.
+        let name = if kind == ExtensionKind::Type {
+            name.strip_prefix("u!").map(str::to_string).unwrap_or(name)
+        } else if name.starts_with("u!") {
+            return Err(InsertError::InvalidName { kind, name });
+        } else {
+            name
+        };
         let missing_urn = !self.urns.contains_key(&urn);
 
         let prev = match self.extensions.entry((anchor, kind)) {
@@ -1078,6 +1091,24 @@ Type Variations:
         assert!(
             text.contains("equal:str_str"),
             "compound name must appear in output"
+        );
+    }
+
+    #[test]
+    fn test_insert_error_invalid_name_type_variation() {
+        // u! prefix is invalid on TypeVariation declarations, just as it is for Functions.
+        let mut exts = SimpleExtensions::new();
+        exts.add_extension_urn("urn:example".to_string(), 1)
+            .unwrap();
+        let err = exts
+            .add_extension(ExtensionKind::TypeVariation, 1, 30, "u!myvar".to_string())
+            .unwrap_err();
+        assert_eq!(
+            err,
+            InsertError::InvalidName {
+                kind: ExtensionKind::TypeVariation,
+                name: "u!myvar".to_string()
+            }
         );
     }
 }

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -31,11 +31,27 @@ quoted_name = @{
 // A name of a function or table can either be an unquoted identifier or a quoted string
 name = { identifier | quoted_name }
 
-// A compound name is a Substrait function compound name: base identifier followed by an optional
-// colon-delimited signature (e.g. "equal:any_any", "regexp_match_substring:str_str_i64").
-// The rule is atomic so no whitespace is allowed around the colon, making it unambiguous
-// with the output-type annotation which always follows the closing parenthesis.
-compound_name = @{ identifier ~ (":" ~ identifier)? }
+// A plain or u!-prefixed type name, used in schema, cast positions, and function base names.
+// Examples: "geo_point", "u!geo_point"
+type_name = @{ "u!" ~ identifier | identifier }
+
+// Examples: 'geo_point', 'u!geo_point', 'u!"my type"'
+udt_name = @{ "u!" ~ (identifier | quoted_name) | identifier | quoted_name }
+
+// No underscores since "_" is the argument separator.
+// Examples: "i64", "str", "any", "json"
+type_code = @{ ASCII_ALPHA ~ ASCII_ALPHANUMERIC* }
+
+// argument type in a function signature: plain or u!-prefixed.
+// Examples: "i64", "u!json"
+type_arg = @{ "u!" ~ type_code | type_code }
+
+// suffix of a compound name: underscore-separated type_args.
+function_args = @{ type_arg ~ ("_" ~ type_arg)* }
+
+// A Substrait compound name: base name with an optional colon-delimited signature suffix.
+// Examples: "add", "equal:any_any", "count:", "json_extract_path:u!json_str", "bar:u!arg_u!arg".
+compound_name = @{ type_name ~ (":" ~ function_args?)? }
 
 // Expression Components
 // Field reference
@@ -117,18 +133,10 @@ precision_time_type         = { ^"precisiontime"        ~ nullability ~ "<" ~ in
 compound_type = { list_type | map_type | struct_type | precision_timestamp_tz_type | precision_timestamp_type | precision_time_type }
 
 // A user-defined type expression.
-// 
-// Example: point#8@2?<i8>
-// 
-// - The `u!` prefix is optional.
-// - The anchor is optional if the name is unique in the extensions; otherwise,
-// required.
-// - The URN anchor is optional. Note that this is different from type
-// expressions in the YAML, where these do not exist.
-// - If the type is nullable, the nullability is required.
-// - The parameters are required if they exist for this type.
+// Examples: "point#8@2?<i8>", "u!json?", "u!geo_point#5@1"
+// Anchor is required when the name is ambiguous across URNs; URN anchor is optional.
 user_defined_type = {
-    "u!"? ~ name ~ anchor? ~ urn_anchor? ~ nullability ~ parameters?
+    udt_name ~ anchor? ~ urn_anchor? ~ nullability ~ parameters?
 }
 
 // A type expression is a simple type, a compound type, or a user-defined type.

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -134,8 +134,9 @@ compound_type = { list_type | map_type | struct_type | precision_timestamp_tz_ty
 // both "json" and "u!json" resolve to the same extension.
 // Examples: "point#8@2?<i8>", "json?", "u!json?", "geo_point#5@1", "u!geo_point#5@1"
 // Anchor is required when the name is ambiguous across URNs; URN anchor is optional.
+// TODO: Do we need to support quoted names / special characters in type/function names?
 user_defined_type = {
-    "u!"? ~ (identifier | quoted_name) ~ anchor? ~ urn_anchor? ~ nullability ~ parameters?
+    "u!"? ~ identifier ~ anchor? ~ urn_anchor? ~ nullability ~ parameters?
 }
 
 // A type expression is a simple type, a compound type, or a user-defined type.
@@ -202,8 +203,6 @@ extension_urn_declaration = { urn_anchor ~ ":" ~ sp ~ urn }
 // Examples: #10@1: my_func   #1@2: equal:any_any   #5@1: json   #11@1: u!point
 // `anchor` is defined above as "#" ~ integer.
 // `urn_anchor` is defined above as "@" ~ integer.
-// The u! prefix is accepted at grammar level for all extension kinds, but is only valid
-// semantically for Type declarations; Function and TypeVariation names must be bare.
 simple_extension_name = @{ "u!"? ~ identifier ~ (":" ~ argument_signature?)? }
 simple_extension = { anchor ~ sp ~ urn_anchor ~ sp ~ ":" ~ sp ~ simple_extension_name }
 

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -32,7 +32,7 @@ quoted_name = @{
 name = { identifier | quoted_name }
 
 // Short argument type name in a function signature.
-// Underscores are intentionally excluded: "_" is the argument separator in function_args,
+// Underscores are intentionally excluded: "_" is the argument separator in argument_signature,
 // so a type name like "json_str" cannot be written as a single arg — it would parse as
 // two arguments "json" and "str". All Substrait-defined arg type codes are alphanumeric-only.
 // Examples: "i64", "str", "any", "json"

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -153,7 +153,7 @@ argument_list = { "(" ~ (expression ~ (sp ~ "," ~ sp ~ expression)*)? ~ ")" }
 // - Required output type annotation after closing paren, e.g. :i64
 //   (unambiguous because function_signature is atomic and ends before the opening paren)
 function_call = {
-    function_signature ~ sp ~ anchor? ~ sp ~ urn_anchor? ~ sp ~ argument_list ~ (":" ~ sp ~ type)?
+    function_signature ~ sp ~ anchor? ~ sp ~ urn_anchor? ~ sp ~ argument_list ~ ":" ~ sp ~ type
 }
 
 if_clause = {

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -31,27 +31,24 @@ quoted_name = @{
 // A name of a function or table can either be an unquoted identifier or a quoted string
 name = { identifier | quoted_name }
 
-// A plain or u!-prefixed type name, used in schema, cast positions, and function base names.
-// Examples: "geo_point", "u!geo_point"
-type_name = @{ "u!" ~ identifier | identifier }
-
-// Examples: 'geo_point', 'u!geo_point', 'u!"my type"'
-udt_name = @{ "u!" ~ (identifier | quoted_name) | identifier | quoted_name }
-
-// No underscores since "_" is the argument separator.
+// Short argument type name in a function signature.
+// Underscores are intentionally excluded: "_" is the argument separator in function_args,
+// so a type name like "json_str" cannot be written as a single arg — it would parse as
+// two arguments "json" and "str". All Substrait-defined arg type codes are alphanumeric-only.
 // Examples: "i64", "str", "any", "json"
-type_code = @{ ASCII_ALPHA ~ ASCII_ALPHANUMERIC* }
+short_arg_name = @{ ASCII_ALPHA ~ ASCII_ALPHANUMERIC* }
 
-// argument type in a function signature: plain or u!-prefixed.
+// A single argument type in a function signature: plain or u!-prefixed.
 // Examples: "i64", "u!json"
-type_arg = @{ "u!" ~ type_code | type_code }
+short_arg_type = @{ "u!" ~ short_arg_name | short_arg_name }
 
-// suffix of a compound name: underscore-separated type_args.
-function_args = @{ type_arg ~ ("_" ~ type_arg)* }
+// The type-signature suffix of a function signature: underscore-separated argument types.
+// Examples: "any_any", "i64_i64", "u!json_str"
+argument_signature = @{ short_arg_type ~ ("_" ~ short_arg_type)* }
 
-// A Substrait compound name: base name with an optional colon-delimited signature suffix.
-// Examples: "add", "equal:any_any", "count:", "json_extract_path:u!json_str", "bar:u!arg_u!arg".
-compound_name = @{ type_name ~ (":" ~ function_args?)? }
+// A Substrait function signature: function base name with an optional colon-delimited type-signature suffix.
+// Examples: "add", "equal:any_any", "count:", "json_extract_path:u!json_str"
+function_signature = @{ identifier ~ (":" ~ argument_signature?)? }
 
 // Expression Components
 // Field reference
@@ -132,11 +129,12 @@ precision_time_type         = { ^"precisiontime"        ~ nullability ~ "<" ~ in
 // TODO: interval_day
 compound_type = { list_type | map_type | struct_type | precision_timestamp_tz_type | precision_timestamp_type | precision_time_type }
 
-// A user-defined type expression.
-// Examples: "point#8@2?<i8>", "u!json?", "u!geo_point#5@1"
+// A user-defined type expression. The u! prefix is optional and ignored for lookup purposes;
+// both "json" and "u!json" resolve to the same extension.
+// Examples: "point#8@2?<i8>", "json?", "u!json?", "geo_point#5@1", "u!geo_point#5@1"
 // Anchor is required when the name is ambiguous across URNs; URN anchor is optional.
 user_defined_type = {
-    udt_name ~ anchor? ~ urn_anchor? ~ nullability ~ parameters?
+    "u!"? ~ (identifier | quoted_name) ~ anchor? ~ urn_anchor? ~ nullability ~ parameters?
 }
 
 // A type expression is a simple type, a compound type, or a user-defined type.
@@ -152,9 +150,9 @@ argument_list = { "(" ~ (expression ~ (sp ~ "," ~ sp ~ expression)*)? ~ ")" }
 // - Optional URN Anchor, e.g. @1
 // - Arguments `()` are required, e.g. (1, 2, 3)
 // - Optional output type annotation after closing paren, e.g. :i64
-//   (unambiguous because compound_name is atomic and ends before the opening paren)
+//   (unambiguous because function_signature is atomic and ends before the opening paren)
 function_call = {
-    compound_name ~ sp ~ anchor? ~ sp ~ urn_anchor? ~ sp ~ argument_list ~ (":" ~ sp ~ type)?
+    function_signature ~ sp ~ anchor? ~ sp ~ urn_anchor? ~ sp ~ argument_list ~ (":" ~ sp ~ type)?
 }
 
 if_clause = {
@@ -199,12 +197,14 @@ urn = @{ (!whitespace ~ ANY)+ }
 extension_urn_declaration = { urn_anchor ~ ":" ~ sp ~ urn }
 
 // -- Simple Extension Declaration (Function, Type, TypeVariation) --
-// Format: #anchor@urn_ref: name_or_compound_name
-// Examples: #10@1: my_func   #1@2: equal:any_any
+// Format: #anchor@urn_ref: simple_extension_name
+// Examples: #10@1: my_func   #1@2: equal:any_any   #5@1: json   #11@1: u!point
 // `anchor` is defined above as "#" ~ integer.
 // `urn_anchor` is defined above as "@" ~ integer.
-// `compound_name` accepts both plain names and compound names with signatures.
-simple_extension = { anchor ~ sp ~ urn_anchor ~ sp ~ ":" ~ sp ~ compound_name }
+// The u! prefix is accepted at grammar level for all extension kinds, but is only valid
+// semantically for Type declarations; Function and TypeVariation names must be bare.
+simple_extension_name = @{ "u!"? ~ identifier ~ (":" ~ argument_signature?)? }
+simple_extension = { anchor ~ sp ~ urn_anchor ~ sp ~ ":" ~ sp ~ simple_extension_name }
 
 // == Relations ==
 // These rules are for parsing relations - well, for parsing one relation on one line.

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -1112,7 +1112,7 @@ mod tests {
     #[test]
     fn test_compound_name_full_zero_arg_type_signature() {
         // A Full name whose type signature encodes zero argument types (nothing after the colon).
-        let n = parse_compound_name("add:");
+        let n = parse_function_signature("add:");
         assert_eq!(n.full(), "add:");
         assert_eq!(n.base(), "add");
         assert!(n.matches("add:"));
@@ -1273,7 +1273,10 @@ mod tests {
         )
         .unwrap();
 
-        let pair = parse_exact(Rule::function_call, "json_extract_path:u!json_str($0, $1)");
+        let pair = parse_exact(
+            Rule::function_call,
+            "json_extract_path:u!json_str($0, $1):string",
+        );
         let f = ScalarFunction::parse_pair(&exts, pair).unwrap();
         assert_eq!(f.function_reference, 10);
         assert_eq!(f.arguments.len(), 2);

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -618,7 +618,7 @@ impl ParsePair for Name {
 
 impl ParsePair for CompoundName {
     fn rule() -> Rule {
-        Rule::compound_name
+        Rule::function_signature
     }
 
     fn message() -> &'static str {
@@ -1078,48 +1078,51 @@ mod tests {
         );
     }
 
-    // ---- Tests for CompoundName grammar rule ----
+    // ---- Tests for function_signature grammar rule ----
 
-    fn parse_compound_name(input: &str) -> CompoundName {
-        let pair = parse_exact(Rule::compound_name, input);
+    fn parse_function_signature(input: &str) -> CompoundName {
+        let pair = parse_exact(Rule::function_signature, input);
         CompoundName::parse_pair(pair)
     }
 
     #[test]
     fn test_compound_name_plain() {
-        assert_eq!(parse_compound_name("add").full(), "add");
+        assert_eq!(parse_function_signature("add").full(), "add");
     }
 
     #[test]
     fn test_compound_name_with_signature() {
-        assert_eq!(parse_compound_name("equal:any_any").full(), "equal:any_any");
         assert_eq!(
-            parse_compound_name("regexp_match_substring:str_str_i64").full(),
+            parse_function_signature("equal:any_any").full(),
+            "equal:any_any"
+        );
+        assert_eq!(
+            parse_function_signature("regexp_match_substring:str_str_i64").full(),
             "regexp_match_substring:str_str_i64"
         );
-        assert_eq!(parse_compound_name("add:i64_i64").full(), "add:i64_i64");
-    }
-
-    #[test]
-    fn test_compound_name_user_defined_type_base() {
-        // u! prefix on the base name, used in extension type declarations e.g. "# 5 @ 1: u!json"
-        // u!json name, base() and full() are identical by design since there's no :suffix.
-        assert_eq!(parse_compound_name("u!json").full(), "u!json");
-        assert_eq!(parse_compound_name("u!json").base(), "u!json");
+        assert_eq!(
+            parse_function_signature("add:i64_i64").full(),
+            "add:i64_i64"
+        );
     }
 
     #[test]
     fn test_compound_name_trailing_colon_grammar() {
-        // "count:" (trailing colon, zero-arg type signature) must parse fully at grammar level.
-        let pairs = ExpressionParser::parse(Rule::compound_name, "count:").unwrap();
-        assert_eq!(pairs.as_str(), "count:");
+        // "count:" (trailing colon, zero-arg type signature) parses as a compound name with
+        // an empty signature suffix: base "count", has_signature true, full "count:".
+        let name = parse_function_signature("count:");
+        assert_eq!(name.base(), "count");
+        assert_eq!(name.full(), "count:");
+        assert!(
+            name.has_signature(),
+            "trailing colon must set has_signature"
+        );
     }
 
     #[test]
     fn test_compound_name_stops_at_opening_paren() {
-        // In a function call, the compound_name must stop before the '('.
-        // Verify the grammar does not consume the paren.
-        let pairs = ExpressionParser::parse(Rule::compound_name, "equal:any_any").unwrap();
+        // In a function call, the function_signature must stop before the '('.
+        let pairs = ExpressionParser::parse(Rule::function_signature, "equal:any_any").unwrap();
         assert_eq!(pairs.as_str(), "equal:any_any");
     }
 
@@ -1365,7 +1368,7 @@ mod tests {
 
     #[test]
     fn test_parse_cast_to_user_defined_type_with_u_prefix() {
-        // Cast target type is a u!-prefixed UDT; exercises type_name in the cast path.
+        // Cast target type is a u!-prefixed UDT; exercises the user_defined_type rule in the cast path.
         let mut extensions = SimpleExtensions::default();
         extensions.add_extension_urn("urn".to_string(), 1).unwrap();
         extensions
@@ -1385,5 +1388,15 @@ mod tests {
             }
             other => panic!("expected UserDefined, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_function_call_u_prefix_base_name_rejected() {
+        // u! is not valid in a function call base name. The grammar's function_signature
+        // rule uses `identifier` as the base, which cannot match "u!" + identifier.
+        assert!(
+            ExpressionParser::parse(Rule::function_call, "u!json_get($0)").is_err(),
+            "u! prefix in function call base name must be rejected by the grammar"
+        );
     }
 }

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -1101,8 +1101,22 @@ mod tests {
     }
 
     #[test]
+    fn test_compound_name_user_defined_type_base() {
+        // u! prefix on the base name, used in extension type declarations e.g. "# 5 @ 1: u!json"
+        // u!json name, base() and full() are identical by design since there's no :suffix.
+        assert_eq!(parse_compound_name("u!json").full(), "u!json");
+        assert_eq!(parse_compound_name("u!json").base(), "u!json");
+    }
+
+    #[test]
+    fn test_compound_name_trailing_colon_grammar() {
+        // "count:" (trailing colon, zero-arg type signature) must parse fully at grammar level.
+        let pairs = ExpressionParser::parse(Rule::compound_name, "count:").unwrap();
+        assert_eq!(pairs.as_str(), "count:");
+    }
+
+    #[test]
     fn test_compound_name_stops_at_opening_paren() {
-        // where is the paren ???
         // In a function call, the compound_name must stop before the '('.
         // Verify the grammar does not consume the paren.
         let pairs = ExpressionParser::parse(Rule::compound_name, "equal:any_any").unwrap();
@@ -1203,6 +1217,25 @@ mod tests {
         let pair = parse_exact(Rule::function_call, "like#1($0)");
         let result = ScalarFunction::parse_pair(&exts, pair);
         assert!(result.is_err(), "mismatched name/anchor should fail");
+    }
+
+    #[test]
+    fn test_scalar_function_user_defined_type_in_signature() {
+        // u!-prefixed type segments in function signatures parse and resolve.
+        let mut exts = SimpleExtensions::default();
+        exts.add_extension_urn("urn".to_string(), 1).unwrap();
+        exts.add_extension(
+            crate::extensions::simple::ExtensionKind::Function,
+            1,
+            10,
+            "json_extract_path:u!json_str".to_string(),
+        )
+        .unwrap();
+
+        let pair = parse_exact(Rule::function_call, "json_extract_path:u!json_str($0, $1)");
+        let f = ScalarFunction::parse_pair(&exts, pair).unwrap();
+        assert_eq!(f.function_reference, 10);
+        assert_eq!(f.arguments.len(), 2);
     }
 
     #[test]
@@ -1328,5 +1361,29 @@ mod tests {
             result.failure_behavior,
             cast::FailureBehavior::ThrowException as i32
         );
+    }
+
+    #[test]
+    fn test_parse_cast_to_user_defined_type_with_u_prefix() {
+        // Cast target type is a u!-prefixed UDT; exercises type_name in the cast path.
+        let mut extensions = SimpleExtensions::default();
+        extensions.add_extension_urn("urn".to_string(), 1).unwrap();
+        extensions
+            .add_extension(
+                crate::extensions::simple::ExtensionKind::Type,
+                1,
+                5,
+                "u!json".to_string(),
+            )
+            .unwrap();
+
+        let pair = parse_exact(Rule::cast_expression, "($0)::u!json");
+        let result = Cast::parse_pair(&extensions, pair).unwrap();
+        match result.r#type.as_ref().unwrap().kind.as_ref().unwrap() {
+            substrait::proto::r#type::Kind::UserDefined(u) => {
+                assert_eq!(u.type_reference, 5);
+            }
+            other => panic!("expected UserDefined, got {other:?}"),
+        }
     }
 }

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -707,6 +707,16 @@ Type Variations:
     }
 
     #[test]
+    fn test_parse_simple_extension_declaration_u_prefix_function_with_u_signature() {
+        // A function declaration with a u!-prefixed type in the signature.
+        let line = "#5 @2: json_extract_path:u!json_str";
+        let decl = SimpleExtensionDeclaration::from_str(line).unwrap();
+        assert_eq!(decl.anchor, 5);
+        assert_eq!(decl.urn_anchor, 2);
+        assert_eq!(decl.name, "json_extract_path:u!json_str");
+    }
+
+    #[test]
     fn test_extensions_round_trip_plan_with_compound_names() {
         let input = r#"=== Extensions
 URNs:

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -228,8 +228,7 @@ impl ParsePair for SimpleExtensionDeclaration {
             .as_str()
             .parse::<u32>()
             .unwrap();
-        // compound_name handles both plain names ("add") and compound names with signatures ("equal:any_any").
-        let name_pair = iter.pop(Rule::compound_name);
+        let name_pair = iter.pop(Rule::simple_extension_name);
         let name = name_pair.as_str().to_string();
         iter.done();
 
@@ -608,11 +607,11 @@ mod tests {
     use substrait::proto::expression::literal::LiteralType;
 
     use super::*;
-    use crate::OutputOptions;
     use crate::extensions::{Expr, ExtensionValue};
     use crate::fixtures::TestContext;
     use crate::parser::Parser;
     use crate::parser::common::test_support::ScopedParse;
+    use crate::{OutputOptions, format};
 
     fn parse_extension_value(text: &str) -> ExtensionValue {
         ExtensionValue::parse(&SimpleExtensions::default(), text).unwrap()
@@ -714,6 +713,68 @@ Type Variations:
         assert_eq!(decl.anchor, 5);
         assert_eq!(decl.urn_anchor, 2);
         assert_eq!(decl.name, "json_extract_path:u!json_str");
+    }
+
+    #[test]
+    fn test_u_prefix_type_declaration_accepted() {
+        // u! prefix on a type name is non-standard but accepted; normalized to bare name at storage.
+        let plan_text = "\
+=== Extensions
+URNs:
+  @  1: https://example.com/types
+Types:
+  # 11 @  1: u!point
+=== Plan
+Root[result]
+  Project[$0]
+    Read[data => p:point#11]";
+        let plan = Parser::parse(plan_text).unwrap();
+        let (text, errors) = format(&plan);
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+        assert!(
+            text.contains("  # 11 @  1: point"),
+            "declaration line must use bare name"
+        );
+        assert!(
+            !text.contains("u!point"),
+            "u! prefix should be stripped in output"
+        );
+    }
+
+    #[test]
+    fn test_u_prefix_type_variation_declaration_rejected() {
+        // u! prefix on a type variation name is invalid, same as for functions.
+        let plan_text = "\
+=== Extensions
+URNs:
+  @  1: https://example.com/types
+Type Variations:
+  # 30 @  1: u!myvar
+=== Plan
+Root[result]
+  Read[data => x:i64]";
+        assert!(
+            Parser::parse(plan_text).is_err(),
+            "u! prefix on a type variation name should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_u_prefix_function_declaration_rejected() {
+        // u! prefix on a function base name is invalid; function names are never u!-prefixed.
+        let plan_text = "\
+=== Extensions
+URNs:
+  @  1: https://example.com/funcs
+Functions:
+  # 21 @  1: u!json_get
+=== Plan
+Root[result]
+  Read[data => x:i64]";
+        assert!(
+            Parser::parse(plan_text).is_err(),
+            "u! prefix on a function name should be rejected"
+        );
     }
 
     #[test]

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -137,7 +137,7 @@ impl ExtensionParser {
         match line {
             IndentedLine(0, _s) => self.parse_subsection(line), // Pass the original line with 0 indent
             IndentedLine(1, s) => {
-                let decl = parse_decl_for_kind(s, extension_kind)?;
+                let decl = SimpleExtensionDeclaration::parse_from_kind(s, extension_kind)?;
                 self.extensions.add_extension(
                     extension_kind,
                     decl.urn_anchor,
@@ -206,95 +206,52 @@ impl FromStr for URNExtensionDeclaration {
     }
 }
 
-impl ParsePair for SimpleExtensionDeclaration {
-    fn rule() -> Rule {
-        Rule::simple_extension
-    }
-
-    fn message() -> &'static str {
-        "SimpleExtensionDeclaration"
-    }
-
-    fn parse_pair(pair: pest::iterators::Pair<Rule>) -> Self {
-        assert_eq!(pair.as_rule(), Self::rule());
+impl SimpleExtensionDeclaration {
+    fn parse_from_kind(s: &str, kind: ExtensionKind) -> Result<Self, MessageParseError> {
+        let mut pairs = <ExpressionParser as pest::Parser<Rule>>::parse(Rule::simple_extension, s)
+            .map_err(|e| {
+                MessageParseError::new("SimpleExtensionDeclaration", ErrorKind::Syntax, Box::new(e))
+            })?;
+        assert_eq!(pairs.as_str(), s);
+        let pair = pairs.next().unwrap();
         let mut iter = RuleIter::from(pair.into_inner());
-        let anchor_pair = iter.pop(Rule::anchor);
-        let anchor = unwrap_single_pair(anchor_pair)
+
+        let anchor = unwrap_single_pair(iter.pop(Rule::anchor))
             .as_str()
             .parse::<u32>()
             .unwrap();
-        let urn_anchor_pair = iter.pop(Rule::urn_anchor);
-        let urn_anchor = unwrap_single_pair(urn_anchor_pair)
+        let urn_anchor = unwrap_single_pair(iter.pop(Rule::urn_anchor))
             .as_str()
             .parse::<u32>()
             .unwrap();
         let name_pair = iter.pop(Rule::simple_extension_name);
-        let name = name_pair.as_str().to_string();
+        let name_span = name_pair.as_span();
+        let name = name_pair.as_str();
+
+        if kind != ExtensionKind::Type && name.starts_with("u!") {
+            return Err(MessageParseError::invalid(
+                "simple_extension_name",
+                name_span,
+                format!("'u!' prefix is only valid for type declarations, not {kind}"),
+            ));
+        }
+        if matches!(kind, ExtensionKind::Type | ExtensionKind::TypeVariation) && name.contains(':')
+        {
+            return Err(MessageParseError::invalid(
+                "simple_extension_name",
+                name_span,
+                format!(
+                    "type/type-variation names must not include a signature suffix, got '{name}'"
+                ),
+            ));
+        }
         iter.done();
 
-        SimpleExtensionDeclaration {
+        Ok(SimpleExtensionDeclaration {
             anchor,
             urn_anchor,
-            name,
-        }
-    }
-}
-
-/// Like [`SimpleExtensionDeclaration::parse_str`] but retains the Pest span of the name
-/// token so that kind-specific validation errors carry a column pointer. Parsing is
-/// duplicated rather than delegated because `parse_pair` discards the span before returning.
-fn parse_decl_for_kind(
-    s: &str,
-    kind: ExtensionKind,
-) -> Result<SimpleExtensionDeclaration, MessageParseError> {
-    let mut pairs = <ExpressionParser as pest::Parser<Rule>>::parse(Rule::simple_extension, s)
-        .map_err(|e| {
-            MessageParseError::new("SimpleExtensionDeclaration", ErrorKind::Syntax, Box::new(e))
-        })?;
-    assert_eq!(pairs.as_str(), s);
-    let pair = pairs.next().unwrap();
-    let mut iter = RuleIter::from(pair.into_inner());
-
-    let anchor = unwrap_single_pair(iter.pop(Rule::anchor))
-        .as_str()
-        .parse::<u32>()
-        .unwrap();
-    let urn_anchor = unwrap_single_pair(iter.pop(Rule::urn_anchor))
-        .as_str()
-        .parse::<u32>()
-        .unwrap();
-    let name_pair = iter.pop(Rule::simple_extension_name);
-    let name_span = name_pair.as_span();
-    let name = name_pair.as_str();
-
-    if kind != ExtensionKind::Type && name.starts_with("u!") {
-        return Err(MessageParseError::invalid(
-            "simple_extension_name",
-            name_span,
-            format!("'u!' prefix is only valid for type declarations, not {kind}"),
-        ));
-    }
-    if matches!(kind, ExtensionKind::Type | ExtensionKind::TypeVariation) && name.contains(':') {
-        return Err(MessageParseError::invalid(
-            "simple_extension_name",
-            name_span,
-            format!("type/type-variation names must not include a signature suffix, got '{name}'"),
-        ));
-    }
-    iter.done();
-
-    Ok(SimpleExtensionDeclaration {
-        anchor,
-        urn_anchor,
-        name: name.to_string(),
-    })
-}
-
-impl FromStr for SimpleExtensionDeclaration {
-    type Err = super::MessageParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::parse_str(s)
+            name: name.to_string(),
+        })
     }
 }
 
@@ -677,16 +634,16 @@ mod tests {
 
     #[test]
     fn test_parse_simple_extension_declaration() {
-        // Assumes a format like "@anchor: urn_anchor:name"
         let line = "#5@2: my_function_name";
-        let decl = SimpleExtensionDeclaration::from_str(line).unwrap();
+        let decl =
+            SimpleExtensionDeclaration::parse_from_kind(line, ExtensionKind::Function).unwrap();
         assert_eq!(decl.anchor, 5);
         assert_eq!(decl.urn_anchor, 2);
         assert_eq!(decl.name, "my_function_name");
 
-        // Test with a different name format, e.g. with underscores and numbers
         let line2 = "#10  @200: another_ext_123";
-        let decl = SimpleExtensionDeclaration::from_str(line2).unwrap();
+        let decl =
+            SimpleExtensionDeclaration::parse_from_kind(line2, ExtensionKind::Function).unwrap();
         assert_eq!(decl.anchor, 10);
         assert_eq!(decl.urn_anchor, 200);
         assert_eq!(decl.name, "another_ext_123");
@@ -740,7 +697,8 @@ Type Variations:
     fn test_parse_simple_extension_declaration_compound_name() {
         // A function name that includes a Substrait signature suffix
         let line = "#1 @2: equal:any_any";
-        let decl = SimpleExtensionDeclaration::from_str(line).unwrap();
+        let decl =
+            SimpleExtensionDeclaration::parse_from_kind(line, ExtensionKind::Function).unwrap();
         assert_eq!(decl.anchor, 1);
         assert_eq!(decl.urn_anchor, 2);
         assert_eq!(decl.name, "equal:any_any");
@@ -749,7 +707,8 @@ Type Variations:
     #[test]
     fn test_parse_simple_extension_declaration_compound_name_multi_segment() {
         let line = "#3 @1: regexp_match_substring:str_str_i64";
-        let decl = SimpleExtensionDeclaration::from_str(line).unwrap();
+        let decl =
+            SimpleExtensionDeclaration::parse_from_kind(line, ExtensionKind::Function).unwrap();
         assert_eq!(decl.anchor, 3);
         assert_eq!(decl.urn_anchor, 1);
         assert_eq!(decl.name, "regexp_match_substring:str_str_i64");
@@ -757,9 +716,11 @@ Type Variations:
 
     #[test]
     fn test_parse_simple_extension_declaration_u_prefix_function_with_u_signature() {
-        // A function declaration with a u!-prefixed type in the signature.
+        // u! is valid inside a signature suffix (e.g. u!json as an arg type); only
+        // the base function name itself may not be u!-prefixed.
         let line = "#5 @2: json_extract_path:u!json_str";
-        let decl = SimpleExtensionDeclaration::from_str(line).unwrap();
+        let decl =
+            SimpleExtensionDeclaration::parse_from_kind(line, ExtensionKind::Function).unwrap();
         assert_eq!(decl.anchor, 5);
         assert_eq!(decl.urn_anchor, 2);
         assert_eq!(decl.name, "json_extract_path:u!json_str");

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -808,8 +808,7 @@ Root[result]
 
     #[test]
     fn test_u_prefix_function_rejected_at_parser_level() {
-        // The u! rejection must come from parse_decl_for_kind (a MessageParseError with
-        // column info), not from add_extension (an InsertError without position).
+        // The parser should reject function names with a `u!` prefix
         let plan_text = "\
 === Extensions
 URNs:

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -5,8 +5,8 @@ use substrait::proto::{Expression, Type};
 use thiserror::Error;
 
 use super::{
-    MessageParseError, ParsePair, Rule, RuleIter, ScopedParsePair, unescape_string,
-    unwrap_single_pair,
+    ErrorKind, ExpressionParser, MessageParseError, ParsePair, Rule, RuleIter, ScopedParsePair,
+    unescape_string, unwrap_single_pair,
 };
 use crate::extensions::simple::{self, ExtensionKind};
 use crate::extensions::{
@@ -137,7 +137,7 @@ impl ExtensionParser {
         match line {
             IndentedLine(0, _s) => self.parse_subsection(line), // Pass the original line with 0 indent
             IndentedLine(1, s) => {
-                let decl = SimpleExtensionDeclaration::from_str(s)?;
+                let decl = parse_decl_for_kind(s, extension_kind)?;
                 self.extensions.add_extension(
                     extension_kind,
                     decl.urn_anchor,
@@ -238,6 +238,56 @@ impl ParsePair for SimpleExtensionDeclaration {
             name,
         }
     }
+}
+
+/// Like [`SimpleExtensionDeclaration::parse_str`] but retains the Pest span of the name
+/// token so that kind-specific validation errors carry a column pointer. Parsing is
+/// duplicated rather than delegated because `parse_pair` discards the span before returning.
+fn parse_decl_for_kind(
+    s: &str,
+    kind: ExtensionKind,
+) -> Result<SimpleExtensionDeclaration, MessageParseError> {
+    let mut pairs = <ExpressionParser as pest::Parser<Rule>>::parse(Rule::simple_extension, s)
+        .map_err(|e| {
+            MessageParseError::new("SimpleExtensionDeclaration", ErrorKind::Syntax, Box::new(e))
+        })?;
+    assert_eq!(pairs.as_str(), s);
+    let pair = pairs.next().unwrap();
+    let mut iter = RuleIter::from(pair.into_inner());
+
+    let anchor = unwrap_single_pair(iter.pop(Rule::anchor))
+        .as_str()
+        .parse::<u32>()
+        .unwrap();
+    let urn_anchor = unwrap_single_pair(iter.pop(Rule::urn_anchor))
+        .as_str()
+        .parse::<u32>()
+        .unwrap();
+    let name_pair = iter.pop(Rule::simple_extension_name);
+    let name_span = name_pair.as_span();
+    let name = name_pair.as_str();
+
+    if kind != ExtensionKind::Type && name.starts_with("u!") {
+        return Err(MessageParseError::invalid(
+            "simple_extension_name",
+            name_span,
+            format!("'u!' prefix is only valid for type declarations, not {kind}"),
+        ));
+    }
+    if matches!(kind, ExtensionKind::Type | ExtensionKind::TypeVariation) && name.contains(':') {
+        return Err(MessageParseError::invalid(
+            "simple_extension_name",
+            name_span,
+            format!("type/type-variation names must not include a signature suffix, got '{name}'"),
+        ));
+    }
+    iter.done();
+
+    Ok(SimpleExtensionDeclaration {
+        anchor,
+        urn_anchor,
+        name: name.to_string(),
+    })
 }
 
 impl FromStr for SimpleExtensionDeclaration {
@@ -774,6 +824,47 @@ Root[result]
         assert!(
             Parser::parse(plan_text).is_err(),
             "u! prefix on a function name should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_signature_on_type_declaration_rejected() {
+        // Function signatures (':' suffix) are invalid on type declarations.
+        let plan_text = "\
+=== Extensions
+URNs:
+  @  1: https://example.com/types
+Types:
+  # 10 @  1: mytype:i64_i64
+=== Plan
+Root[result]
+  Read[data => x:i64]";
+        assert!(
+            Parser::parse(plan_text).is_err(),
+            "function signature suffix on a type declaration should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_u_prefix_function_rejected_at_parser_level() {
+        // The u! rejection must come from parse_decl_for_kind (a MessageParseError with
+        // column info), not from add_extension (an InsertError without position).
+        let plan_text = "\
+=== Extensions
+URNs:
+  @  1: https://example.com/funcs
+Functions:
+  # 21 @  1: u!bad_func
+=== Plan
+Root[result]
+  Read[data => x:i64]";
+        let err = Parser::parse(plan_text).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                crate::parser::ParseError::Extension(_, ExtensionParseError::Message(_))
+            ),
+            "expected parser-level MessageParseError, got: {err}"
         );
     }
 

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -276,7 +276,7 @@ fn parse_user_defined_type(
     let span = pair.as_span();
     assert_eq!(pair.as_rule(), Rule::user_defined_type);
     let mut iter = iter_pairs(pair.into_inner());
-    let name = iter.pop(Rule::name).as_str();
+    let name = iter.pop(Rule::udt_name).as_str();
     let anchor = iter
         .try_pop(Rule::anchor)
         .map(|n| unwrap_single_pair(n).as_str().parse::<u32>().unwrap());
@@ -474,6 +474,93 @@ mod tests {
                     }],
                 }))
             }
+        );
+    }
+
+    #[test]
+    fn test_udts_with_u_prefix() {
+        // Extensions declared with "u!" prefix (e.g. "# 7 @ 4: u!json") store the name
+        // including the prefix. Lookups from type annotations like "u!json?" must match.
+        let mut extensions = SimpleExtensions::default();
+        extensions
+            .add_extension_urn("some_source".to_string(), 4)
+            .unwrap();
+        extensions
+            .add_extension(ExtensionKind::Type, 4, 7, "u!json".to_string())
+            .unwrap();
+
+        // With explicit anchor
+        let pair = ExpressionParser::parse(Rule::user_defined_type, "u!json#7")
+            .unwrap()
+            .next()
+            .unwrap();
+        let t = parse_user_defined_type(&extensions, pair).unwrap();
+        assert_eq!(
+            t,
+            Type {
+                kind: Some(Kind::UserDefined(proto::r#type::UserDefined {
+                    type_reference: 7,
+                    type_variation_reference: 0,
+                    nullability: Nullability::Required as i32,
+                    type_parameters: vec![],
+                }))
+            }
+        );
+
+        // Nullable, no anchor — name is unique so anchor-free lookup succeeds
+        let pair = ExpressionParser::parse(Rule::user_defined_type, "u!json?")
+            .unwrap()
+            .next()
+            .unwrap();
+        let t = parse_user_defined_type(&extensions, pair).unwrap();
+        assert_eq!(
+            t,
+            Type {
+                kind: Some(Kind::UserDefined(proto::r#type::UserDefined {
+                    type_reference: 7,
+                    type_variation_reference: 0,
+                    nullability: Nullability::Nullable as i32,
+                    type_parameters: vec![],
+                }))
+            }
+        );
+    }
+
+    #[test]
+    fn test_udt_prefix_mismatch_u_prefix_against_plain_registration() {
+        // Extension registered without "u!" but plan uses "u!json" — must fail.
+        let mut extensions = SimpleExtensions::default();
+        extensions.add_extension_urn("src".to_string(), 1).unwrap();
+        extensions
+            .add_extension(ExtensionKind::Type, 1, 3, "json".to_string())
+            .unwrap();
+
+        let pair = ExpressionParser::parse(Rule::user_defined_type, "u!json")
+            .unwrap()
+            .next()
+            .unwrap();
+        assert!(
+            parse_user_defined_type(&extensions, pair).is_err(),
+            "u!json should not match an extension declared as json"
+        );
+    }
+
+    #[test]
+    fn test_udt_prefix_mismatch_plain_against_u_prefix_registration() {
+        // Extension registered with "u!" but plan uses bare "json" — must fail.
+        let mut extensions = SimpleExtensions::default();
+        extensions.add_extension_urn("src".to_string(), 1).unwrap();
+        extensions
+            .add_extension(ExtensionKind::Type, 1, 3, "u!json".to_string())
+            .unwrap();
+
+        let pair = ExpressionParser::parse(Rule::user_defined_type, "json")
+            .unwrap()
+            .next()
+            .unwrap();
+        assert!(
+            parse_user_defined_type(&extensions, pair).is_err(),
+            "bare json should not match an extension declared as u!json"
         );
     }
 }

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -2,7 +2,7 @@ use pest::iterators::Pair;
 use substrait::proto::r#type::{Kind, Nullability, Parameter};
 use substrait::proto::{self, Type};
 
-use super::{ParsePair, Rule, ScopedParsePair, iter_pairs, unescape_string, unwrap_single_pair};
+use super::{ParsePair, Rule, ScopedParsePair, iter_pairs, unwrap_single_pair};
 use crate::extensions::SimpleExtensions;
 use crate::extensions::simple::{ExtensionKind, MissingReference};
 use crate::parser::MessageParseError;
@@ -276,11 +276,8 @@ fn parse_user_defined_type(
     let span = pair.as_span();
     assert_eq!(pair.as_rule(), Rule::user_defined_type);
     let mut iter = iter_pairs(pair.into_inner());
-    let name = if let Some(p) = iter.try_pop(Rule::identifier) {
-        p.as_str().to_string()
-    } else {
-        unescape_string(iter.pop(Rule::quoted_name))
-    };
+    // TODO: quoted names not yet supported — see grammar TODO at user_defined_type
+    let name = iter.pop(Rule::identifier).as_str().to_string();
     let anchor = iter
         .try_pop(Rule::anchor)
         .map(|n| unwrap_single_pair(n).as_str().parse::<u32>().unwrap());

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -2,7 +2,7 @@ use pest::iterators::Pair;
 use substrait::proto::r#type::{Kind, Nullability, Parameter};
 use substrait::proto::{self, Type};
 
-use super::{ParsePair, Rule, ScopedParsePair, iter_pairs, unwrap_single_pair};
+use super::{ParsePair, Rule, ScopedParsePair, iter_pairs, unescape_string, unwrap_single_pair};
 use crate::extensions::SimpleExtensions;
 use crate::extensions::simple::{ExtensionKind, MissingReference};
 use crate::parser::MessageParseError;
@@ -276,7 +276,11 @@ fn parse_user_defined_type(
     let span = pair.as_span();
     assert_eq!(pair.as_rule(), Rule::user_defined_type);
     let mut iter = iter_pairs(pair.into_inner());
-    let name = iter.pop(Rule::udt_name).as_str();
+    let name = if let Some(p) = iter.try_pop(Rule::identifier) {
+        p.as_str().to_string()
+    } else {
+        unescape_string(iter.pop(Rule::quoted_name))
+    };
     let anchor = iter
         .try_pop(Rule::anchor)
         .map(|n| unwrap_single_pair(n).as_str().parse::<u32>().unwrap());
@@ -293,7 +297,7 @@ fn parse_user_defined_type(
     };
     iter.done();
 
-    let anchor = get_and_validate_anchor(extensions, ExtensionKind::Type, anchor, name, span)?;
+    let anchor = get_and_validate_anchor(extensions, ExtensionKind::Type, anchor, &name, span)?;
 
     Ok(Type {
         kind: Some(Kind::UserDefined(proto::r#type::UserDefined {
@@ -479,8 +483,9 @@ mod tests {
 
     #[test]
     fn test_udts_with_u_prefix() {
-        // Extensions declared with "u!" prefix (e.g. "# 7 @ 4: u!json") store the name
-        // including the prefix. Lookups from type annotations like "u!json?" must match.
+        // Extensions declared with "u!" prefix (e.g. "# 7 @ 4: u!json") normalize to
+        // bare name at storage time. Both "u!json" and "json" in the plan resolve to the
+        // same anchor.
         let mut extensions = SimpleExtensions::default();
         extensions
             .add_extension_urn("some_source".to_string(), 4)
@@ -489,7 +494,7 @@ mod tests {
             .add_extension(ExtensionKind::Type, 4, 7, "u!json".to_string())
             .unwrap();
 
-        // With explicit anchor
+        // Plan uses u! prefix with explicit anchor
         let pair = ExpressionParser::parse(Rule::user_defined_type, "u!json#7")
             .unwrap()
             .next()
@@ -507,8 +512,8 @@ mod tests {
             }
         );
 
-        // Nullable, no anchor — name is unique so anchor-free lookup succeeds
-        let pair = ExpressionParser::parse(Rule::user_defined_type, "u!json?")
+        // Plan uses bare name — also resolves to the same anchor
+        let pair = ExpressionParser::parse(Rule::user_defined_type, "json?")
             .unwrap()
             .next()
             .unwrap();
@@ -524,11 +529,29 @@ mod tests {
                 }))
             }
         );
+
+        // Plan uses u! prefix with no anchor — anchor-free lookup must strip u! and find the type
+        let pair = ExpressionParser::parse(Rule::user_defined_type, "u!json")
+            .unwrap()
+            .next()
+            .unwrap();
+        let t = parse_user_defined_type(&extensions, pair).unwrap();
+        assert_eq!(
+            t,
+            Type {
+                kind: Some(Kind::UserDefined(proto::r#type::UserDefined {
+                    type_reference: 7,
+                    type_variation_reference: 0,
+                    nullability: Nullability::Required as i32,
+                    type_parameters: vec![],
+                }))
+            }
+        );
     }
 
     #[test]
-    fn test_udt_prefix_mismatch_u_prefix_against_plain_registration() {
-        // Extension registered without "u!" but plan uses "u!json" — must fail.
+    fn test_udt_u_prefix_matches_plain_registration() {
+        // Extension registered without "u!" and plan uses "u!json" — must succeed.
         let mut extensions = SimpleExtensions::default();
         extensions.add_extension_urn("src".to_string(), 1).unwrap();
         extensions
@@ -539,15 +562,21 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        assert!(
-            parse_user_defined_type(&extensions, pair).is_err(),
-            "u!json should not match an extension declared as json"
+        let t = parse_user_defined_type(&extensions, pair).unwrap();
+        assert_eq!(
+            t.kind,
+            Some(Kind::UserDefined(proto::r#type::UserDefined {
+                type_reference: 3,
+                type_variation_reference: 0,
+                nullability: Nullability::Required as i32,
+                type_parameters: vec![],
+            }))
         );
     }
 
     #[test]
-    fn test_udt_prefix_mismatch_plain_against_u_prefix_registration() {
-        // Extension registered with "u!" but plan uses bare "json" — must fail.
+    fn test_udt_plain_matches_u_prefix_registration() {
+        // Extension registered with "u!" prefix and plan uses bare "json" — must succeed.
         let mut extensions = SimpleExtensions::default();
         extensions.add_extension_urn("src".to_string(), 1).unwrap();
         extensions
@@ -558,9 +587,15 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        assert!(
-            parse_user_defined_type(&extensions, pair).is_err(),
-            "bare json should not match an extension declared as u!json"
+        let t = parse_user_defined_type(&extensions, pair).unwrap();
+        assert_eq!(
+            t.kind,
+            Some(Kind::UserDefined(proto::r#type::UserDefined {
+                type_reference: 3,
+                type_variation_reference: 0,
+                nullability: Nullability::Required as i32,
+                type_parameters: vec![],
+            }))
         );
     }
 }

--- a/src/textify/expressions.rs
+++ b/src/textify/expressions.rs
@@ -668,7 +668,7 @@ impl Textify for AggregateFunction {
 mod tests {
     use substrait::proto::Type;
     use substrait::proto::expression::{cast, if_then};
-    use substrait::proto::r#type::{I16, I32, Kind, Nullability};
+    use substrait::proto::r#type::{I16, I32, Kind, Nullability, UserDefined};
 
     use super::*;
     use crate::extensions::simple::{ExtensionKind, MissingReference};
@@ -1098,5 +1098,26 @@ mod tests {
                 panic!("Expected Format(InvalidValue) for invalid failure_behavior, got: {other}")
             }
         }
+    }
+
+    #[test]
+    fn test_cast_to_user_defined_type_textifies_with_u_prefix() {
+        // Cast to a u!-prefixed UDT must emit "::u!json", not "::json".
+        let ctx = TestContext::new()
+            .with_urn(1, "urn:example:types")
+            .with_type(1, 5, "u!json");
+        let cast = Cast {
+            r#type: Some(Type {
+                kind: Some(Kind::UserDefined(UserDefined {
+                    type_variation_reference: 0,
+                    nullability: Nullability::Required as i32,
+                    type_reference: 5,
+                    type_parameters: vec![],
+                })),
+            }),
+            input: Some(Box::new(literal_i32(1))),
+            failure_behavior: 0,
+        };
+        assert_eq!(ctx.textify_no_errors(&cast), "(1:i32)::u!json");
     }
 }

--- a/src/textify/expressions.rs
+++ b/src/textify/expressions.rs
@@ -1101,8 +1101,8 @@ mod tests {
     }
 
     #[test]
-    fn test_cast_to_user_defined_type_textifies_with_u_prefix() {
-        // Cast to a u!-prefixed UDT must emit "::u!json", not "::json".
+    fn test_cast_to_user_defined_type_textifies_without_u_prefix() {
+        // A type stored as "u!json" normalizes to "json"; cast emits "::json".
         let ctx = TestContext::new()
             .with_urn(1, "urn:example:types")
             .with_type(1, 5, "u!json");
@@ -1118,6 +1118,6 @@ mod tests {
             input: Some(Box::new(literal_i32(1))),
             failure_behavior: 0,
         };
-        assert_eq!(ctx.textify_no_errors(&cast), "(1:i32)::u!json");
+        assert_eq!(ctx.textify_no_errors(&cast), "(1:i32)::json");
     }
 }

--- a/src/textify/foundation.rs
+++ b/src/textify/foundation.rs
@@ -304,6 +304,7 @@ impl FormatError {
             FormatError::Insert(InsertError::DuplicateAnchor { .. }) => "extension",
             FormatError::Insert(InsertError::MissingUrn { .. }) => "uri",
             FormatError::Insert(InsertError::DuplicateAndMissingUrn { .. }) => "uri",
+            FormatError::Insert(InsertError::InvalidName { .. }) => "extension",
         }
     }
 }

--- a/src/textify/types.rs
+++ b/src/textify/types.rs
@@ -1045,8 +1045,9 @@ mod tests {
     }
 
     #[test]
-    fn u_prefix_type_textifies_with_prefix() {
-        // A type registered as "u!json" must textify back as "u!json", not bare "json".
+    fn u_prefix_type_textifies_without_prefix() {
+        // A type registered as "u!json" normalizes to "json" at storage time and
+        // textifies back as "json" (the u! prefix is not part of the type name).
         let ctx = TestContext::new()
             .with_urn(1, "urn:example:types")
             .with_type(1, 5, "u!json");
@@ -1059,11 +1060,11 @@ mod tests {
                 type_parameters: vec![],
             })),
         };
-        assert_eq!(ctx.textify_no_errors(&t), "u!json");
+        assert_eq!(ctx.textify_no_errors(&t), "json");
     }
 
     #[test]
-    fn u_prefix_type_nullable_textifies_with_prefix_and_nullability() {
+    fn u_prefix_type_nullable_textifies_without_prefix() {
         let ctx = TestContext::new()
             .with_urn(1, "urn:example:types")
             .with_type(1, 7, "u!geo_point");
@@ -1076,7 +1077,7 @@ mod tests {
                 type_parameters: vec![],
             })),
         };
-        assert_eq!(ctx.textify_no_errors(&t), "u!geo_point?");
+        assert_eq!(ctx.textify_no_errors(&t), "geo_point?");
     }
 
     #[test]

--- a/src/textify/types.rs
+++ b/src/textify/types.rs
@@ -1045,6 +1045,41 @@ mod tests {
     }
 
     #[test]
+    fn u_prefix_type_textifies_with_prefix() {
+        // A type registered as "u!json" must textify back as "u!json", not bare "json".
+        let ctx = TestContext::new()
+            .with_urn(1, "urn:example:types")
+            .with_type(1, 5, "u!json");
+
+        let t = proto::Type {
+            kind: Some(ptype::Kind::UserDefined(ptype::UserDefined {
+                type_variation_reference: 0,
+                nullability: ptype::Nullability::Required as i32,
+                type_reference: 5,
+                type_parameters: vec![],
+            })),
+        };
+        assert_eq!(ctx.textify_no_errors(&t), "u!json");
+    }
+
+    #[test]
+    fn u_prefix_type_nullable_textifies_with_prefix_and_nullability() {
+        let ctx = TestContext::new()
+            .with_urn(1, "urn:example:types")
+            .with_type(1, 7, "u!geo_point");
+
+        let t = proto::Type {
+            kind: Some(ptype::Kind::UserDefined(ptype::UserDefined {
+                type_variation_reference: 0,
+                nullability: ptype::Nullability::Nullable as i32,
+                type_reference: 7,
+                type_parameters: vec![],
+            })),
+        };
+        assert_eq!(ctx.textify_no_errors(&t), "u!geo_point?");
+    }
+
+    #[test]
     fn named_anchor_compact_plain_name_non_unique_shows_anchor() {
         let ctx = TestContext::new()
             .with_urn(1, "urn1")

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -376,7 +376,7 @@ Functions:
 
 === Plan
 Root[result]
-  Project[json_extract_path($0, $1)]
+  Project[json_extract_path($0, $1):string]
     Read[data => doc:string, path:string]"#;
 
     // Explicit compound name in the call site resolves to the same canonical output.
@@ -388,7 +388,7 @@ Functions:
 
 === Plan
 Root[result]
-  Project[json_extract_path:u!json_str($0, $1)]
+  Project[json_extract_path:u!json_str($0, $1):string]
     Read[data => doc:string, path:string]"#;
 
     roundtrip_plan(canonical);

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -252,25 +252,40 @@ Root[ts, ts_tz, pt]
 
 #[test]
 fn test_u_prefix_type_in_schema_roundtrip() {
-    let plan = r#"=== Extensions
+    // Types are declared without u! in the Extensions section. The u! prefix is
+    // accepted but ignored in plan references (both "doc:json" and "doc:u!json" resolve
+    // to the same type), and output is always the bare name.
+    let canonical = r#"=== Extensions
 URNs:
   @  1: https://example.com/types
 Types:
-  #  5 @  1: u!json
+  #  5 @  1: json
+
+=== Plan
+Root[result]
+  Project[$0]
+    Read[data => doc:json]"#;
+
+    // Plan authored with u! prefix on the type reference round-trips to the canonical form.
+    let with_prefix = r#"=== Extensions
+URNs:
+  @  1: https://example.com/types
+Types:
+  #  5 @  1: json
 
 === Plan
 Root[result]
   Project[$0]
     Read[data => doc:u!json]"#;
 
-    roundtrip_plan(plan);
+    assert_roundtrip_canonical(canonical, with_prefix);
 }
 
 #[test]
 fn test_u_prefix_type_in_function_declaration_roundtrip() {
-    // The declaration preserves the full compound name including the u!-prefixed
-    // signature. The call site uses the compact base name since the function is unique.
-    let plan = r#"=== Extensions
+    // The declaration preserves the full compound name including the u!-prefixed signature.
+    // The call site uses the compact base name since the function is unique.
+    let canonical = r#"=== Extensions
 URNs:
   @  1: https://example.com/funcs
 Functions:
@@ -281,7 +296,50 @@ Root[result]
   Project[json_extract_path($0, $1)]
     Read[data => doc:string, path:string]"#;
 
-    roundtrip_plan(plan);
+    // Explicit compound name in the call site resolves to the same canonical output.
+    let with_signature = r#"=== Extensions
+URNs:
+  @  1: https://example.com/funcs
+Functions:
+  #  5 @  1: json_extract_path:u!json_str
+
+=== Plan
+Root[result]
+  Project[json_extract_path:u!json_str($0, $1)]
+    Read[data => doc:string, path:string]"#;
+
+    roundtrip_plan(canonical);
+    assert_roundtrip_canonical(canonical, with_signature);
+}
+
+#[test]
+fn test_u_prefix_type_in_cast_roundtrip() {
+    // A cast to a u!-prefixed UDT: both "::u!json" and "::json" in the plan resolve to
+    // the same type. Canonical output always uses the bare name.
+    let canonical = r#"=== Extensions
+URNs:
+  @  1: https://example.com/types
+Types:
+  #  5 @  1: json
+
+=== Plan
+Root[result]
+  Project[($0)::json]
+    Read[data => doc:string]"#;
+
+    let with_prefix = r#"=== Extensions
+URNs:
+  @  1: https://example.com/types
+Types:
+  #  5 @  1: json
+
+=== Plan
+Root[result]
+  Project[($0)::u!json]
+    Read[data => doc:string]"#;
+
+    roundtrip_plan(canonical);
+    assert_roundtrip_canonical(canonical, with_prefix);
 }
 
 #[test]

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -251,6 +251,40 @@ Root[ts, ts_tz, pt]
 }
 
 #[test]
+fn test_u_prefix_type_in_schema_roundtrip() {
+    let plan = r#"=== Extensions
+URNs:
+  @  1: https://example.com/types
+Types:
+  #  5 @  1: u!json
+
+=== Plan
+Root[result]
+  Project[$0]
+    Read[data => doc:u!json]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_u_prefix_type_in_function_declaration_roundtrip() {
+    // The declaration preserves the full compound name including the u!-prefixed
+    // signature. The call site uses the compact base name since the function is unique.
+    let plan = r#"=== Extensions
+URNs:
+  @  1: https://example.com/funcs
+Functions:
+  #  5 @  1: json_extract_path:u!json_str
+
+=== Plan
+Root[result]
+  Project[json_extract_path($0, $1)]
+    Read[data => doc:string, path:string]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
 fn test_join_relation_roundtrip() {
     let plan = r#"=== Extensions
 URNs:


### PR DESCRIPTION
User-defined types with u! prefix support

The text format now fully supports user-defined types with the optional u! prefix used in Substrait YAML files. Both u!json and json refer to the same registered type — the prefix is normalized at storage time so declarations and plan references can use either form interchangeably. The canonical output always uses the bare name.

The u! prefix is accepted on type declarations in the Extensions section but is rejected on function and type-variation declarations, matching the Substrait spec. Function signatures may include u!-prefixed argument type codes (e.g. json_extract_path:u!json_str).

## Type of Change
- [x] Bug fix
- [x] New feature

## Testing
- [x] Added tests for new functionality
- [x] All existing tests pass


## Related Issues

Closes #148
