### PR TITLE
feat(parser): support typed null literals

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -179,9 +179,9 @@ Enum fields in arguments are represented as &-prefixed variants (e.g., `&AscNull
 
 ### `literal`
 
-A literal can come in the form of an integer, float, boolean, or string, and can have an optional additional type:
+A literal can be an integer, float, boolean, string, or null. Literals may include a type annotation:
 
-`literal := (float / integer / boolean / string) (":" type)?`
+`literal := (float / integer / boolean / string / "null") (":" type)?`
 
 - **`integer`**` := "-"? digit+`
   - Examples: `42`, `-10`, `0`
@@ -195,11 +195,14 @@ A literal can come in the form of an integer, float, boolean, or string, and can
 - **`string`**` := "'" ("\\" . / !"'" .)* "'"`
   - Examples: `'hello'`, `'table name'`, `'C:\path\to\file'`, `'line1\nline2'`, `'quote\'s here'`
   - Default to `string` type; other types may also be assigned
+- **`null`**` := "null"`
+  - Examples: `null:i64?`, `null:string?`, `null:date?`
+  - A type annotation is required for `null`
 - **`typed_literal`**` := string ":" type`
   - String literals with type annotations for non-primitive types
   - Examples: `'2023-01-01':date`, `'2023-12-25T14:30:45.123':timestamp`
 
-All basic literal types (`integer`, `float`, `boolean`, and `string`) are supported, plus `date`, `time`, and `timestamp` typed literals. Other Substrait literal types (e.g., `interval_year`, `decimal`, `uuid`) are not yet implemented.
+All basic literal types (`integer`, `float`, `boolean`, and `string`) are supported, plus `date`, `time`, `timestamp`, and typed null literals. Other Substrait literal types (e.g., `interval_year`, `decimal`, `uuid`) are not yet implemented.
 
 ## Types
 

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -9,6 +9,7 @@ identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
 integer    = @{ "-"? ~ ASCII_DIGIT+ }
 float      = @{ "-"? ~ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ }
 boolean    = @{ "true" | "false" }
+null       = @{ "null" }
 
 // Basic string literals, does not handle escape sequences for simplicity here.
 // String literals are for literal values
@@ -44,7 +45,7 @@ compound_name = @{ identifier ~ (":" ~ identifier?)? }
 // Field reference
 reference = { "$" ~ integer }
 // Literal
-literal = { (float | integer | boolean | string_literal) ~ (":" ~ sp ~ type)? }
+literal = { (float | integer | boolean | string_literal | null) ~ (":" ~ sp ~ type)? }
 
 // -- Components for types and functions
 anchor     = { "#" ~ sp ~ integer }

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -266,6 +266,26 @@ fn to_string_literal(
     }
 }
 
+fn to_null_literal(
+    value: pest::iterators::Pair<Rule>,
+    typ: Option<Type>,
+) -> Result<Literal, MessageParseError> {
+    assert_eq!(value.as_rule(), Rule::null);
+    let typ = typ.ok_or_else(|| {
+        MessageParseError::invalid(
+            "null_literal_type",
+            value.as_span(),
+            "Null literals require an explicit type annotation, e.g. null:i64?",
+        )
+    })?;
+
+    Ok(Literal {
+        literal_type: Some(LiteralType::Null(typ)),
+        nullable: false,
+        type_variation_reference: 0,
+    })
+}
+
 /// Parse a date string using chrono to days since Unix epoch
 fn parse_date_to_days(date_str: &str, span: pest::Span) -> Result<i32, MessageParseError> {
     // Try multiple date formats for flexibility
@@ -370,6 +390,7 @@ impl ScopedParsePair for Literal {
             Rule::float => to_float_literal(value, typ),
             Rule::boolean => to_boolean_literal(value, typ),
             Rule::string_literal => to_string_literal(value, typ),
+            Rule::null => to_null_literal(value, typ),
             _ => unreachable!("Literal unexpected rule: {:?}", value.as_rule()),
         }
     }

--- a/src/textify/expressions.rs
+++ b/src/textify/expressions.rs
@@ -164,7 +164,7 @@ fn write_literal_value<S: Scope, W: fmt::Write>(
         #[allow(deprecated)]
         LiteralType::TimestampTz(_) => unimplemented_literal("TimestampTz", ctx, w),
         LiteralType::Uuid(_) => unimplemented_literal("Uuid", ctx, w),
-        LiteralType::Null(_) => unimplemented_literal("Null", ctx, w),
+        LiteralType::Null(_) => write!(w, "null"),
         LiteralType::List(_) => unimplemented_literal("List", ctx, w),
         LiteralType::EmptyList(_) => unimplemented_literal("EmptyList", ctx, w),
         LiteralType::EmptyMap(_) => unimplemented_literal("EmptyMap", ctx, w),
@@ -242,6 +242,10 @@ impl Textify for expr::Literal {
             Visibility::Always => true,
             Visibility::Required => self.nullable || !is_default_for_syntax(lit),
         };
+        if let LiteralType::Null(typ) = lit {
+            write!(w, ":{}", ctx.expect(Some(typ)))?;
+            return Ok(());
+        }
         if show_suffix {
             if let Some(suffix) = literal_type_suffix(lit) {
                 write!(w, ":{suffix}")?;

--- a/tests/literal_roundtrip.rs
+++ b/tests/literal_roundtrip.rs
@@ -3,6 +3,7 @@
 mod common;
 
 use common::roundtrip_plan;
+use substrait_explain::Parser;
 
 #[test]
 fn test_float_literal_roundtrip() {
@@ -112,6 +113,35 @@ Root[result]
     Read[data => a:i64]
 "#;
     roundtrip_plan(plan);
+}
+
+#[test]
+fn test_null_literal_roundtrip() {
+    let plan = r#"
+=== Plan
+Root[result]
+  Project[null:i64?, null:string?, null:date?]
+    Read[data => a:i64]
+"#;
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_bare_null_literal_requires_type() {
+    let plan = r#"
+=== Plan
+Root[result]
+  Project[null]
+    Read[data => a:i64]
+"#;
+
+    let error = Parser::parse(plan).expect_err("bare null literal should fail");
+    assert!(
+        error
+            .to_string()
+            .contains("Null literals require an explicit type annotation"),
+        "unexpected error: {error}"
+    );
 }
 
 #[test]

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -583,6 +583,16 @@ Root[id, name]
 }
 
 #[test]
+fn test_virtual_read_typed_null_roundtrip() {
+    let plan = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[(1, null:string?), (2, 'bob') => id:i64, name:string?]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
 fn test_virtual_read_empty() {
     let plan = r#"
 === Plan


### PR DESCRIPTION
## Description

This PR adds typed null literals to the text format. For example:

```text
Project[null:i64?, null:string?, null:date?]
```

Bare `null` is still rejected in ordinary expressions because Substrait requires `null` to be typed, and we currently have no type inference set up.

## Changes

- Adds `null` to the literal grammar.
- Parses `null:<type>` into `LiteralType::Null(Type)`.
- Textifies null literals back as `null:<type>`.
- Documents typed null literal syntax in `GRAMMAR.md`.
- Adds roundtrip coverage for typed nulls, including `Read:Virtual[(1, null:string?), ...]`.
- Adds a negative test for bare `null` without a type annotation.

## API Impact

- Text format now accepts typed null literals.
- Bare `null` remains invalid outside contexts that add inference later.