### PR TITLE
docs: add agent contribution guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,8 @@ Relations generally follow `RelationName[arguments => output_columns]` with
 
 ## Routing
 
+- For project-level design philosophy like compatibility expectations, error handling
+  posture, extension boundaries, or format change guidance, read `DESIGN.md`.
 - For syntax or text-format changes, read `GRAMMAR.md` and update the docs,
   Pest grammar, parser, textifier, and roundtrip tests together.
 - For contributor process, PR expectations, issue shape, or public guidance,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,99 @@
+# AGENTS.md
+
+This file gives AI agents the repository-specific context needed to work on
+`substrait-explain`. Read `AGENTS.local.md` if it exists.
+
+For contributor-facing policy, use `CONTRIBUTING.md` as the source of truth.
+
+## Development Commands
+
+- `just fmt` - Format code with custom import grouping
+- `just check` - Run clippy checks
+- `just fix` - Format code and auto-fix clippy issues where possible
+- `just test` - Run tests, examples, and CLI validation
+- `cargo check` - Check compilation without producing a final binary
+- `cargo test --doc` - Test documentation examples; required for `GRAMMAR.md` changes
+- `cargo test -- --nocapture` - Run tests with output visible
+- `bash pre-commit.sh install` - Install local formatting/linting hooks
+
+## Architecture
+
+`substrait-explain` is a bidirectional parser/formatter for Substrait query
+plans:
+
+- Text format -> Substrait protobuf: `src/parser/`
+- Substrait protobuf -> text format: `src/textify/`
+- Extension function/type handling: `src/extensions/`
+
+Key files:
+
+- `src/parser/structural.rs` handles document structure and indentation.
+- `src/parser/expression_grammar.pest` defines relation, expression, literal,
+  type, extension, and addendum syntax.
+- `src/grammar.rs` exposes `GRAMMAR.md` as crate documentation for doctests and
+  generated docs.
+- `src/textify/foundation.rs` provides formatting infrastructure and error
+  accumulation.
+- `src/textify/plan.rs`, `src/textify/rels.rs`, `src/textify/expressions.rs`,
+  and `src/textify/types.rs` format plans, relations, expressions, and types.
+
+The text format has optional `=== Extensions` and required `=== Plan` sections.
+Relations generally follow `RelationName[arguments => output_columns]` with
+2-space indentation showing the plan tree.
+
+## Development Rules
+
+- Prefer code that supports local reasoning: keep invariants close to the data
+  they describe, avoid unnecessary cross-module helper plumbing, and use named
+  types or trait implementations when signatures can carry intent.
+- When implementing or documenting support for a Substrait feature, start from
+  the upstream spec or protobuf definition. Link the relevant reference in the
+  issue or PR, use upstream terminology where it exists, and describe
+  `substrait-explain` text-format choices as representation choices rather than
+  changes to Substrait itself.
+- Parser code should fail with contextual errors for bad input. Pest pair
+  parsers may unwrap only when the grammar enforces the invariant, and should
+  assert the expected rule first.
+- Textifier code should accumulate errors and keep producing best-effort output.
+  Do not panic or silently emit invalid text for malformed, older, or partially
+  populated protobuf input.
+- Tests may unwrap known-good inputs. Prefer expected-value assertions when they
+  are readable, but avoid huge hand-built protobuf expectations when focused
+  property checks communicate the behavior better.
+
+## Routing
+
+- For syntax or text-format changes, read `GRAMMAR.md` and update the docs,
+  Pest grammar, parser, textifier, and roundtrip tests together.
+- For contributor process, PR expectations, issue shape, or public guidance,
+  read `CONTRIBUTING.md`.
+- For local workflow or user-specific rules, read `AGENTS.local.md` if it
+  exists.
+- For release-process changes, read `RELEASING.md`.
+- For review tasks, inspect the actual diff first and focus on regressions,
+  missing tests, API boundaries, and grammar/parser/textifier alignment.
+
+## Grammar and Text Format
+
+- Treat `GRAMMAR.md` as the user-facing text-format contract.
+- For syntax changes, update `GRAMMAR.md`, the Pest grammar, parser,
+  textifier, and roundtrip tests together so accepted input and produced output
+  stay aligned.
+- `GRAMMAR.md` uses PEG-style documentation syntax. Do not copy Pest-specific
+  syntax (e.g. `~` or `|`) into the user-facing grammar.
+- Documentation examples must compile. Run `cargo test --doc` when changing
+  `GRAMMAR.md`.
+- Rustdoc hides lines that begin with `#`; use `##` for literal `#` characters
+  in Substrait syntax examples.
+- Prefer readable defaults in text output when they do not lose information.
+  Keep common cases concise while preserving anchors, signatures, types, and
+  extension references where needed for disambiguation.
+
+## Project Notes
+
+- Keep this file concise and agent-oriented. Contributor-facing policy belongs
+  in `CONTRIBUTING.md`; user- or workspace-specific workflow belongs in
+  `AGENTS.local.md`.
+- Public API changes should be intentional. In PR descriptions, state whether
+  the change preserves compatibility, intentionally breaks compatibility, or
+  narrows an accidentally exposed internal surface.

--- a/API.md
+++ b/API.md
@@ -13,6 +13,9 @@ A Rust library that converts Substrait query plans between protobuf format and a
 - **Flexible formatting**: Configurable output options for different use cases
 - **Complete grammar**: Full specification of the text format in the [`grammar`] module
 
+For project-level design principles, compatibility expectations, and format
+change guidance, see the
+[design philosophy](https://github.com/DataDog/substrait-explain/blob/main/DESIGN.md).
 For installation instructions, see the [README](https://github.com/DataDog/substrait-explain/blob/main/README.md).
 
 ## Quick Start

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+Read AGENTS.md. Also read AGENTS.local.md if it exists.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,8 @@ For non-trivial bug fixes, please open an issue first to discuss the problem and
    just fmt                      # Format code
    just check                    # Run linting and checks
    just fix                      # Format code, auto-fix clippy errors
-   cargo test                    # Run all tests
+   just test                     # Run all tests and examples
+   cargo test                    # Run Rust tests
    cargo test -- --nocapture     # Run tests with output
    cargo run --example basic_usage
    cargo doc --open              # View documentation
@@ -56,7 +57,9 @@ For non-trivial bug fixes, please open an issue first to discuss the problem and
 - Add documentation for public APIs, and review them with `cargo doc --open`
 - Include tests for new functionality
 - **Import organization**: Prefer module-level imports over function-level `use` statements or long inline type references (e.g., `use substrait::proto::RelType;` at module level rather than `substrait::proto::RelType` inline)
+- **Structure for local reasoning**: Prefer code that keeps invariants close to the data they describe. Use named intermediate types, trait implementations, or methods when they make parser/textifier behavior easier to understand from signatures and local context. Avoid helper functions whose signatures expose unrelated state or spread one concept across several modules.
 - **Pattern matching depth**: Avoid deeply nested pattern matching (if-let chains, match arms). Prefer sequential operations with let-else patterns or early returns for clarity
+
   ```rust
   // Good: Sequential with let-else
   let Some(root) = plan.relations.first_mut() else {
@@ -73,6 +76,7 @@ For non-trivial bug fixes, please open an issue first to discuss the problem and
       }
   }
   ```
+
 - **Unused parameters**: When refactoring changes behavior, remove parameters that are no longer used rather than prefixing with underscore
 
 ### Project-Specific Guidelines
@@ -81,10 +85,13 @@ For non-trivial bug fixes, please open an issue first to discuss the problem and
 
 This project implements Substrait protobuf plan parsing and formatting. See the [official Substrait documentation](https://substrait.io/) for the complete specification, including output mapping rules per relation type.
 
+When implementing or documenting support for a Substrait feature, start from the upstream spec or protobuf definition. Link the relevant reference in the issue or PR, use upstream terminology where it exists, and describe `substrait-explain` text-format choices as representation choices rather than changes to Substrait itself.
+
 ##### Project-specific text format patterns
 
 - **Enum textification**: All Substrait enums use `&` prefix in text format (e.g., `&Inner`, `&AscNullsFirst`)
 - **Unknown enum handling**: For invalid/unknown enum values, use `Value::Missing(PlanError)` and fallback to reasonable default enum value (usually `UNSPECIFIED`) for processing
+- **Readable defaults**: Prefer concise, human-readable text output when it does not lose information. Syntax should make the common case clear while still preserving enough detail to disambiguate Substrait/Protobuf specifics like anchors, signatures, types, and extension references when needed.
 
 #### Error Handling Patterns
 
@@ -104,7 +111,7 @@ fn parse_pair(pair: pest::iterators::Pair<Rule>) -> Self {
 }
 ```
 
-_Note: Ideally, `pest_derive` would remove the need for unwraps by providing structural types that encode the invariants, ensuring at compile-time the grammar and code remain in sync._
+_Note: Ideally, `pest_derive` would remove the need for unwraps by providing structural types that encode the invariants, ensuring at compile-time the grammar and code remain in sync; however, that functionality does not yet fully exist._
 
 ##### Other Parsing Context (e.g., lookups)
 
@@ -195,10 +202,14 @@ When working with [`GRAMMAR.md`](GRAMMAR.md):
 - Use PEG format with `rule_name := definition` syntax
 - Run `cargo test --doc` to verify all code examples compile
 - Ensure all referenced identifiers are properly defined somewhere in the grammar
+- Treat `GRAMMAR.md` as the user-facing text-format contract. For syntax changes, update the docs, Pest grammar, parser, textifier, and roundtrip tests together so accepted input and produced output stay aligned.
+- Describe the user-facing grammar clearly rather than copying Pest syntax directly. Pest-specific details such as `~` for concatenation and `|` for choice belong in `src/parser/expression_grammar.pest`, not in the documentation grammar. The syntax described by `GRAMMAR.md` and the Pest grammar should match; however, naming and/or structuring (e.g. inlining rules) may differ so that `GRAMMAR.md` prioritizes user-facing documentation whereas the Pest grammar must also lead to code generation.
 
 #### Testing Guidelines
 
 **Roundtrip testing**: The most effective validation is parse→format→parse comparison. Parse text to protobuf, format back to text, and verify the output matches the input. See `tests/plan_roundtrip.rs` for examples.
+
+When changing protobuf-to-text behavior, include tests for raw, malformed, older, or partially populated protobuf inputs when relevant. Textification should surface missing or unsupported fields through accumulated errors and `!{...}` output rather than panicking or silently producing text the parser cannot read.
 
 **Assert on expected values, not just properties**: When testing structured output, prefer comparing against concrete expected values rather than only checking lengths or other surface-level properties. Use judgment for deeply nested structures where building a full expected value would be unwieldy — property-based checks are fine there. For example:
 
@@ -219,15 +230,18 @@ assert_eq!(result.len(), 3);
 3. Make your changes
 4. Add tests for new functionality
 5. Commit your changes with a clear message
-   - Pre-commit hooks will automatically run tests, clippy, and formatting
+   - Pre-commit hooks run formatting and clippy; run `just test` locally or rely on CI for tests and examples
 6. Push to the branch (`git push origin feature-name`)
 7. Open a Pull Request
 
 **PR Guidelines:**
 
 - Keep changes focused and atomic
-- Include tests for new functionality
-- Update documentation if needed
+- Make the PR title and description match the actual scope. If one diff implements multiple concepts, split it or call out the combined scope explicitly so reviewers can reason about it.
+- Use [Conventional Commits](https://www.conventionalcommits.org/) syntax for PR titles, which are automatically compiled into our Changelog.
+- Include tests for new functionality.
+- Update documentation if needed.
+- For public API changes, state whether the change preserves compatibility, intentionally breaks compatibility, or narrows an accidentally exposed internal surface.
 - Ensure all CI checks pass
   - You may wish to leave it in 'Draft' form until you validate this
 - Provide a clear description of what the PR does
@@ -242,6 +256,20 @@ version bumping or changelog entries — just use
 release automation handles the rest.
 
 ## Contributing to Issues
+
+### Feature Requests
+
+Feature Requests should:
+
+- Clearly state the missing feature at a user level.
+  - If the feature is support for a particular Substrait feature, describe the Substrait feature in terms of Substrait itself (<https://substrait.io/>), not in terms of language-specific libraries.
+- Give a reproducible example wherever possible / reasonable. This should include both the input and commands to reproduce, and the output / errors it produced.
+  - For example, a Substrait feature would ideally include a JSON form of a plan with the feature in it, and show the output when running substrait-explain (e.g. the output of `substrait-explain convert ...`).
+- (Optional) Possible solutions, with a recommendation.
+  - If desired, suggest what some possible options are, and what your preference might be and why.
+  - In particular, focus on the user-level API / syntax changes.
+
+Example issue: <https://github.com/DataDog/substrait-explain/issues/160>
 
 ### Contributing to reporting bugs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,8 @@ For non-trivial bug fixes, please open an issue first to discuss the problem and
 
 ### Project-Specific Guidelines
 
+See the overall [Design Philosophy documentation](DESIGN.md) for the project-level design principles and [`GRAMMAR.md`](GRAMMAR.md) for the user-facing syntax contract.
+
 #### Substrait-Specific Development
 
 This project implements Substrait protobuf plan parsing and formatting. See the [official Substrait documentation](https://substrait.io/) for the complete specification, including output mapping rules per relation type.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,120 @@
+# Design Philosophy
+
+`substrait-explain` is a human-facing text format and toolchain for Substrait
+plans. It should make generated plans easy to inspect, discuss, test, and
+round-trip. It prioritizes both being human-readable in its syntax, with its
+semantics closely tied to Substrait and its protobuf format.
+
+For the detailed syntax principles of the text format itself, see
+[`GRAMMAR.md`](GRAMMAR.md).
+
+## What This Project Is For
+
+Substrait protobuf plans are precise and portable, but they are verbose and hard
+to read directly. `substrait-explain` exists to give those plans a compact,
+stable text representation that is useful for:
+
+- debugging generated query plans;
+- writing readable examples, fixtures, and tests;
+- converting between text, JSON, YAML, and binary protobuf forms;
+- preserving enough Substrait structure to parse the text back into protobuf;
+- discussing plan structure without expanding deeply nested protobuf fields.
+
+The text format is not SQL, an optimizer IR, or a semantic validator for all of
+Substrait. It is a representation of Substrait plan structure.
+
+## Core Principles
+
+### Human Audience, Protobuf Semantics
+
+The primary reader is a human trying to understand a plan. The primary data
+model is still Substrait protobuf. Text should be concise and regular, but
+format choices should map back to concrete Substrait fields. The _syntax_ of
+`substrait-explain` is intended for humans; the _semantics_ should match
+Substrait.
+
+### Bidirectional
+
+Supported Substrait features should exist in both the parser and formatter, with
+identical syntax and semantics. To support this, the canonical testing method is
+a round-trip test:
+
+1. parse text into protobuf;
+2. format protobuf back to text;
+3. compare the canonical text output.
+
+This demonstrates that the syntax and semantics are equivalent between the two,
+and as the protobuf is in between, also indirectly demonstrates that the feature
+is mapping to and from the protobuf format. Note that arbitrary or newer
+protobufs may contain unsupported fields, old encodings, or custom payloads that
+need best-effort output.
+
+### Lenient Conversion, Explicit Warnings
+
+Parsing and formatting should accept representable plans even when they are not
+fully valid Substrait. If the text or protobuf has a clear mapping into the
+supported `substrait-explain` model, conversion should usually preserve it rather
+than reject it for semantic issues such as invalid URNs, type mismatches, or
+function arity problems.
+
+Invalidity should be reported as diagnostics or warnings where possible. That is
+partly implemented and partly aspirational today: formatting already has an
+error channel for degraded output, but parsing does not yet have a warning
+channel, and output does not perform full validation or type checking. The
+design goal is to keep conversion and validation separate so users can still
+inspect, debug, and round-trip plans that are good enough to represent.
+
+Parsing should still reject input that is structurally ambiguous, missing fields
+needed to build the protobuf shape, or outside the supported text-format contract.
+Formatting should make unsupported or malformed protobuf structure visible rather
+than panicking or silently dropping the problem.
+
+### Neutral Extension Support
+
+Substrait extensions are intentionally open-ended, and `substrait-explain` should
+stay neutral rather than baking in one organization's extension catalog or
+semantics. The project should provide broad syntax, data structures, and hooks
+that let extension users represent their plans without requiring those extensions
+to live in this repository.
+
+Simple extensions are supported as first-class text-format concepts via the
+`=== Extensions` section. Consistent with lenient conversion, `substrait-explain`
+does not need to validate those declarations against external YAML extension
+files in order to preserve them.
+
+Advanced extensions carry `google.protobuf.Any` payloads and require external
+serialization/deserialization, and so are supported via a registry system,
+allowing users to extend `substrait-explain` to get full support for their
+advanced extensions. For extensions without handlers, the formatter should still
+preserve the surrounding plan and report the unsupported payload clearly.
+
+### Regular, Readable Syntax Over Protobuf Verbosity
+
+The text format should expose the important plan shape directly: relation names,
+arguments, output columns, expressions, types, extensions, and hierarchy. It
+should avoid mirroring every protobuf nesting level when a regular text form can
+represent the same structure more clearly.
+
+### Boundaries Should Be Documented
+
+Unsupported Substrait features are expected while the project grows. The docs
+should state current boundaries clearly and point users to the grammar or API
+surface that is actually implemented. Avoid broad support claims that are true
+only for part of the library.
+
+## Changing The Format
+
+Format changes should preserve the project goals above:
+
+- start from the upstream Substrait spec or protobuf definition;
+- describe text-format choices as representation choices, not Substrait changes;
+- update `GRAMMAR.md`, the Pest grammar, parser, textifier, and round-trip tests
+  together when syntax changes;
+- prefer canonical output that is easy to diff and review;
+- keep conversion lenient where the plan is representable, while surfacing
+  invalidity through diagnostics where the current APIs support it;
+- document any compatibility impact in the PR.
+
+`GRAMMAR.md` is the user-facing text-format contract. This file explains the
+larger design posture that humans and agents should use before changing that
+contract.

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -11,6 +11,10 @@ The Substrait text format consists of two main sections:
 
 ## Design Principles
 
+This section describes the syntax and semantics principles of the text-format
+DSL. For the repository-level design philosophy, compatibility expectations, and
+format change guidance, see [`DESIGN.md`](DESIGN.md).
+
 The grammar is designed around several concrete choices that make it practical and consistent:
 
 ### 1. Single-Line, Structured Relations
@@ -353,7 +357,7 @@ Currently, only references to fields in the Relations' input are supported.
 
 ```rust
 # use substrait_explain::Parser;
-# 
+#
 # let plan_text = r#"
 === Plan
 Root[result]
@@ -439,7 +443,7 @@ An IfThen expression is a conditional function or logical operator that evaluate
 
 ```rust
 # use substrait_explain::Parser;
-# 
+#
 # let plan_text = r#"
 === Plan
 Root[status]
@@ -447,7 +451,7 @@ Root[status]
     Project[if_then(true -> $0, false -> $1, _ -> $2)]
       Read[events.logs => status:string?]
 #  "#;
-# 
+#
 #  let plan = Parser::parse(plan_text).unwrap();
 #  assert_eq!(plan.relations.len(), 1);
 ```

--- a/README.md
+++ b/README.md
@@ -109,9 +109,21 @@ Root[revenue]
 
 Now you can easily see what the query does: it reads from an orders table, multiplies quantity and price, filters for orders where the result is greater than 100, and outputs the revenue.
 
+## Design Philosophy
+
+`substrait-explain` is human-first and protobuf-backed. It provides a readable
+text representation for inspecting, discussing, testing, and round-tripping
+Substrait plans; it is not SQL, an optimizer IR, or a replacement for Substrait
+protobuf.
+
+For the project-level design stance, including round-trip expectations, error
+handling, extension boundaries, and guidance for changing the format, see
+[`DESIGN.md`](DESIGN.md). For the syntax and semantics of the text format itself,
+see [`GRAMMAR.md`](GRAMMAR.md).
+
 ## Supported Relations
 
-The following Substrait relations are currently supported in the text format:
+The core text format currently supports these standard relations:
 
 - `Read`
 - `Project`
@@ -121,7 +133,11 @@ The following Substrait relations are currently supported in the text format:
 - `Sort`
 - `Root`
 
-Support for additional relations (e.g., Set, Fetch, Window, etc.) is planned for future releases.
+The grammar also documents supported read variants, extension relations, and
+advanced extension addenda. For the full current syntax contract, see
+[`GRAMMAR.md`](GRAMMAR.md).
+
+Support for additional standard relations (e.g., Set, Window, etc.) is planned for future releases.
 If you need a specific relation, please open an issue or contribute!
 
 ## Quick Start
@@ -181,6 +197,7 @@ substrait = "0.57.0"  # For protobuf types
 
 ## Documentation
 
+- **[Design Philosophy](https://github.com/DataDog/substrait-explain/blob/main/DESIGN.md)** - Project-level design principles, compatibility expectations, and change guidance
 - **[API Documentation](https://github.com/DataDog/substrait-explain/blob/main/API.md)** - Complete API reference with examples and configuration options
 - **[Grammar Specification](https://github.com/DataDog/substrait-explain/blob/main/GRAMMAR.md)** - Detailed specification of the text format grammar
 - **[Full Documentation](https://datadoghq.dev/substrait-explain/substrait_explain/)** - Generated API docs using GitHub Pages, including grammar and API docs.


### PR DESCRIPTION
## Description

This PR adds checked-in guidance for AI agents working in this repository, plus a small Claude compatibility pointer.

The intent is to give agents a clear entry point for repo-specific expectations without turning `CONTRIBUTING.md` into agent-only workflow docs. `AGENTS.md` covers the implementation context agents need most often: commands, parser/textifier architecture, grammar routing, text-format expectations, and review focus areas. `CLAUDE.md` points Claude-style agents at `AGENTS.md` and an optional local override file. `DESIGN.md` describes the repository design philosophy.

## Changes

- Adds `AGENTS.md` as the checked-in agent entry point for this repo.
- Adds `DESIGN.md`, describing overall design philosophy, with links to it from `AGENTS.md` and elsewhere.
- Adds `CLAUDE.md` as a one-line compatibility shim:
  ```text
  Read AGENTS.md. Also read AGENTS.local.md if it exists.
  ```
- Updates `CONTRIBUTING.md` with review-derived contributor guidance:
  - use `just test` for full tests/examples
  - keep syntax changes aligned across `GRAMMAR.md`, Pest grammar, parser, textifier, and roundtrip tests
  - treat Substrait behavior as upstream semantics and `substrait-explain` syntax as representation choices
  - call out public API compatibility in PRs
  - include concrete feature-request examples when possible

The `CONTRIBUTING.md` updates were gathered from recent PR reviews; hopefully they will be helpful for users / AI agents reviewing further.

## Validation

- Documentation-only change.
