### PR TITLE
feat!: Add - as a new line type to substrait-explain's parser within virtual tables

### DIFF
--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -224,9 +224,11 @@ named_column_list = { (named_column ~ ("," ~ sp ~ named_column)*)? }
 planNode = {
     // Specialized read relations must precede read_relation: all start with
     // "Read", and PEG tries alternatives in order — the longer prefixes
-    // must be attempted first.
+    // must be attempted first. virtual_read_relation (full inline form) must
+    // precede virtual_read_relation_open (opening bracket only).
     extension_read_relation
   | virtual_read_relation
+  | virtual_read_relation_open
   | read_relation
   | filter_relation
   | project_relation
@@ -254,10 +256,13 @@ extension_read_relation = { "Read:Extension" ~ "[" ~ named_column_list ~ "]" }
 
 // VirtualTable read: Read:Virtual[rows => columns] or Read:Virtual[_ => columns]
 // Rows are parenthesized tuples; _ means empty (no rows).
-virtual_read_relation = { "Read:Virtual" ~ "[" ~ virtual_read_args ~ sp ~ "=>" ~ sp ~ named_column_list ~ "]" }
-virtual_read_args     = { virtual_row_list | empty }
-virtual_row_list      = { virtual_row ~ (sp ~ "," ~ sp ~ virtual_row)* }
-virtual_row           = { "(" ~ sp ~ expression_list? ~ sp ~ ")" }
+// virtual_read_relation_open is the opening bracket only; rows and schema follow
+// on `- ` continuation lines.
+virtual_read_relation      = { "Read:Virtual" ~ "[" ~ virtual_read_args ~ sp ~ "=>" ~ sp ~ named_column_list ~ "]" }
+virtual_read_relation_open = { "Read:Virtual[" }
+virtual_read_args          = { virtual_row_list | empty }
+virtual_row_list           = { virtual_row ~ (sp ~ "," ~ sp ~ virtual_row)* }
+virtual_row                = { "(" ~ sp ~ expression_list? ~ sp ~ ")" }
 
 filter_relation = { "Filter" ~ "[" ~ expression ~ sp ~ "=>" ~ sp ~ reference_list ~ "]" }
 reference_list  = { (reference ~ (sp ~ "," ~ sp ~ reference)*)? }

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -401,11 +401,13 @@ impl VirtualReadRel {
             .trim_end();
 
         let columns = {
-            let mut pairs =
-                <ExpressionParser as pest::Parser<Rule>>::parse(Rule::named_column_list, schema_str)
-                    .map_err(|e| {
-                        MessageParseError::new("named_column_list", ErrorKind::Syntax, Box::new(e))
-                    })?;
+            let mut pairs = <ExpressionParser as pest::Parser<Rule>>::parse(
+                Rule::named_column_list,
+                schema_str,
+            )
+            .map_err(|e| {
+                MessageParseError::new("named_column_list", ErrorKind::Syntax, Box::new(e))
+            })?;
             let pair = pairs.next().expect("named_column_list yields one pair");
             NamedColumnList::parse_pair(extensions, pair)?.0
         };

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -15,7 +15,10 @@ use substrait::proto::{
     RelCommon, SortField, SortRel, Type, aggregate_rel, join_rel, read_rel, r#type,
 };
 
-use super::{MessageParseError, ParsePair, Rule, RuleIter, ScopedParsePair, unwrap_single_pair};
+use super::{
+    ErrorKind, ExpressionParser, MessageParseError, ParsePair, Rule, RuleIter, ScopedParsePair,
+    unwrap_single_pair,
+};
 use crate::extensions::any::Any;
 use crate::extensions::registry::ExtensionError;
 use crate::extensions::{AddendumKind, ExtensionArgs, ExtensionRegistry, SimpleExtensions};
@@ -354,6 +357,88 @@ impl RelationParsePair for ReadRel {
 /// proto type is `ReadRel` (same as `NamedTable`), but the grammar and handling
 /// are different.
 pub(crate) struct VirtualReadRel(ReadRel);
+
+impl VirtualReadRel {
+    /// Parse the multi-line `Read:Virtual[` form from raw continuation-line
+    /// content strings.  Each `&str` in `contents` is the text after the
+    /// leading `"- "` prefix, still pointing into the original input so Pest
+    /// can borrow it without allocation.
+    ///
+    /// All but the last element are row lines of the form `(expr, ...) [,]`.
+    /// The last element is the schema line: `=> col:type, ... ]`.
+    pub(crate) fn parse_from_continuation_contents<'i>(
+        extensions: &SimpleExtensions,
+        contents: &[&'i str],
+    ) -> Result<(Self, usize), MessageParseError> {
+        // The caller guarantees contents is non-empty (schema line is required).
+        let (row_contents, schema_content): (&[&'i str], &'i str) = {
+            let (last, rest) = contents
+                .split_last()
+                .expect("parse_from_continuation_contents called with empty contents");
+            (rest, *last)
+        };
+
+        // Parse schema line: strip leading `=>` and trailing `]`.
+        let after_arrow = schema_content.trim().strip_prefix("=>").ok_or_else(|| {
+            let span = pest::Span::new(schema_content, 0, schema_content.len()).unwrap();
+            MessageParseError::invalid(
+                "VirtualReadRel",
+                span,
+                "last continuation line of Read:Virtual[ must start with `=>`",
+            )
+        })?;
+        let schema_str = after_arrow
+            .trim_start()
+            .strip_suffix(']')
+            .ok_or_else(|| {
+                let span = pest::Span::new(schema_content, 0, schema_content.len()).unwrap();
+                MessageParseError::invalid(
+                    "VirtualReadRel",
+                    span,
+                    "last continuation line of Read:Virtual[ must end with `]`",
+                )
+            })?
+            .trim_end();
+
+        let columns = {
+            let mut pairs =
+                <ExpressionParser as pest::Parser<Rule>>::parse(Rule::named_column_list, schema_str)
+                    .map_err(|e| {
+                        MessageParseError::new("named_column_list", ErrorKind::Syntax, Box::new(e))
+                    })?;
+            let pair = pairs.next().expect("named_column_list yields one pair");
+            NamedColumnList::parse_pair(extensions, pair)?.0
+        };
+
+        // Parse each row line: strip optional trailing `,` then parse as virtual_row.
+        let rows = row_contents
+            .iter()
+            .map(|content: &&'i str| {
+                let row_str: &'i str = content.trim_end().trim_end_matches(',').trim_end();
+                let mut pairs =
+                    <ExpressionParser as pest::Parser<Rule>>::parse(Rule::virtual_row, row_str)
+                        .map_err(|e| {
+                            MessageParseError::new("virtual_row", ErrorKind::Syntax, Box::new(e))
+                        })?;
+                let pair = pairs.next().expect("virtual_row yields one pair");
+                parse_virtual_row(extensions, pair)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let output_count = columns.len();
+        Ok((
+            VirtualReadRel(ReadRel {
+                base_schema: Some(build_named_struct(columns)),
+                read_type: Some(read_rel::ReadType::VirtualTable(read_rel::VirtualTable {
+                    expressions: rows,
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }),
+            output_count,
+        ))
+    }
+}
 
 impl RelationParsePair for VirtualReadRel {
     fn rule() -> Rule {

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -59,12 +59,29 @@ pub struct Addendum<'a> {
     pub line_no: i64,
 }
 
+/// A `-`-prefixed continuation line attached to a `Read:Virtual` relation.
+/// `content` is the raw text after the leading `"- "` prefix.
+#[derive(Debug, Clone)]
+pub struct Continuation<'a> {
+    pub content: &'a str,
+    pub line_no: i64,
+}
+
+impl<'a> Continuation<'a> {
+    pub fn context(&self) -> ParseContext {
+        ParseContext::new(self.line_no, format!("- {}", self.content))
+    }
+}
+
 /// A relation node in the plan tree, before conversion to a Substrait proto.
 #[derive(Debug, Clone)]
 pub struct RelationNode<'a> {
     pub pair: Pair<'a, Rule>,
     pub line_no: i64,
     pub addenda: Vec<Addendum<'a>>,
+    /// Continuation lines (`- row`) attached to a `Read:Virtual` relation.
+    /// Always empty for all other relation types.
+    pub continuations: Vec<Continuation<'a>>,
     pub children: Vec<RelationNode<'a>>,
 }
 
@@ -77,7 +94,8 @@ impl<'a> RelationNode<'a> {
     }
 }
 
-/// A parsed plan line: either a relation or a `+`-prefixed addendum line.
+/// A parsed plan line: either a relation, a `+`-prefixed addendum, or a
+/// `-`-prefixed continuation line.
 ///
 /// Classification happens at construction time by inspecting the inner grammar
 /// rule, so downstream code can use standard Rust pattern matching rather than
@@ -86,10 +104,15 @@ impl<'a> RelationNode<'a> {
 pub enum LineNode<'a> {
     Relation(RelationNode<'a>),
     Addendum(Addendum<'a>),
+    Continuation(Continuation<'a>),
 }
 
 impl<'a> LineNode<'a> {
     pub fn parse(line: &'a str, line_no: i64) -> Result<Self, ParseError> {
+        if let Some(content) = line.strip_prefix("- ") {
+            return Ok(LineNode::Continuation(Continuation { content, line_no }));
+        }
+
         let mut pairs: pest::iterators::Pairs<'a, Rule> =
             <ExpressionParser as pest::Parser<Rule>>::parse(Rule::planNode, line).map_err(|e| {
                 ParseError::Plan(
@@ -114,6 +137,7 @@ impl<'a> LineNode<'a> {
                 pair: inner,
                 line_no,
                 addenda: Vec::new(),
+                continuations: Vec::new(),
                 children: Vec::new(),
             }),
         })
@@ -155,6 +179,7 @@ impl<'a> LineNode<'a> {
             pair,
             line_no,
             addenda: Vec::new(),
+            continuations: Vec::new(),
             children: Vec::new(),
         }))
     }
@@ -255,6 +280,42 @@ impl<'a> TreeBuilder<'a> {
 
                 parent.addenda.push(addendum);
             }
+            LineNode::Continuation(cont) => {
+                let context = cont.context();
+                if depth == 0 {
+                    return Err(ParseError::ValidationError(
+                        context,
+                        "continuation lines (`- `) cannot appear at the top level".to_string(),
+                    ));
+                }
+
+                let parent = match self.get_at_depth(depth - 1) {
+                    None => {
+                        return Err(ParseError::ValidationError(
+                            context,
+                            format!("no parent found for continuation at depth {depth}"),
+                        ));
+                    }
+                    Some(parent) => parent,
+                };
+
+                if parent.pair.as_rule() != Rule::virtual_read_relation_open {
+                    return Err(ParseError::ValidationError(
+                        context,
+                        "continuation lines (`- `) are only supported inside `Read:Virtual[`"
+                            .to_string(),
+                    ));
+                }
+
+                if !parent.children.is_empty() {
+                    return Err(ParseError::ValidationError(
+                        context,
+                        "continuation lines must appear before child relations".to_string(),
+                    ));
+                }
+
+                parent.continuations.push(cont);
+            }
         }
         Ok(())
     }
@@ -280,6 +341,7 @@ struct RelationContext<'a> {
     children: Vec<Rel>,
     input_field_count: usize,
     addenda: Addenda<'a>,
+    continuations: Vec<Continuation<'a>>,
 }
 
 /// A parsed addendum line plus enough source location to build later errors.
@@ -464,6 +526,9 @@ impl<'a> RelationParser<'a> {
             Rule::virtual_read_relation => {
                 self.parse_rel::<VirtualReadRel>(extensions, registry, ctx)
             }
+            Rule::virtual_read_relation_open => {
+                self.parse_virtual_read_relation_open(extensions, registry, ctx)
+            }
             Rule::read_relation => self.parse_rel::<ReadRel>(extensions, registry, ctx),
             Rule::filter_relation => self.parse_rel::<FilterRel>(extensions, registry, ctx),
             Rule::project_relation => self.parse_rel::<ProjectRel>(extensions, registry, ctx),
@@ -492,6 +557,7 @@ impl<'a> RelationParser<'a> {
             children,
             input_field_count,
             addenda,
+            continuations: _,
         } = ctx;
         assert_eq!(pair.as_rule(), T::rule());
         let line = pair.as_str();
@@ -554,6 +620,47 @@ impl<'a> RelationParser<'a> {
         Ok((rel, output_column_count))
     }
 
+    /// Parse the multi-line `Read:Virtual[` form, where rows and the schema are
+    /// supplied by `- ` continuation lines:
+    ///
+    /// ```text
+    /// Read:Virtual[
+    ///   - (1, 'alice'),
+    ///   - (2, 'bob')
+    ///   - => id:i64, name:string]
+    /// ```
+    ///
+    /// Row continuations have the form `(expr, ...) [,]`; the schema continuation
+    /// starts with `=>` and ends with `]`.  All continuation strings are slices of
+    /// the original input, so Pest can borrow them without allocation.
+    fn parse_virtual_read_relation_open<'i>(
+        &self,
+        extensions: &SimpleExtensions,
+        registry: &ExtensionRegistry,
+        ctx: RelationContext<'i>,
+    ) -> Result<(Rel, usize), ParseError> {
+        assert_eq!(ctx.pair.as_rule(), Rule::virtual_read_relation_open);
+        let context = ParseContext::new(ctx.line_no, ctx.pair.as_str().to_string());
+        let advanced_extension = ctx.addenda.into_standard_advanced_extension(registry)?;
+
+        if ctx.continuations.is_empty() {
+            return Err(ParseError::ValidationError(
+                context,
+                "`Read:Virtual[` must be followed by continuation lines (`- rows...`)"
+                    .to_string(),
+            ));
+        }
+
+        let cont_contents: Vec<&'i str> =
+            ctx.continuations.into_iter().map(|c| c.content).collect();
+
+        let (parsed, count) =
+            VirtualReadRel::parse_from_continuation_contents(extensions, &cont_contents)
+                .map_err(|e| ParseError::Plan(context, e))?;
+
+        Ok((parsed.into_rel(advanced_extension), count))
+    }
+
     /// Parse `Read:Extension[...]`, whose table detail is supplied by exactly
     /// one `+ Ext:Name[...]` addendum.
     fn parse_extension_read_relation(
@@ -598,6 +705,7 @@ impl<'a> RelationParser<'a> {
         }
 
         let addenda = Addenda::parse(extensions, node.addenda)?;
+        let continuations = node.continuations;
 
         self.parse_relation(
             extensions,
@@ -608,6 +716,7 @@ impl<'a> RelationParser<'a> {
                 children,
                 input_field_count,
                 addenda,
+                continuations,
             },
         )
     }

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -646,8 +646,7 @@ impl<'a> RelationParser<'a> {
         if ctx.continuations.is_empty() {
             return Err(ParseError::ValidationError(
                 context,
-                "`Read:Virtual[` must be followed by continuation lines (`- rows...`)"
-                    .to_string(),
+                "`Read:Virtual[` must be followed by continuation lines (`- rows...`)".to_string(),
             ));
         }
 

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -657,6 +657,113 @@ Root[result]
     );
 }
 
+#[test]
+fn test_virtual_read_continuation_single_row() {
+    // A single continuation row parses to the same plan as the inline form.
+    let continuation = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[
+    - (1, 'alice')
+    - => id:i64, name:string]"#;
+
+    let inline = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[(1, 'alice') => id:i64, name:string]"#;
+
+    assert_roundtrip_canonical(inline.trim(), continuation.trim());
+}
+
+#[test]
+fn test_virtual_read_continuation_multi_row() {
+    // Multiple continuation rows produce the same plan as the inline form.
+    let continuation = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[
+    - (1, 'alice'),
+    - (2, 'bob'),
+    - (3, 'carol')
+    - => id:i64, name:string]"#;
+
+    let inline = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[(1, 'alice'), (2, 'bob'), (3, 'carol') => id:i64, name:string]"#;
+
+    assert_roundtrip_canonical(inline.trim(), continuation.trim());
+}
+
+#[test]
+fn test_virtual_read_continuation_typed_expressions() {
+    // Typed literals and nulls work in continuation rows.
+    // The formatter drops redundant type annotations (e.g. 'Alice':string? → 'Alice'),
+    // so the canonical form uses the formatter's actual output.
+    let continuation = r#"
+=== Plan
+Root[id, name, age]
+  Read:Virtual[
+    - (1:i32, 'Alice':string?, 25:i32),
+    - (15:i32, null:string?, 30:i32)
+    - => id:i32, name:string?, age:i32]"#;
+
+    let canonical = r#"
+=== Plan
+Root[id, name, age]
+  Read:Virtual[(1:i32, 'Alice', 25:i32), (15:i32, null:string?, 30:i32) => id:i32, name:string?, age:i32]"#;
+
+    assert_roundtrip_canonical(canonical.trim(), continuation.trim());
+}
+
+#[test]
+fn test_virtual_read_continuation_missing_schema_rejected() {
+    // A Read:Virtual[ with no continuation lines must be rejected.
+    let plan = r#"
+=== Plan
+Root[id]
+  Read:Virtual["#;
+
+    let result = Parser::parse(plan);
+    assert!(
+        result.is_err(),
+        "Read:Virtual[ with no continuation lines should fail"
+    );
+}
+
+#[test]
+fn test_virtual_read_continuation_invalid_row_rejected() {
+    // A malformed continuation row (not a valid virtual_row) must fail.
+    let plan = r#"
+=== Plan
+Root[id]
+  Read:Virtual[
+    - not_a_row
+    - => id:i64]"#;
+
+    let result = Parser::parse(plan);
+    assert!(
+        result.is_err(),
+        "malformed continuation row should fail to parse"
+    );
+}
+
+#[test]
+fn test_virtual_read_continuation_wrong_relation_rejected() {
+    // Continuation lines attached to a non-VirtualTable relation must be rejected.
+    let plan = r#"
+=== Plan
+Root[id]
+  Filter[$0 => $0]
+    - (1)"#;
+
+    let result = Parser::parse(plan);
+    assert!(
+        result.is_err(),
+        "continuation lines on non-VirtualTable relation should fail"
+    );
+}
+
 // === Emit / output-field-count propagation tests ===
 //
 // These exercise the pipeline: child's output_field_count → parent's


### PR DESCRIPTION
## Description

Added parsing and error handling for multi-line virtual tables. Also added tests to verify the new format.

## Type of Change
New feature. The next steps after this implementation would be to output multi rows for virtual tables that are being converted from substrait, and to update Grammar.md with my changes.

## Testing

- [x] Added tests for new functionality
- [x] All existing tests pass
- [x] Ran examples to verify behavior

## Checklist

- [x] Code follows Rust conventions
- [x] Documentation updated if needed (Need to update grammar.md on completion)
- [x] No breaking changes (or breaking changes documented)
- [x] Pre-commit hooks pass

## Related Issues

Closes #(issue number)
https://github.com/DataDog/substrait-explain/issues/162
