### PR TITLE
feat!: Allow multi-row virtual tables to be emitted

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -655,8 +655,10 @@ Root[id, name]
 ```
 
 The multi-line form is purely a layout convenience: it parses to exactly the
-same plan as the inline form above. (Formatting currently always emits the
-inline form.)
+same plan as the inline form above. When formatting a plan back to text, a
+`Read:Virtual` is emitted in this multi-line form once it has at least
+`OutputOptions::virtual_table_multiline_threshold` rows (3 by default), and
+inline below that. Raising the threshold keeps larger tables inline.
 
 ### `ExtensionTable` Read Relation
 

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -655,10 +655,7 @@ Root[id, name]
 ```
 
 The multi-line form is purely a layout convenience: it parses to exactly the
-same plan as the inline form above. When formatting a plan back to text, a
-`Read:Virtual` is emitted in this multi-line form once it has at least
-`OutputOptions::virtual_table_multiline_threshold` rows (3 by default), and
-inline below that. Raising the threshold keeps larger tables inline.
+same plan as the inline form above. The standard output may use inline or multi-line form depending on the length of the `VirtualTable`.
 
 ### `ExtensionTable` Read Relation
 

--- a/src/textify/foundation.rs
+++ b/src/textify/foundation.rs
@@ -51,6 +51,10 @@ pub struct OutputOptions {
     /// Show the binary values for literal types as hex strings. Normally, they
     /// are shown as '{{binary}}'
     pub show_literal_binaries: bool,
+    /// A `Read:Virtual` with at least this many rows is emitted across multiple
+    /// lines (one `- row` per line) instead of inline. Set to a very large
+    /// value to keep virtual tables inline regardless of row count.
+    pub virtual_table_multiline_threshold: usize,
 }
 
 impl Default for OutputOptions {
@@ -65,6 +69,7 @@ impl Default for OutputOptions {
             nullability: false,
             indent: "  ".to_string(),
             show_literal_binaries: false,
+            virtual_table_multiline_threshold: 3,
         }
     }
 }
@@ -84,6 +89,7 @@ impl OutputOptions {
             nullability: true,
             indent: "  ".to_string(),
             show_literal_binaries: true,
+            virtual_table_multiline_threshold: 3,
         }
     }
 }

--- a/src/textify/foundation.rs
+++ b/src/textify/foundation.rs
@@ -53,7 +53,7 @@ pub struct OutputOptions {
     pub show_literal_binaries: bool,
     /// A `Read:Virtual` with at least this many rows is emitted across multiple
     /// lines (one `- row` per line) instead of inline. Set to a very large
-    /// value to keep virtual tables inline regardless of row count.
+    /// value to keep virtual tables inline regardless of row count. Defaults to 3.
     pub virtual_table_multiline_threshold: usize,
 }
 

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -262,7 +262,8 @@ impl<'a> Arguments<'a> {
     }
 
     /// A row-per-line argument list (`- arg` per line) used for `Read:Virtual`
-    /// with many rows. There are no named arguments in this form.
+    /// with many rows. Currently not enabled for named arguments.
+    /// TODO: enable for named arguments as well.
     pub fn rows(positional: Vec<Value<'a>>) -> Self {
         Arguments {
             positional,
@@ -341,8 +342,8 @@ impl Relation<'_> {
     ///   - => id:i64, name:string]
     /// ```
     ///
-    /// Callers are responsible for any newline that follows (either from an addendum or
-    /// from the next child).
+    /// Does not write a trailing newline; callers are responsible for any
+    /// newline that follows (either from an addendum or from the next child).
     pub fn write_header<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
         let cols = Emitted::new(&self.columns, self.emit);
         let indent = ctx.indent();
@@ -422,14 +423,17 @@ impl<'a> Relation<'a> {
                     .map(|row| Value::Tuple(row.fields.iter().map(Value::Expression).collect()))
                     .collect();
 
-                // Emit many rows across multiple lines for readability
-                // based on configurable threshold (default = 3)
-                let arguments =
-                    if positional.len() >= ctx.options().virtual_table_multiline_threshold {
-                        Arguments::rows(positional)
-                    } else {
-                        Arguments::inline(positional, vec![])
-                    };
+                // Emit many rows across multiple lines for readability, based on
+                // a configurable threshold (default = 3). An empty table has no
+                // rows to spread out and is written `_`, so it stays inline
+                // regardless of the threshold — the row layout has no `_` form.
+                let multiline = !positional.is_empty()
+                    && positional.len() >= ctx.options().virtual_table_multiline_threshold;
+                let arguments = if multiline {
+                    Arguments::rows(positional)
+                } else {
+                    Arguments::inline(positional, vec![])
+                };
 
                 Relation {
                     name: Cow::Borrowed("Read:Virtual"),

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -228,12 +228,48 @@ impl<'a> Textify for Emitted<'a> {
     }
 }
 
+/// How an argument list renders inside a relation's `[...]`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ArgsLayout {
+    /// `arg, arg, arg` on a single line.
+    #[default]
+    Inline,
+    /// One `- arg` per line, used for `Read:Virtual` rows. See
+    /// [`Relation::write_header`] for the exact layout.
+    Rows,
+}
+
 #[derive(Debug, Clone)]
 pub struct Arguments<'a> {
     /// Positional arguments (e.g., a filter condition, group-bys, etc.)
     pub positional: Vec<Value<'a>>,
     /// Named arguments (e.g., limit=10, offset=5)
     pub named: Vec<NamedArg<'a>>,
+    /// How this argument list is laid out. Defaults to [`ArgsLayout::Inline`];
+    /// only `Read:Virtual` opts into [`ArgsLayout::Rows`].
+    layout: ArgsLayout,
+}
+
+impl<'a> Arguments<'a> {
+    /// An inline argument list (`arg, arg, arg`), the default for every
+    /// relation.
+    pub fn inline(positional: Vec<Value<'a>>, named: Vec<NamedArg<'a>>) -> Self {
+        Arguments {
+            positional,
+            named,
+            layout: ArgsLayout::Inline,
+        }
+    }
+
+    /// A row-per-line argument list (`- arg` per line) used for `Read:Virtual`
+    /// with many rows. There are no named arguments in this form.
+    pub fn rows(positional: Vec<Value<'a>>) -> Self {
+        Arguments {
+            positional,
+            named: vec![],
+            layout: ArgsLayout::Rows,
+        }
+    }
 }
 
 impl<'a> Textify for Arguments<'a> {
@@ -293,9 +329,20 @@ impl Textify for Relation<'_> {
 }
 
 impl Relation<'_> {
-    /// Write the single header line for this relation, e.g. `Filter[$0 => $0]`.
-    /// Does not write a trailing newline; callers are responsible for any
-    /// newline that follows (either from an addendum or from the next child).
+    /// Write the header for this relation, e.g. `Filter[$0 => $0]`.
+    ///
+    /// Usually a single line, but an argument list with [`ArgsLayout::Rows`]
+    /// (used by `Read:Virtual` with many rows) spans several lines:
+    ///
+    /// ```text
+    /// Read:Virtual[
+    ///   - (1, 'alice'),
+    ///   - (2, 'bob')
+    ///   - => id:i64, name:string]
+    /// ```
+    ///
+    /// Callers are responsible for any newline that follows (either from an addendum or
+    /// from the next child).
     pub fn write_header<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
         let cols = Emitted::new(&self.columns, self.emit);
         let indent = ctx.indent();
@@ -304,6 +351,20 @@ impl Relation<'_> {
         match &self.arguments {
             None => {
                 write!(w, "{indent}{name}[{cols}]")
+            }
+            Some(args) if args.layout == ArgsLayout::Rows => {
+                // One `- row` per line, one indent level deeper, with a trailing
+                // comma on every row but the last, then `- => cols]`.
+                let child = ctx.push_indent();
+                let child_indent = child.indent();
+                writeln!(w, "{indent}{name}[")?;
+                let last = args.positional.len().saturating_sub(1);
+                for (i, row) in args.positional.iter().enumerate() {
+                    let row = ctx.display(row);
+                    let comma = if i == last { "" } else { "," };
+                    writeln!(w, "{child_indent}- {row}{comma}")?;
+                }
+                write!(w, "{child_indent}- => {cols}]")
             }
             Some(args) => {
                 let args = ctx.display(args);
@@ -344,10 +405,7 @@ impl<'a> Relation<'a> {
                 let table_name = Value::TableName(table.names.iter().map(|n| Name(n)).collect());
                 Relation {
                     name: Cow::Borrowed("Read"),
-                    arguments: Some(Arguments {
-                        positional: vec![table_name],
-                        named: vec![],
-                    }),
+                    arguments: Some(Arguments::inline(vec![table_name], vec![])),
                     columns,
                     emit,
                     addenda: AddendumLines::from_advanced_extension(
@@ -358,18 +416,24 @@ impl<'a> Relation<'a> {
                 }
             }
             Some(ReadType::VirtualTable(vt)) => {
-                let positional = vt
+                let positional: Vec<Value> = vt
                     .expressions
                     .iter()
                     .map(|row| Value::Tuple(row.fields.iter().map(Value::Expression).collect()))
                     .collect();
 
+                // Emit many rows across multiple lines for readability
+                // based on configurable threshold (default = 3)
+                let arguments =
+                    if positional.len() >= ctx.options().virtual_table_multiline_threshold {
+                        Arguments::rows(positional)
+                    } else {
+                        Arguments::inline(positional, vec![])
+                    };
+
                 Relation {
                     name: Cow::Borrowed("Read:Virtual"),
-                    arguments: Some(Arguments {
-                        positional,
-                        named: vec![],
-                    }),
+                    arguments: Some(arguments),
                     columns,
                     emit,
                     addenda: AddendumLines::from_advanced_extension(
@@ -406,10 +470,7 @@ impl<'a> Relation<'a> {
                 );
                 Relation {
                     name: Cow::Borrowed("Read"),
-                    arguments: Some(Arguments {
-                        positional: vec![Value::Missing(err)],
-                        named: vec![],
-                    }),
+                    arguments: Some(Arguments::inline(vec![Value::Missing(err)], vec![])),
                     columns,
                     emit,
                     addenda: AddendumLines::from_advanced_extension(
@@ -474,10 +535,7 @@ impl<'a> Relation<'a> {
             PlanError::unimplemented("FilterRel", Some("condition"), "Condition is None")
         });
         let positional = vec![condition];
-        let arguments = Some(Arguments {
-            positional,
-            named: vec![],
-        });
+        let arguments = Some(Arguments::inline(positional, vec![]));
         let emit = get_emit(rel.common.as_ref());
         let (children, columns) = Relation::convert_children(vec![rel.input.as_deref()], ctx);
         let columns = (0..columns).map(|i| Value::Reference(i as i32)).collect();
@@ -600,7 +658,7 @@ impl<'a> Relation<'a> {
                 }
                 Relation {
                     name: Cow::Owned(format!("{}:{}", ext_type, name)),
-                    arguments: Some(Arguments { positional, named }),
+                    arguments: Some(Arguments::inline(positional, named)),
                     columns,
                     emit: None,
                     // Extension relations use `detail` rather than
@@ -683,10 +741,7 @@ impl<'a> Relation<'a> {
         }
 
         // adding the grouping_sets as a list of Arguments to Aggregate Rel
-        let arguments = Some(Arguments {
-            positional,
-            named: vec![],
-        });
+        let arguments = Some(Arguments::inline(positional, vec![]));
 
         // The columns are the direct outputs of this relation (before emit)
         let mut all_outputs: Vec<Value> = expression_list;
@@ -799,10 +854,7 @@ impl<'a> Relation<'a> {
         for sort_field in &rel.sorts {
             positional.push(Value::from(sort_field));
         }
-        let arguments = Some(Arguments {
-            positional,
-            named: vec![],
-        });
+        let arguments = Some(Arguments::inline(positional, vec![]));
         // The columns are the direct outputs of this relation (before emit)
         let mut col_values = vec![];
         for i in 0..input_columns {
@@ -863,10 +915,7 @@ impl<'a> Relation<'a> {
             .collect();
         Relation {
             name: Cow::Borrowed("Fetch"),
-            arguments: Some(Arguments {
-                positional: vec![],
-                named: named_args,
-            }),
+            arguments: Some(Arguments::inline(vec![], named_args)),
             columns,
             emit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
@@ -967,10 +1016,7 @@ impl<'a> Relation<'a> {
         // Currently post_join_filter is not supported in the text format
         // grammar
         let positional = vec![join_type_value, condition];
-        let arguments = Some(Arguments {
-            positional,
-            named: vec![],
-        });
+        let arguments = Some(Arguments::inline(positional, vec![]));
 
         let emit = get_emit(rel.common.as_ref());
         let columns = join_output_columns(join_type, left_columns, right_columns);
@@ -1476,10 +1522,7 @@ Filter[gt($0, 10:i32):boolean => $0, $1]
     #[test]
     fn test_arguments_textify_positional_only() {
         let ctx = TestContext::new();
-        let args = Arguments {
-            positional: vec![Value::Integer(42), Value::Integer(7)],
-            named: vec![],
-        };
+        let args = Arguments::inline(vec![Value::Integer(42), Value::Integer(7)], vec![]);
         let (result, errors) = ctx.textify(&args);
         assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
         assert_eq!(result, "42, 7");
@@ -1488,9 +1531,9 @@ Filter[gt($0, 10:i32):boolean => $0, $1]
     #[test]
     fn test_arguments_textify_named_only() {
         let ctx = TestContext::new();
-        let args = Arguments {
-            positional: vec![],
-            named: vec![
+        let args = Arguments::inline(
+            vec![],
+            vec![
                 NamedArg {
                     name: Cow::Borrowed("limit"),
                     value: Value::Integer(10),
@@ -1500,7 +1543,7 @@ Filter[gt($0, 10:i32):boolean => $0, $1]
                     value: Value::Integer(5),
                 },
             ],
-        };
+        );
         let (result, errors) = ctx.textify(&args);
         assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
         assert_eq!(result, "limit=10, offset=5");
@@ -1545,13 +1588,13 @@ Filter[gt($0, 10:i32):boolean => $0, $1]
     #[test]
     fn test_arguments_textify_both() {
         let ctx = TestContext::new();
-        let args = Arguments {
-            positional: vec![Value::Integer(1)],
-            named: vec![NamedArg {
+        let args = Arguments::inline(
+            vec![Value::Integer(1)],
+            vec![NamedArg {
                 name: "foo".into(),
                 value: Value::Integer(2),
             }],
-        };
+        );
         let (result, errors) = ctx.textify(&args);
         assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
         assert_eq!(result, "1, foo=2");
@@ -1560,10 +1603,7 @@ Filter[gt($0, 10:i32):boolean => $0, $1]
     #[test]
     fn test_arguments_textify_empty() {
         let ctx = TestContext::new();
-        let args = Arguments {
-            positional: vec![],
-            named: vec![],
-        };
+        let args = Arguments::inline(vec![], vec![]);
         let (result, errors) = ctx.textify(&args);
         assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
         assert_eq!(result, "_");

--- a/tests/multi_line_roundtrip.rs
+++ b/tests/multi_line_roundtrip.rs
@@ -198,26 +198,42 @@ Root[id, name]
 #[test]
 fn test_virtual_read_threshold_is_configurable() {
     // Raising the threshold keeps an otherwise multi-line table (3 rows) inline.
-    let plan = Parser::parse(
-        r#"
+    let inline = r#"
 === Plan
 Root[id]
-  Read:Virtual[(1), (2), (3) => id:i64]"#
-            .trim(),
-    )
-    .expect("parse failed");
+  Read:Virtual[(1), (2), (3) => id:i64]"#;
 
+    let plan = Parser::parse(inline.trim()).expect("parse failed");
     let options = OutputOptions {
         virtual_table_multiline_threshold: 100,
         ..OutputOptions::default()
     };
     let (text, errors) = format_with_options(&plan, &options);
-    assert!(
-        errors.is_empty(),
-        "unexpected formatting errors: {errors:?}"
-    );
-    assert_eq!(
-        text.trim(),
-        "=== Plan\nRoot[id]\n  Read:Virtual[(1), (2), (3) => id:i64]",
-    );
+
+    assert!(errors.is_empty(), "unexpected formatting errors: {errors:?}");
+    assert_eq!(text.trim(), inline.trim());
+}
+
+#[test]
+fn test_virtual_read_empty_stays_inline_even_at_zero_threshold() {
+    // An empty virtual table is written `_`; there is no `- _` row form, so it
+    // must stay inline even when the threshold (0) would otherwise force rows —
+    // otherwise the formatted text would not parse back.
+    let inline = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[_ => id:i64, name:string]"#;
+
+    let plan = Parser::parse(inline.trim()).expect("parse failed");
+    let options = OutputOptions {
+        virtual_table_multiline_threshold: 0,
+        ..OutputOptions::default()
+    };
+    let (text, errors) = format_with_options(&plan, &options);
+
+    assert!(errors.is_empty(), "unexpected formatting errors: {errors:?}");
+    assert_eq!(text.trim(), inline.trim());
+
+    // The output must also parse back cleanly.
+    Parser::parse(text.trim()).expect("formatted empty virtual table should re-parse");
 }

--- a/tests/multi_line_roundtrip.rs
+++ b/tests/multi_line_roundtrip.rs
@@ -1,15 +1,17 @@
 //! Round-trip tests for multi-line relation syntax.
 //!
 //! A `Read:Virtual` may be written across several lines using `- ` continuation
-//! markers. Layout is handled entirely in the chunk layer (grouping physical
+//! markers. Parsing is handled entirely in the chunk layer (grouping physical
 //! lines) and the grammar (silent continuation rules), so a multi-line relation
-//! parses to the same plan as its inline form — and currently formats back to
-//! the inline canonical, since multi-line output is not yet implemented.
+//! parses to the same plan as its inline form. Formatting emits the multi-line
+//! form once a virtual table reaches
+//! [`OutputOptions::virtual_table_multiline_threshold`] rows (default 3), and
+//! the inline form below that.
 
 mod common;
 
 use common::assert_roundtrip_canonical;
-use substrait_explain::Parser;
+use substrait_explain::{OutputOptions, Parser, format_with_options};
 
 #[test]
 fn test_virtual_read_multiline_single_row() {
@@ -30,12 +32,8 @@ Root[id, name]
 
 #[test]
 fn test_virtual_read_multiline_multi_row() {
-    // Rows carry trailing commas; the last row before `=>` does not.
-    let inline = r#"
-=== Plan
-Root[id, name]
-  Read:Virtual[(1, 'alice'), (2, 'bob'), (3, 'carol') => id:i64, name:string]"#;
-
+    // With three rows (the default threshold) the multi-line form is canonical:
+    // rows carry trailing commas, and the last row before `=>` does not.
     let multiline = r#"
 === Plan
 Root[id, name]
@@ -45,7 +43,12 @@ Root[id, name]
     - (3, 'carol')
     - => id:i64, name:string]"#;
 
-    assert_roundtrip_canonical(inline.trim(), multiline.trim());
+    let inline = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[(1, 'alice'), (2, 'bob'), (3, 'carol') => id:i64, name:string]"#;
+
+    assert_roundtrip_canonical(multiline.trim(), inline.trim());
 }
 
 #[test]
@@ -169,5 +172,52 @@ Root[id]
     assert!(
         Parser::parse(plan.trim()).is_err(),
         "malformed continuation row should fail to parse"
+    );
+}
+
+#[test]
+fn test_virtual_read_two_rows_stays_inline() {
+    // Two rows is below the default threshold (3), so the canonical output is
+    // inline even though the multi-line form parses to the same plan.
+    let inline = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[(1, 'alice'), (2, 'bob') => id:i64, name:string]"#;
+
+    let multiline = r#"
+=== Plan
+Root[id, name]
+  Read:Virtual[
+    - (1, 'alice'),
+    - (2, 'bob')
+    - => id:i64, name:string]"#;
+
+    assert_roundtrip_canonical(inline.trim(), multiline.trim());
+}
+
+#[test]
+fn test_virtual_read_threshold_is_configurable() {
+    // Raising the threshold keeps an otherwise multi-line table (3 rows) inline.
+    let plan = Parser::parse(
+        r#"
+=== Plan
+Root[id]
+  Read:Virtual[(1), (2), (3) => id:i64]"#
+            .trim(),
+    )
+    .expect("parse failed");
+
+    let options = OutputOptions {
+        virtual_table_multiline_threshold: 100,
+        ..OutputOptions::default()
+    };
+    let (text, errors) = format_with_options(&plan, &options);
+    assert!(
+        errors.is_empty(),
+        "unexpected formatting errors: {errors:?}"
+    );
+    assert_eq!(
+        text.trim(),
+        "=== Plan\nRoot[id]\n  Read:Virtual[(1), (2), (3) => id:i64]",
     );
 }

--- a/tests/multi_line_roundtrip.rs
+++ b/tests/multi_line_roundtrip.rs
@@ -210,7 +210,10 @@ Root[id]
     };
     let (text, errors) = format_with_options(&plan, &options);
 
-    assert!(errors.is_empty(), "unexpected formatting errors: {errors:?}");
+    assert!(
+        errors.is_empty(),
+        "unexpected formatting errors: {errors:?}"
+    );
     assert_eq!(text.trim(), inline.trim());
 }
 
@@ -231,7 +234,10 @@ Root[id, name]
     };
     let (text, errors) = format_with_options(&plan, &options);
 
-    assert!(errors.is_empty(), "unexpected formatting errors: {errors:?}");
+    assert!(
+        errors.is_empty(),
+        "unexpected formatting errors: {errors:?}"
+    );
     assert_eq!(text.trim(), inline.trim());
 
     // The output must also parse back cleanly.

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -665,10 +665,16 @@ Root[id, name]
 
 #[test]
 fn test_virtual_read_single_column() {
+    // Three rows reaches the multi-line threshold, so the canonical output
+    // spreads the rows across lines.
     let plan = r#"
 === Plan
 Root[id]
-  Read:Virtual[(1), (2), (3) => id:i64]"#;
+  Read:Virtual[
+    - (1),
+    - (2),
+    - (3)
+    - => id:i64]"#;
 
     roundtrip_plan(plan);
 }
@@ -686,7 +692,11 @@ Functions:
 === Plan
 Root[name]
   Filter[gt($0, 1):boolean => $0, $1]
-    Read:Virtual[(1, 'alice'), (2, 'bob'), (3, 'carol') => id:i64, name:string]"#;
+    Read:Virtual[
+      - (1, 'alice'),
+      - (2, 'bob'),
+      - (3, 'carol')
+      - => id:i64, name:string]"#;
 
     roundtrip_plan(plan);
 }


### PR DESCRIPTION

## Description

This PR enables multi-row virtual tables to be emitted when converting from protobuf to substrait-explain. It works by adding an ArgsLayout enum and a layout field to arguments, so we attach how we format arguments to the arguments parameter when it's passed into relations. Whether we want it to be multi-line or in-line can be decided when passing into a relation function.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Example update
- [ ] Other (please describe)

## Testing

- [x] Added tests for new functionality
- [x] All existing tests pass
- [x] Ran examples to verify behavior

## Checklist

- [x] Code follows Rust conventions
- [x] Documentation updated if needed
- [x] No breaking changes (or breaking changes documented)
- [x] Pre-commit hooks pass

## Related Issues

Closes #(issue number)
