### PR TITLE
feat: added versioning to plans, and textifies versions from substrait plans

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -4,10 +4,11 @@ This document describes the grammar for the human-readable Substrait text format
 
 ## Overview
 
-The Substrait text format consists of two main sections:
+The Substrait text format consists of three sections:
 
-1. **Extensions Section** (optional) - Defines URNs and function/type extensions
-2. **Plan Section** - Contains the actual query plan with relations
+1. **Version Section** (optional) - Declares the Substrait version of the plan
+2. **Extensions Section** (optional) - Defines URNs and function/type extensions
+3. **Plan Section** - Contains the actual query plan with relations
 
 ## Design Principles
 
@@ -96,8 +97,44 @@ A Substrait text format document consists of two main sections with specific for
 
 The document uses `===` headers to separate major sections:
 
+- **`=== Version`** - Declares the plan's Substrait version (optional)
 - **`=== Extensions`** - Defines URNs and function/type mappings (optional)
 - **`=== Plan`** - Contains the actual query plan (required)
+
+When present, the sections appear in this order, mirroring the field order of
+the Substrait `Plan` protobuf.
+
+#### Version format
+
+```text
+=== Version major.minor.patch
+  producer: producer string
+  git_hash: git hash
+```
+
+The header carries the version number as `major.minor.patch` (three
+non-negative integers). The indented `producer:` and `git_hash:` lines are
+optional and may appear in either order beneath the header.
+
+The `=== Version` section as a whole is optional; a document with no version
+section is valid and denotes a plan without a declared version.
+
+```rust
+# use substrait_explain::Parser;
+#
+# let plan_text = r#"
+=== Version 0.55.0
+  producer: my-optimizer
+=== Plan
+Root[result]
+  Read[orders => quantity:i32?]
+# "#;
+#
+# let plan = Parser::parse(plan_text).unwrap();
+# let version = plan.version.unwrap();
+# assert_eq!(version.minor_number, 55);
+# assert_eq!(version.producer, "my-optimizer");
+```
 
 #### Extension format
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15,5 +15,5 @@ pub(crate) use common::{
 pub use errors::{ParseContext, ParseError, ParseResult};
 pub use extensions::{ExpectedExtensionLine, ExtensionParseError};
 pub(crate) use relations::RelationParsePair;
-pub(crate) use structural::PLAN_HEADER;
 pub use structural::Parser;
+pub(crate) use structural::{PLAN_HEADER, VERSION_HEADER};

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -10,7 +10,7 @@ use pest::iterators::Pair;
 use substrait::proto::extensions::AdvancedExtension;
 use substrait::proto::{
     AggregateRel, FetchRel, FilterRel, JoinRel, Plan, PlanRel, ProjectRel, ReadRel, Rel, RelRoot,
-    SortRel, plan_rel,
+    SortRel, Version, plan_rel,
 };
 
 use crate::extensions::any::Any;
@@ -26,6 +26,7 @@ use crate::parser::relations::{ExtensionReadRel, RelationParsingContext, Virtual
 use crate::parser::{ErrorKind, ExpressionParser, RelationParsePair, Rule, unwrap_single_pair};
 
 pub const PLAN_HEADER: &str = "=== Plan";
+pub const VERSION_HEADER: &str = "=== Version";
 
 /// Represents an input line, trimmed of leading two-space indents and final
 /// whitespace. Contains the number of indents and the trimmed line.
@@ -165,6 +166,9 @@ impl<'a> LineNode<'a> {
 pub enum State {
     // The initial state, before we have parsed any lines.
     Initial,
+    // The version section, after parsing the `=== Version` header. Accepts the
+    // optional indented `producer:` / `git_hash:` detail lines.
+    Version,
     // The extensions section, after parsing the header and any other Extension lines.
     Extensions,
     // The plan section, after parsing the header and any other Plan lines.
@@ -812,6 +816,8 @@ pub struct Parser<'a> {
     /// [`next_chunk`](Self::next_chunk). `None` before parsing starts and once
     /// the input is exhausted.
     cursor: Option<ChunkCursor<'a>>,
+    /// The plan version from an optional `=== Version` section
+    version: Option<Version>,
     extension_parser: ExtensionParser,
     extension_registry: ExtensionRegistry,
     relation_parser: RelationParser<'a>,
@@ -861,6 +867,7 @@ impl<'a> Parser<'a> {
             line_no: 1,
             state: State::Initial,
             cursor: None,
+            version: None,
             extension_parser: ExtensionParser::default(),
             extension_registry: ExtensionRegistry::new(),
             relation_parser: RelationParser::default(),
@@ -945,6 +952,7 @@ impl<'a> Parser<'a> {
 
         match self.state {
             State::Initial => self.parse_initial(indented_line),
+            State::Version => self.parse_version(indented_line),
             State::Extensions => self
                 .parse_extensions(indented_line)
                 .map_err(|e| ParseError::Extension(ctx(), e)),
@@ -968,6 +976,13 @@ impl<'a> Parser<'a> {
     fn parse_initial(&mut self, line: IndentedLine) -> Result<(), ParseError> {
         match line {
             IndentedLine(0, l) if l.trim().is_empty() => {}
+            IndentedLine(0, l)
+                if l.strip_prefix(VERSION_HEADER)
+                    .is_some_and(|rest| rest.is_empty() || rest.starts_with(' ')) =>
+            {
+                self.parse_version_header(l)?;
+                self.state = State::Version;
+            }
             IndentedLine(0, simple::EXTENSIONS_HEADER) => {
                 self.state = State::Extensions;
             }
@@ -988,6 +1003,104 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
+    /// Parse the `=== Version <major>.<minor>.<patch>` header line and store
+    /// the resulting [`Version`], leaving `producer` / `git_hash` empty
+    fn parse_version_header(&mut self, line: &str) -> Result<(), ParseError> {
+        let ctx = || ParseContext::new(self.line_no, line.to_string());
+        let rest = line
+            .strip_prefix(VERSION_HEADER)
+            .expect("version header prefix checked by caller")
+            .trim();
+
+        let mut numbers = rest.split('.');
+        let mut next_number = |field: &str| -> Result<u32, ParseError> {
+            let part = numbers.next().filter(|p| !p.is_empty()).ok_or_else(|| {
+                ParseError::ValidationError(
+                    ctx(),
+                    format!("version header is missing the {field} number, expected '{VERSION_HEADER} <major>.<minor>.<patch>'"),
+                )
+            })?;
+            part.parse::<u32>().map_err(|e| {
+                ParseError::ValidationError(
+                    ctx(),
+                    format!("invalid {field} version number {part:?}: {e}"),
+                )
+            })
+        };
+
+        let major_number = next_number("major")?;
+        let minor_number = next_number("minor")?;
+        let patch_number = next_number("patch")?;
+        if numbers.next().is_some() {
+            return Err(ParseError::ValidationError(
+                ctx(),
+                format!(
+                    "version {rest:?} has too many components, expected '<major>.<minor>.<patch>'"
+                ),
+            ));
+        }
+
+        self.version = Some(Version {
+            major_number,
+            minor_number,
+            patch_number,
+            ..Default::default()
+        });
+        Ok(())
+    }
+
+    /// Parses a single line from the version section: either an indented
+    /// `producer:` / `git_hash:` detail line, or a section header
+    fn parse_version(&mut self, line: IndentedLine) -> Result<(), ParseError> {
+        match line {
+            IndentedLine(0, l) if l.trim().is_empty() => Ok(()),
+            IndentedLine(0, simple::EXTENSIONS_HEADER) => {
+                self.state = State::Extensions;
+                Ok(())
+            }
+            IndentedLine(0, PLAN_HEADER) => {
+                self.state = State::Plan;
+                Ok(())
+            }
+            IndentedLine(1, l) => self.parse_version_detail(l),
+            IndentedLine(_, l) => Err(ParseError::ValidationError(
+                ParseContext::new(self.line_no, l.to_string()),
+                format!(
+                    "unexpected line in version section: {l:?}; expected an indented 'producer:' \
+                     or 'git_hash:' line, or a section header"
+                ),
+            )),
+        }
+    }
+
+    /// Parse an indented `producer:` / `git_hash:` detail line, mutating the
+    /// [`Version`] set by [`parse_version_header`](Self::parse_version_header).
+    fn parse_version_detail(&mut self, line: &str) -> Result<(), ParseError> {
+        let ctx = || ParseContext::new(self.line_no, line.to_string());
+        let (key, value) = line.split_once(':').ok_or_else(|| {
+            ParseError::ValidationError(
+                ctx(),
+                format!("expected 'producer:' or 'git_hash:' in version section, found {line:?}"),
+            )
+        })?;
+        let value = value.trim().to_string();
+        let version = self
+            .version
+            .as_mut()
+            .expect("version is set on entry to the version section");
+        match key.trim() {
+            "producer" => version.producer = value,
+            "git_hash" => version.git_hash = value,
+            other => {
+                return Err(ParseError::ValidationError(
+                    ctx(),
+                    format!("unknown version field {other:?}, expected 'producer' or 'git_hash'"),
+                ));
+            }
+        }
+        Ok(())
+    }
+
     /// Parse a single line from the extensions section of the input, updating
     /// the parser state.
     fn parse_extensions(&mut self, line: IndentedLine<'_>) -> Result<(), ExtensionParseError> {
@@ -1001,6 +1114,7 @@ impl<'a> Parser<'a> {
     /// Build the plan from the parser state with warning collection.
     fn build_plan(self) -> Result<Plan, ParseError> {
         let Parser {
+            version,
             relation_parser,
             extension_parser,
             extension_registry,
@@ -1014,6 +1128,7 @@ impl<'a> Parser<'a> {
 
         // Build the final plan
         Ok(Plan {
+            version,
             extension_urns: extensions.to_extension_urns(),
             extensions: extensions.to_extension_declarations(),
             relations: root_relations,

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -162,7 +162,7 @@ impl<'a> LineNode<'a> {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum State {
     // The initial state, before we have parsed any lines.
     Initial,
@@ -173,6 +173,21 @@ pub enum State {
     Extensions,
     // The plan section, after parsing the header and any other Plan lines.
     Plan,
+}
+
+impl State {
+    /// Position of this section in the required document order (`Version`,
+    /// `Extensions`, `Plan`). Sections must appear in strictly increasing
+    /// order, so a `===` header may only transition to a state with a higher
+    /// rank than the current one.
+    fn section_rank(&self) -> u8 {
+        match self {
+            State::Initial => 0,
+            State::Version => 1,
+            State::Extensions => 2,
+            State::Plan => 3,
+        }
+    }
 }
 
 impl fmt::Display for State {
@@ -950,13 +965,26 @@ impl<'a> Parser<'a> {
             line: line.to_string(),
         };
 
-        // A `===`-prefixed line at indent 0 is always a section header,
-        // regardless of the current state: it transitions us into the next
-        // section.
+        // A `===`-prefixed line at indent 0 is always a section header: it
+        // transitions us into the next section. Sections must appear in
+        // strictly increasing order (`Version`, `Extensions`, `Plan`,
+        // mirroring the Substrait `Plan` protobuf field order), so a header
+        // cannot repeat a section or move backwards.
         if let IndentedLine(0, l) = indented_line
             && l.starts_with("===")
         {
-            self.state = self.parse_section_header(l)?;
+            let next = self.parse_section_header(l)?;
+            if next.section_rank() <= self.state.section_rank() {
+                return Err(ParseError::ValidationError(
+                    ctx(),
+                    format!(
+                        "section {next} is out of order after {current}; sections must appear \
+                         in the order Version, Extensions, Plan",
+                        current = self.state,
+                    ),
+                ));
+            }
+            self.state = next;
             return Ok(());
         }
 
@@ -1002,8 +1030,8 @@ impl<'a> Parser<'a> {
         if line == PLAN_HEADER {
             return Ok(State::Plan);
         }
-        if line
-            .strip_prefix(VERSION_HEADER)
+        if let Some(rest) = line.strip_prefix(VERSION_HEADER)
+            && (rest.is_empty() || rest.starts_with(' '))
         {
             self.version = Some(self.parse_version_header(line)?);
             return Ok(State::Version);
@@ -1503,5 +1531,85 @@ Project[$0, $1, 42, 84]
             }
             other => panic!("Expected Rel type, got {other:?}"),
         }
+    }
+
+    /// Sections must appear in the order `Version`, `Extensions`, `Plan`
+    /// (each optional except `Plan`); a header out of that order is rejected.
+    #[test]
+    fn test_section_headers_out_of_order_rejected() {
+        let input = r#"
+=== Plan
+Root[result]
+  Read[t => a:i32]
+
+=== Extensions
+URNs:
+  @  1: /urn/common
+"#;
+        let err = Parser::parse(input).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("out of order"),
+            "expected an out-of-order error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_repeated_section_header_rejected() {
+        let input = r#"
+=== Extensions
+URNs:
+  @  1: /urn/common
+
+=== Extensions
+URNs:
+  @  2: /urn/other
+
+=== Plan
+Root[result]
+  Read[t => a:i32]
+"#;
+        let err = Parser::parse(input).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("out of order"),
+            "expected an out-of-order error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_version_after_plan_rejected() {
+        let input = r#"
+=== Plan
+Root[result]
+  Read[t => a:i32]
+
+=== Version 1.0.0
+"#;
+        let err = Parser::parse(input).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("out of order"),
+            "expected an out-of-order error, got: {msg}"
+        );
+    }
+
+    /// The full, valid section order (`Version`, `Extensions`, `Plan`) is
+    /// still accepted.
+    #[test]
+    fn test_all_sections_in_order_accepted() {
+        let input = r#"
+=== Version 1.2.3
+=== Extensions
+URNs:
+  @  1: /urn/common
+
+=== Plan
+Root[result]
+  Read[t => a:i32]
+"#;
+        let plan = Parser::parse(input).unwrap();
+        assert_eq!(plan.relations.len(), 1);
+        assert!(plan.version.is_some());
     }
 }

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -950,8 +950,28 @@ impl<'a> Parser<'a> {
             line: line.to_string(),
         };
 
+        // A `===`-prefixed line at indent 0 is always a section header,
+        // regardless of the current state: it transitions us into the next
+        // section.
+        if let IndentedLine(0, l) = indented_line
+            && l.starts_with("===")
+        {
+            self.state = self.parse_section_header(l)?;
+            return Ok(());
+        }
+
         match self.state {
-            State::Initial => self.parse_initial(indented_line),
+            State::Initial => match indented_line {
+                IndentedLine(0, l) if l.trim().is_empty() => Ok(()),
+                IndentedLine(n, l) => Err(ParseError::Initial(
+                    ParseContext::new(n as i64, l.to_string()),
+                    MessageParseError::invalid(
+                        "initial",
+                        pest::Span::new(l, 0, l.len()).expect("Invalid span?!"),
+                        format!("Unknown initial line: {l:?}"),
+                    ),
+                )),
+            },
             State::Version => self.parse_version(indented_line),
             State::Extensions => self
                 .parse_extensions(indented_line)
@@ -971,41 +991,38 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Parse the initial line(s) of the input, which is either a blank line or
-    /// the extensions or plan header.
-    fn parse_initial(&mut self, line: IndentedLine) -> Result<(), ParseError> {
-        match line {
-            IndentedLine(0, l) if l.trim().is_empty() => {}
-            IndentedLine(0, l)
-                if l.strip_prefix(VERSION_HEADER)
-                    .is_some_and(|rest| rest.is_empty() || rest.starts_with(' ')) =>
-            {
-                self.parse_version_header(l)?;
-                self.state = State::Version;
-            }
-            IndentedLine(0, simple::EXTENSIONS_HEADER) => {
-                self.state = State::Extensions;
-            }
-            IndentedLine(0, PLAN_HEADER) => {
-                self.state = State::Plan;
-            }
-            IndentedLine(n, l) => {
-                return Err(ParseError::Initial(
-                    ParseContext::new(n as i64, l.to_string()),
-                    MessageParseError::invalid(
-                        "initial",
-                        pest::Span::new(l, 0, l.len()).expect("Invalid span?!"),
-                        format!("Unknown initial line: {l:?}"),
-                    ),
-                ));
-            }
+    /// Parse a `===`-prefixed section header line (at indent 0), returning
+    /// the [`State`] to transition into. Also performs any header-specific
+    /// parsing, e.g. storing the plan [`Version`] from a `=== Version`
+    /// header.
+    fn parse_section_header(&mut self, line: &str) -> Result<State, ParseError> {
+        if line == simple::EXTENSIONS_HEADER {
+            return Ok(State::Extensions);
         }
-        Ok(())
+        if line == PLAN_HEADER {
+            return Ok(State::Plan);
+        }
+        if line
+            .strip_prefix(VERSION_HEADER)
+            .is_some_and(|rest| rest.is_empty() || rest.starts_with(' '))
+        {
+            self.version = Some(self.parse_version_header(line)?);
+            return Ok(State::Version);
+        }
+
+        Err(ParseError::Initial(
+            ParseContext::new(self.line_no, line.to_string()),
+            MessageParseError::invalid(
+                "initial",
+                pest::Span::new(line, 0, line.len()).expect("Invalid span?!"),
+                format!("Unknown section header: {line:?}"),
+            ),
+        ))
     }
 
     /// Parse the `=== Version <major>.<minor>.<patch>` header line and store
     /// the resulting [`Version`], leaving `producer` / `git_hash` empty
-    fn parse_version_header(&mut self, line: &str) -> Result<(), ParseError> {
+    fn parse_version_header(&self, line: &str) -> Result<Version, ParseError> {
         let ctx = || ParseContext::new(self.line_no, line.to_string());
         let rest = line
             .strip_prefix(VERSION_HEADER)
@@ -1040,28 +1057,20 @@ impl<'a> Parser<'a> {
             ));
         }
 
-        self.version = Some(Version {
+        Ok(Version {
             major_number,
             minor_number,
             patch_number,
             ..Default::default()
-        });
-        Ok(())
+        })
     }
 
-    /// Parses a single line from the version section: either an indented
-    /// `producer:` / `git_hash:` detail line, or a section header
+    /// Parses a single line from the version section: an indented
+    /// `producer:` / `git_hash:` detail line. Section headers are
+    /// intercepted by [`parse_line`](Self::parse_line) before reaching here.
     fn parse_version(&mut self, line: IndentedLine) -> Result<(), ParseError> {
         match line {
             IndentedLine(0, l) if l.trim().is_empty() => Ok(()),
-            IndentedLine(0, simple::EXTENSIONS_HEADER) => {
-                self.state = State::Extensions;
-                Ok(())
-            }
-            IndentedLine(0, PLAN_HEADER) => {
-                self.state = State::Plan;
-                Ok(())
-            }
             IndentedLine(1, l) => self.parse_version_detail(l),
             IndentedLine(_, l) => Err(ParseError::ValidationError(
                 ParseContext::new(self.line_no, l.to_string()),
@@ -1101,13 +1110,10 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    /// Parse a single line from the extensions section of the input, updating
-    /// the parser state.
+    /// Parse a single line from the extensions section of the input.
+    /// Section headers are intercepted by [`parse_line`](Self::parse_line)
+    /// before reaching here.
     fn parse_extensions(&mut self, line: IndentedLine<'_>) -> Result<(), ExtensionParseError> {
-        if line == IndentedLine(0, PLAN_HEADER) {
-            self.state = State::Plan;
-            return Ok(());
-        }
         self.extension_parser.parse_line(line)
     }
 

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -1004,7 +1004,6 @@ impl<'a> Parser<'a> {
         }
         if line
             .strip_prefix(VERSION_HEADER)
-            .is_some_and(|rest| rest.is_empty() || rest.starts_with(' '))
         {
             self.version = Some(self.parse_version_header(line)?);
             return Ok(State::Version);

--- a/src/textify/foundation.rs
+++ b/src/textify/foundation.rs
@@ -26,6 +26,8 @@ pub enum Visibility {
 /// OutputOptions holds the options for textifying a Substrait type.
 #[derive(Debug, Clone)]
 pub struct OutputOptions {
+    /// Show the `=== Version` section when the plan carries a non-empty version
+    pub show_version: bool,
     /// Show the extension URNs in the output.
     pub show_extension_urns: bool,
     /// Show the extensions in the output. By default, simple extensions are
@@ -56,6 +58,7 @@ pub struct OutputOptions {
 impl Default for OutputOptions {
     fn default() -> Self {
         Self {
+            show_version: true,
             show_extension_urns: false,
             show_simple_extensions: false,
             show_simple_extension_anchors: Visibility::Required,
@@ -74,6 +77,7 @@ impl OutputOptions {
     /// reconstructing a plan.
     pub fn verbose() -> Self {
         Self {
+            show_version: true,
             show_extension_urns: true,
             show_simple_extensions: true,
             show_simple_extension_anchors: Visibility::Always,

--- a/src/textify/foundation.rs
+++ b/src/textify/foundation.rs
@@ -26,8 +26,6 @@ pub enum Visibility {
 /// OutputOptions holds the options for textifying a Substrait type.
 #[derive(Debug, Clone)]
 pub struct OutputOptions {
-    /// Show the `=== Version` section when the plan carries a non-empty version
-    pub show_version: bool,
     /// Show the extension URNs in the output.
     pub show_extension_urns: bool,
     /// Show the extensions in the output. By default, simple extensions are
@@ -58,7 +56,6 @@ pub struct OutputOptions {
 impl Default for OutputOptions {
     fn default() -> Self {
         Self {
-            show_version: true,
             show_extension_urns: false,
             show_simple_extensions: false,
             show_simple_extension_anchors: Visibility::Required,
@@ -77,7 +74,6 @@ impl OutputOptions {
     /// reconstructing a plan.
     pub fn verbose() -> Self {
         Self {
-            show_version: true,
             show_extension_urns: true,
             show_simple_extensions: true,
             show_simple_extension_anchors: Visibility::Always,

--- a/src/textify/plan.rs
+++ b/src/textify/plan.rs
@@ -4,13 +4,14 @@ use substrait::proto;
 
 use super::Textify;
 use crate::extensions::{ExtensionRegistry, SimpleExtensions};
-use crate::parser::PLAN_HEADER;
+use crate::parser::{PLAN_HEADER, VERSION_HEADER};
 use crate::textify::foundation::ErrorAccumulator;
 use crate::textify::{OutputOptions, ScopedContext};
 
 #[derive(Debug, Clone)]
 pub(crate) struct PlanWriter<'a, E: ErrorAccumulator + Default> {
     options: &'a OutputOptions,
+    version: Option<&'a proto::Version>,
     extensions: SimpleExtensions,
     relations: &'a [proto::PlanRel],
     errors: E,
@@ -36,6 +37,7 @@ impl<'a, E: ErrorAccumulator + Default + Clone> PlanWriter<'a, E> {
         (
             Self {
                 options,
+                version: plan.version.as_ref(),
                 extensions,
                 relations,
                 errors: errors.clone(),
@@ -52,6 +54,33 @@ impl<'a, E: ErrorAccumulator + Default + Clone> PlanWriter<'a, E> {
             &self.extensions,
             self.extension_registry,
         )
+    }
+
+    /// Write the `=== Version` section. Emits nothing unless option is
+    /// enabled and the plan carries a version that is not entirely empty
+    pub(crate) fn write_version(&self, w: &mut impl fmt::Write) -> fmt::Result {
+        if !self.options.show_version {
+            return Ok(());
+        }
+        let Some(version) = self.version else {
+            return Ok(());
+        };
+        if version == &proto::Version::default() {
+            return Ok(());
+        }
+
+        writeln!(
+            w,
+            "{VERSION_HEADER} {}.{}.{}",
+            version.major_number, version.minor_number, version.patch_number
+        )?;
+        if !version.producer.is_empty() {
+            writeln!(w, "{}producer: {}", self.options.indent, version.producer)?;
+        }
+        if !version.git_hash.is_empty() {
+            writeln!(w, "{}git_hash: {}", self.options.indent, version.git_hash)?;
+        }
+        Ok(())
     }
 
     pub(crate) fn write_extensions(&self, w: &mut impl fmt::Write) -> fmt::Result {
@@ -75,6 +104,7 @@ impl<'a, E: ErrorAccumulator + Default + Clone> PlanWriter<'a, E> {
 
 impl<'a, E: ErrorAccumulator + Default> fmt::Display for PlanWriter<'a, E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.write_version(f)?;
         self.write_extensions(f)?;
         if !self.extensions.is_empty() {
             writeln!(f)?;

--- a/src/textify/plan.rs
+++ b/src/textify/plan.rs
@@ -56,12 +56,9 @@ impl<'a, E: ErrorAccumulator + Default + Clone> PlanWriter<'a, E> {
         )
     }
 
-    /// Write the `=== Version` section. Emits nothing unless option is
-    /// enabled and the plan carries a version that is not entirely empty
+    /// Write the `=== Version` section. Emits nothing unless the plan
+    /// carries a version that is not entirely empty
     pub(crate) fn write_version(&self, w: &mut impl fmt::Write) -> fmt::Result {
-        if !self.options.show_version {
-            return Ok(());
-        }
         let Some(version) = self.version else {
             return Ok(());
         };
@@ -75,10 +72,20 @@ impl<'a, E: ErrorAccumulator + Default + Clone> PlanWriter<'a, E> {
             version.major_number, version.minor_number, version.patch_number
         )?;
         if !version.producer.is_empty() {
-            writeln!(w, "{}producer: {}", self.options.indent, version.producer)?;
+            writeln!(
+                w,
+                "{}producer: {}",
+                self.options.indent,
+                version.producer.trim()
+            )?;
         }
         if !version.git_hash.is_empty() {
-            writeln!(w, "{}git_hash: {}", self.options.indent, version.git_hash)?;
+            writeln!(
+                w,
+                "{}git_hash: {}",
+                self.options.indent,
+                version.git_hash.trim()
+            )?;
         }
         Ok(())
     }

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -861,3 +861,123 @@ Root[sum]
 
     roundtrip_plan(plan);
 }
+
+// === Version section tests ===
+
+/// A `=== Version` section with just the semver round-trips, and appears
+/// before the plan (and before extensions, when present).
+#[test]
+fn test_version_semver_only_roundtrip() {
+    let plan = r#"=== Version 0.55.0
+=== Plan
+Root[a]
+  Read[t => a:i64]"#;
+
+    roundtrip_plan(plan);
+
+    let parsed = Parser::parse(plan).unwrap();
+    let version = parsed.version.expect("version should be set");
+    assert_eq!(version.major_number, 0);
+    assert_eq!(version.minor_number, 55);
+    assert_eq!(version.patch_number, 0);
+    assert!(version.producer.is_empty());
+    assert!(version.git_hash.is_empty());
+}
+
+/// The optional `producer:` / `git_hash:` detail lines round-trip and sit
+/// under the version header, above the extensions section.
+#[test]
+fn test_version_with_detail_and_extensions_roundtrip() {
+    let plan = r#"=== Version 1.2.3
+  producer: substrait-explain tests
+  git_hash: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b
+=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml
+Functions:
+  # 10 @  1: add
+
+=== Plan
+Root[sum]
+  Project[add($0, $1):i64]
+    Read[t => a:i64, b:i64]"#;
+
+    roundtrip_plan(plan);
+
+    let version = Parser::parse(plan).unwrap().version.unwrap();
+    assert_eq!(
+        (
+            version.major_number,
+            version.minor_number,
+            version.patch_number
+        ),
+        (1, 2, 3)
+    );
+    assert_eq!(version.producer, "substrait-explain tests");
+    assert_eq!(version.git_hash, "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b");
+}
+
+/// A `git_hash` without a `producer` is emitted on its own, even at version
+/// 0.0.0, because it carries real information.
+#[test]
+fn test_version_git_hash_only_roundtrip() {
+    let plan = r#"=== Version 0.0.0
+  git_hash: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b
+=== Plan
+Root[a]
+  Read[t => a:i64]"#;
+
+    roundtrip_plan(plan);
+}
+
+/// A plan with no version section parses to `version: None` and emits no
+/// `=== Version` line.
+#[test]
+fn test_version_absent() {
+    let plan = r#"=== Plan
+Root[a]
+  Read[t => a:i64]"#;
+
+    let parsed = Parser::parse(plan).unwrap();
+    assert!(parsed.version.is_none());
+
+    let (text, errors) = substrait_explain::format(&parsed);
+    assert!(errors.is_empty());
+    assert!(
+        !text.contains("=== Version"),
+        "no version section expected, got:\n{text}"
+    );
+}
+
+/// An all-default `Version` (0.0.0 with no producer/git_hash) is treated as
+/// "no version" and is not emitted, even though it is present in the proto.
+#[test]
+fn test_version_all_zero_suppressed() {
+    let plan = r#"=== Version 0.0.0
+=== Plan
+Root[a]
+  Read[t => a:i64]"#;
+
+    // The parser preserves the (empty) version it was given...
+    let parsed = Parser::parse(plan).unwrap();
+    assert!(parsed.version.is_some());
+
+    // ...but the formatter suppresses an all-default version.
+    let (text, errors) = substrait_explain::format(&parsed);
+    assert!(errors.is_empty());
+    assert!(
+        !text.contains("=== Version"),
+        "all-zero version should be suppressed, got:\n{text}"
+    );
+}
+
+/// An unparseable version number is a hard error (structural, not lenient).
+#[test]
+fn test_version_invalid_number_errors() {
+    let plan = r#"=== Version 0.x.0
+=== Plan
+Root[a]
+  Read[t => a:i64]"#;
+
+    assert!(Parser::parse(plan).is_err());
+}

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -862,10 +862,6 @@ Root[sum]
     roundtrip_plan(plan);
 }
 
-// === Version section tests ===
-
-/// A `=== Version` section with just the semver round-trips, and appears
-/// before the plan (and before extensions, when present).
 #[test]
 fn test_version_semver_only_roundtrip() {
     let plan = r#"=== Version 0.55.0


### PR DESCRIPTION
## Description

Added a version section to substrait-explain, and added support for round-tripping the version from explain to protobuf, and back. The Version field is not required, and versions at 0.0.0 will not be represented unless there is info on the producer/git hash.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Example update
- [ ] Other (please describe)

## Testing

- [x] Added tests for new functionality
- [x] All existing tests pass
- [x] Ran examples to verify behavior

## Checklist

- [x] Code follows Rust conventions
- [x] Documentation updated if needed
- [x] No breaking changes (or breaking changes documented)
- [x ] Pre-commit hooks pass

## Related Issues

Closes #(issue number)
