### PR TITLE
feat: add explicit emit output grammar and parsing support

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -639,7 +639,7 @@ Root[a, b]
 # assert_eq!(plan.relations.len(), 1);
 ```
 
-Use `+> ... |>` when the read's base schema records the direct output domain but
+Use `+> ... |>` to specify an Emit / output ordering different from the table's base schema:
 only some fields should flow downstream:
 
 ```rust

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -601,9 +601,10 @@ read_output := ("=>" named_column_list) / ("+>" named_column_list ("|>" referenc
 
 - `table_name := name ("." name)*` - table name, optionally qualified with schema/database
 - `named_column := name ":" type` - column name with type annotation
-- `"=>" named_column_list` - legacy implicit output form. It declares the visible output columns without preserving an explicit `RelCommon.emit_kind`.
-- `"+>" named_column_list` - explicit direct output domain. It preserves `RelCommon.emit_kind` as `Direct`.
-- `"+>" named_column_list "|>" reference_list` - explicit direct output domain followed by an explicit `Emit` mapping over that domain.
+- `named_column_list := (named_column ("," named_column)*)?` - the list of columns and their types to be read from the table `table_name`.
+  - `=>` is used to mean implicit column ordering; for `Read`, this translates to `Direct` column ordering.
+  - When used with `+>` and no `|>`, the `named_column`s are in the expected order of the table, and `Direct` emit is used.
+  - When used with `+> … |>`, the `named_column`s are in the expected order of the table, and the emit order is a Remap specified by `reference_list`.
 
 #### Example
 

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -523,6 +523,7 @@ Where:
 - **`named_arguments`**: Named arguments (optional)
 - **`=>`**: Separator between arguments and output columns (optional, only present when both arguments and columns are specified)
 - **`columns`**: Output column names and types, or field references for pass-through (all relations specify outputs, but format varies)
+- **`|>`**: An alternative/additional separator introducing an explicit `RelCommon.emit` mapping that is always preserved as `Emit`
 
 #### Example
 
@@ -592,12 +593,13 @@ Root[c, d]           // root with output columns c and d
 
 #### Syntax
 
-`"Read" "[" table_name "=>" (named_column ("," named_column)*)? "]"`
+`"Read" "[" table_name "=>" (named_column ("," named_column)*)? explicit_emit_suffix "]"`
 
 #### Components
 
 - `table_name := name ("." name)*` - table name, optionally qualified with schema/database
 - `named_column := name ":" type` - column name with type annotation
+- `explicit_emit_suffix := ("|>" reference_list)?` - optional explicit `RelCommon.emit` mapping
 
 #### Example
 
@@ -616,6 +618,21 @@ Root[result2]
 #
 # let plan = Parser::parse(plan_text).unwrap();
 # assert_eq!(plan.relations.len(), 2);
+```
+Use `|>` when the read's base schema
+records the real table schema but only some fields should flow downstream:
+
+```rust
+# use substrait_explain::Parser;
+#
+# let plan_text = r#"
+=== Plan
+Root[b, a]
+  Read[my_table => a:i64, b:string, c:i64 |> $1, $0]
+# "#;
+#
+# let plan = Parser::parse(plan_text).unwrap();
+# assert_eq!(plan.relations.len(), 1);
 ```
 
 ### VirtualTable Read Relation
@@ -761,15 +778,39 @@ Root[id]
 # assert_eq!(formatted.trim(), plan_text.trim());
 ```
 
+### Explicit Emit Mappings
+
+`Filter`, `Sort`, `Fetch`, and `Join` each have a direct output domain that is
+entirely determined by their child relation(s) (the child's columns, or for
+`Join`, the concatenation of both children's columns). For these four, the
+trailing clause is one of two alternatives:
+
+```text
+output_emit := ("=>" reference_list) / ("|>" reference_list)
+```
+
+- `"=>" reference_list` - the existing form. `RelCommon.emit_kind` collapses
+  to `Direct` when the reference list is exactly the identity permutation
+  `$0, $1, ..., $n-1`; otherwise it's `Emit` with that mapping.
+- `"|>" reference_list` - an explicit emit. `RelCommon.emit_kind` is always
+  `Emit` with exactly the written mapping, even when it happens to be the
+  identity permutation. Use `|>` when it matters that the plan explicitly
+  carries `Emit` rather than `Direct` — e.g. round-tripping a plan that came
+  from another system with the two shapes intentionally distinguished.
+
+Only one of `=>` or `|>` may appear — they are alternatives, not a
+`=>` list followed by an additional `|>` mapping.
+
 ### Filter Relation
 
 #### Syntax
 
-`"Filter" "[" expression "=>" reference_list "]"`
+`"Filter" "[" expression output_emit "]"`
 
 #### Components
 
 - `expression` - boolean expression for filtering
+- `output_emit` - see [Explicit Emit Mappings](#explicit-emit-mappings)
 - `reference_list := reference ("," reference)*` - comma-separated list of field references to pass through
 
 #### Example
@@ -787,6 +828,29 @@ Functions:
 === Plan
 Root[result]
   Filter[gt($2, 100):boolean => $0, $1, $2]
+    Project[$0, $1, $2]
+      Read[data => a:i64, b:string, c:i32]
+# "#;
+#
+# let plan = Parser::parse(plan_text).unwrap();
+# assert_eq!(plan.relations.len(), 1);
+```
+
+An explicit emit preserves `RelCommon.emit_kind` as `Emit` even for an identity mapping:
+
+```rust
+# use substrait_explain::Parser;
+#
+# let plan_text = r#"
+=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml
+Functions:
+  ## 10 @  1: gt
+
+=== Plan
+Root[result]
+  Filter[gt($2, 100):boolean |> $0, $1, $2]
     Project[$0, $1, $2]
       Read[data => a:i64, b:string, c:i32]
 # "#;
@@ -867,7 +931,7 @@ Sort[($0, &AscNullsFirst), ($1, &DescNullsLast) => $0, $1]
 #### Syntax
 
 ```text
-sort_relation := "Sort" "[" sort_fields "=>" reference_list "]"
+sort_relation := "Sort" "[" sort_fields output_emit "]"
 sort_fields := sort_field ("," sort_field)*
 sort_field := "(" reference "," sort_direction ")"
 sort_direction := "&AscNullsFirst" / "&AscNullsLast" / "&DescNullsFirst" / "&DescNullsLast"
@@ -877,17 +941,17 @@ sort_direction := "&AscNullsFirst" / "&AscNullsLast" / "&DescNullsFirst" / "&Des
 
 - Each sort field is a tuple: `(reference, sort_direction)`
 - Sort directions follow the general `enum` syntax and specify null handling
-- The columns after `=>` specify the output field order (typically a reference list)
+- `output_emit` - see [Explicit Emit Mappings](#explicit-emit-mappings); e.g. `Sort[($0, &AscNullsFirst) |> $1, $0]` for an explicit emit
 
 ### Join Relation
 
-**Syntax**: `"Join" "[" join_type "," expression "=>" reference_list "]"`
+**Syntax**: `"Join" "[" join_type "," expression output_emit "]"`
 
 **Components**:
 
 - `join_type` - Join type enum with `&` prefix (e.g., `&Inner`, `&Left`, `&Right`, `&Outer`)
 - `expression` - Join condition (boolean expression relating left and right inputs)
-- `reference_list` - Comma-separated list of field references for output columns
+- `output_emit` - see [Explicit Emit Mappings](#explicit-emit-mappings)
 
 **Field Reference Mapping**:
 

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -593,8 +593,10 @@ Root[c, d]           // root with output columns c and d
 #### Syntax
 
 ```text
-read_relation := "Read" "[" table_name read_output "]"
-read_output := ("=>" named_column_list) / ("+>" named_column_list ("|>" reference_list)?)
+read_relation := "Read" "[" table_name output "]"
+output := implicit_output / direct_output
+implicit_output := "=>" named_column_list
+direct_output := "+>" named_column_list ("|>" reference_list)?
 ```
 
 #### Components

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -523,7 +523,6 @@ Where:
 - **`named_arguments`**: Named arguments (optional)
 - **`=>`**: Separator between arguments and output columns (optional, only present when both arguments and columns are specified)
 - **`columns`**: Output column names and types, or field references for pass-through (all relations specify outputs, but format varies)
-- **`|>`**: An alternative/additional separator introducing an explicit `RelCommon.emit` mapping that is always preserved as `Emit`
 
 #### Example
 
@@ -593,13 +592,18 @@ Root[c, d]           // root with output columns c and d
 
 #### Syntax
 
-`"Read" "[" table_name "=>" (named_column ("," named_column)*)? explicit_emit_suffix "]"`
+```text
+read_relation := "Read" "[" table_name read_output "]"
+read_output := ("=>" named_column_list) / ("+>" named_column_list ("|>" reference_list)?)
+```
 
 #### Components
 
 - `table_name := name ("." name)*` - table name, optionally qualified with schema/database
 - `named_column := name ":" type` - column name with type annotation
-- `explicit_emit_suffix := ("|>" reference_list)?` - optional explicit `RelCommon.emit` mapping
+- `"=>" named_column_list` - legacy implicit output form. It declares the visible output columns without preserving an explicit `RelCommon.emit_kind`.
+- `"+>" named_column_list` - explicit direct output domain. It preserves `RelCommon.emit_kind` as `Direct`.
+- `"+>" named_column_list "|>" reference_list` - explicit direct output domain followed by an explicit `Emit` mapping over that domain.
 
 #### Example
 
@@ -619,8 +623,23 @@ Root[result2]
 # let plan = Parser::parse(plan_text).unwrap();
 # assert_eq!(plan.relations.len(), 2);
 ```
-Use `|>` when the read's base schema
-records the real table schema but only some fields should flow downstream:
+Use `+>` when the read's base schema records the direct output domain:
+
+```rust
+# use substrait_explain::Parser;
+#
+# let plan_text = r#"
+=== Plan
+Root[a, b]
+  Read[my_table +> a:i64, b:string]
+# "#;
+#
+# let plan = Parser::parse(plan_text).unwrap();
+# assert_eq!(plan.relations.len(), 1);
+```
+
+Use `+> ... |>` when the read's base schema records the direct output domain but
+only some fields should flow downstream:
 
 ```rust
 # use substrait_explain::Parser;
@@ -628,7 +647,7 @@ records the real table schema but only some fields should flow downstream:
 # let plan_text = r#"
 === Plan
 Root[b, a]
-  Read[my_table => a:i64, b:string, c:i64 |> $1, $0]
+  Read[my_table +> a:i64, b:string, c:i64 |> $1, $0]
 # "#;
 #
 # let plan = Parser::parse(plan_text).unwrap();
@@ -778,39 +797,15 @@ Root[id]
 # assert_eq!(formatted.trim(), plan_text.trim());
 ```
 
-### Explicit Emit Mappings
-
-`Filter`, `Sort`, `Fetch`, and `Join` each have a direct output domain that is
-entirely determined by their child relation(s) (the child's columns, or for
-`Join`, the concatenation of both children's columns). For these four, the
-trailing clause is one of two alternatives:
-
-```text
-output_emit := ("=>" reference_list) / ("|>" reference_list)
-```
-
-- `"=>" reference_list` - the existing form. `RelCommon.emit_kind` collapses
-  to `Direct` when the reference list is exactly the identity permutation
-  `$0, $1, ..., $n-1`; otherwise it's `Emit` with that mapping.
-- `"|>" reference_list` - an explicit emit. `RelCommon.emit_kind` is always
-  `Emit` with exactly the written mapping, even when it happens to be the
-  identity permutation. Use `|>` when it matters that the plan explicitly
-  carries `Emit` rather than `Direct` — e.g. round-tripping a plan that came
-  from another system with the two shapes intentionally distinguished.
-
-Only one of `=>` or `|>` may appear — they are alternatives, not a
-`=>` list followed by an additional `|>` mapping.
-
 ### Filter Relation
 
 #### Syntax
 
-`"Filter" "[" expression output_emit "]"`
+`"Filter" "[" expression "=>" reference_list "]"`
 
 #### Components
 
 - `expression` - boolean expression for filtering
-- `output_emit` - see [Explicit Emit Mappings](#explicit-emit-mappings)
 - `reference_list := reference ("," reference)*` - comma-separated list of field references to pass through
 
 #### Example
@@ -828,29 +823,6 @@ Functions:
 === Plan
 Root[result]
   Filter[gt($2, 100):boolean => $0, $1, $2]
-    Project[$0, $1, $2]
-      Read[data => a:i64, b:string, c:i32]
-# "#;
-#
-# let plan = Parser::parse(plan_text).unwrap();
-# assert_eq!(plan.relations.len(), 1);
-```
-
-An explicit emit preserves `RelCommon.emit_kind` as `Emit` even for an identity mapping:
-
-```rust
-# use substrait_explain::Parser;
-#
-# let plan_text = r#"
-=== Extensions
-URNs:
-  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml
-Functions:
-  ## 10 @  1: gt
-
-=== Plan
-Root[result]
-  Filter[gt($2, 100):boolean |> $0, $1, $2]
     Project[$0, $1, $2]
       Read[data => a:i64, b:string, c:i32]
 # "#;
@@ -931,7 +903,7 @@ Sort[($0, &AscNullsFirst), ($1, &DescNullsLast) => $0, $1]
 #### Syntax
 
 ```text
-sort_relation := "Sort" "[" sort_fields output_emit "]"
+sort_relation := "Sort" "[" sort_fields "=>" reference_list "]"
 sort_fields := sort_field ("," sort_field)*
 sort_field := "(" reference "," sort_direction ")"
 sort_direction := "&AscNullsFirst" / "&AscNullsLast" / "&DescNullsFirst" / "&DescNullsLast"
@@ -941,17 +913,17 @@ sort_direction := "&AscNullsFirst" / "&AscNullsLast" / "&DescNullsFirst" / "&Des
 
 - Each sort field is a tuple: `(reference, sort_direction)`
 - Sort directions follow the general `enum` syntax and specify null handling
-- `output_emit` - see [Explicit Emit Mappings](#explicit-emit-mappings); e.g. `Sort[($0, &AscNullsFirst) |> $1, $0]` for an explicit emit
+- `reference_list` - comma-separated list of field references to pass through
 
 ### Join Relation
 
-**Syntax**: `"Join" "[" join_type "," expression output_emit "]"`
+**Syntax**: `"Join" "[" join_type "," expression "=>" reference_list "]"`
 
 **Components**:
 
 - `join_type` - Join type enum with `&` prefix (e.g., `&Inner`, `&Left`, `&Right`, `&Outer`)
 - `expression` - Join condition (boolean expression relating left and right inputs)
-- `output_emit` - see [Explicit Emit Mappings](#explicit-emit-mappings)
+- `reference_list` - comma-separated list of field references for output columns
 
 **Field Reference Mapping**:
 

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -523,6 +523,7 @@ Where:
 - **`named_arguments`**: Named arguments (optional)
 - **`=>`**: Separator between arguments and output columns (optional, only present when both arguments and columns are specified)
 - **`columns`**: Output column names and types, or field references for pass-through (all relations specify outputs, but format varies)
+- **`reference_list := reference ("," reference)*`**: comma-separated list of field references
 
 #### Example
 
@@ -809,7 +810,7 @@ Root[id]
 #### Components
 
 - `expression` - boolean expression for filtering
-- `reference_list := reference ("," reference)*` - comma-separated list of field references to pass through
+- `reference_list` - field references to pass through
 
 #### Example
 

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -225,13 +225,13 @@ table_name = { (name ~ ("." ~ name)*) }
 named_column      = { name ~ ":" ~ type }
 named_column_list = { (named_column ~ ("," ~ sp ~ named_column)*)? }
 
-// -- Read output clauses --
+// -- Output clauses --
 // `=>` declares the final visible output columns without preserving a RelCommon.emit distinction.
-// `+>` declares the Read direct output domain. Without `|>`, it is an explicit
+// `+>` declares the direct output domain. Without `|>`, it is an explicit
 // `|>` the trailing reference list is preserved as an explicit Emit over that direct output domain.
-read_output          = { read_implicit_output | read_direct_output }
-read_implicit_output = { "=>" ~ sp ~ named_column_list }
-read_direct_output   = { "+>" ~ sp ~ named_column_list ~ read_emit_suffix }
+output          = { implicit_output | direct_output }
+implicit_output = { "=>" ~ sp ~ named_column_list }
+direct_output   = { "+>" ~ sp ~ named_column_list ~ emit_suffix }
 emit_suffix     = { (sp ~ "|>" ~ sp ~ reference_list)? }
 
 planNode = {
@@ -260,7 +260,7 @@ top_level_relation = {
 root_relation  = { "Root" ~ "[" ~ root_name_list ~ "]" }
 root_name_list = { (name ~ (sp ~ "," ~ sp ~ name)*)? }
 
-read_relation = { "Read" ~ "[" ~ table_name ~ sp ~ read_output ~ "]" }
+read_relation = { "Read" ~ "[" ~ table_name ~ sp ~ output ~ "]" }
 
 // ExtensionTable read: Read:Extension[columns], with detail in a required + Ext addendum.
 extension_read_relation = { "Read:Extension" ~ "[" ~ named_column_list ~ "]" }

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -232,7 +232,7 @@ named_column_list = { (named_column ~ ("," ~ sp ~ named_column)*)? }
 read_output          = { read_implicit_output | read_direct_output }
 read_implicit_output = { "=>" ~ sp ~ named_column_list }
 read_direct_output   = { "+>" ~ sp ~ named_column_list ~ read_emit_suffix }
-read_emit_suffix     = { (sp ~ "|>" ~ sp ~ reference_list)? }
+emit_suffix     = { (sp ~ "|>" ~ sp ~ reference_list)? }
 
 planNode = {
     // Specialized read relations must precede read_relation: all start with

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -225,21 +225,14 @@ table_name = { (name ~ ("." ~ name)*) }
 named_column      = { name ~ ":" ~ type }
 named_column_list = { (named_column ~ ("," ~ sp ~ named_column)*)? }
 
-// -- Explicit emit mapping (`RelCommon.emit`) --
-//
-// For relations whose direct output domain is entirely determined by their
-// child (Filter, Sort, Fetch, Join), the trailing clause is either the
-// implicit direct passthrough (`=>`, collapsed to `Direct` when possible) or
-// an explicit emit mapping (`|>`, always preserved as `Emit` even if the
-// mapping happens to be the identity permutation).
-direct_emit   = { "=>" ~ sp ~ reference_list }
-explicit_emit = { "|>" ~ sp ~ reference_list }
-output_emit   = { direct_emit | explicit_emit }
-
-// For relations with their own direct output domain (Read, and eventually
-// Project/Aggregate), an explicit emit mapping is an optional trailing
-// addition after the domain is declared - it does not replace `=>`.
-explicit_emit_suffix = { (sp ~ "|>" ~ sp ~ reference_list)? }
+// -- Read output clauses --
+// `=>` declares the final visible output columns without preserving a RelCommon.emit distinction.
+// `+>` declares the Read direct output domain. Without `|>`, it is an explicit
+// `|>` the trailing reference list is preserved as an explicit Emit over that direct output domain.
+read_output          = { read_implicit_output | read_direct_output }
+read_implicit_output = { "=>" ~ sp ~ named_column_list }
+read_direct_output   = { "+>" ~ sp ~ named_column_list ~ read_emit_suffix }
+read_emit_suffix     = { (sp ~ "|>" ~ sp ~ reference_list)? }
 
 planNode = {
     // Specialized read relations must precede read_relation: all start with
@@ -267,7 +260,7 @@ top_level_relation = {
 root_relation  = { "Root" ~ "[" ~ root_name_list ~ "]" }
 root_name_list = { (name ~ (sp ~ "," ~ sp ~ name)*)? }
 
-read_relation = { "Read" ~ "[" ~ table_name ~ sp ~ "=>" ~ sp ~ named_column_list ~ explicit_emit_suffix ~ "]" }
+read_relation = { "Read" ~ "[" ~ table_name ~ sp ~ read_output ~ "]" }
 
 // ExtensionTable read: Read:Extension[columns], with detail in a required + Ext addendum.
 extension_read_relation = { "Read:Extension" ~ "[" ~ named_column_list ~ "]" }
@@ -302,7 +295,7 @@ virtual_read_args     = { virtual_row_list | empty }
 virtual_row_list      = { virtual_row ~ (relation_comma ~ virtual_row)* }
 virtual_row           = { "(" ~ sp ~ expression_list? ~ sp ~ ")" }
 
-filter_relation = { "Filter" ~ "[" ~ expression ~ sp ~ output_emit ~ "]" }
+filter_relation = { "Filter" ~ "[" ~ expression ~ sp ~ "=>" ~ sp ~ reference_list ~ "]" }
 reference_list  = { (reference ~ (sp ~ "," ~ sp ~ reference)*)? }
 
 project_relation      = { "Project" ~ "[" ~ project_argument_list ~ "]" }
@@ -332,7 +325,7 @@ aggregate_measure = { function_call }
 empty = { "_" }
 
 // SortRel: Sort[($0, &AscNullsFirst), ($2, &DescNullsLast) => ...]
-sort_relation   = { "Sort" ~ "[" ~ sort_field_list ~ sp ~ output_emit ~ "]" }
+sort_relation   = { "Sort" ~ "[" ~ sort_field_list ~ sp ~ "=>" ~ sp ~ reference_list ~ "]" }
 sort_field_list = { (sort_field ~ (sp ~ "," ~ sp ~ sort_field)*)? }
 sort_field      = { "(" ~ sp ~ reference ~ sp ~ "," ~ sp ~ sort_direction ~ sp ~ ")" }
 sort_direction  = { "&AscNullsFirst" | "&AscNullsLast" | "&DescNullsFirst" | "&DescNullsLast" }
@@ -343,13 +336,13 @@ fetch_value          =  { integer | expression }
 fetch_named_arg      =  { fetch_arg_name ~ sp ~ "=" ~ sp ~ fetch_value }
 fetch_named_arg_list =  { fetch_named_arg ~ (sp ~ "," ~ sp ~ fetch_named_arg)* }
 fetch_args           = _{ fetch_named_arg_list | empty }
-fetch_relation       =  { "Fetch" ~ "[" ~ fetch_args ~ sp ~ output_emit ~ "]" }
+fetch_relation       =  { "Fetch" ~ "[" ~ fetch_args ~ sp ~ "=>" ~ sp ~ reference_list ~ "]" }
 
 // JoinRel: Join[&Inner, eq($0, $2) => $0, $1, $2, $3]
 // Note: Longer prefixes must come before shorter ones (e.g., "&LeftSemi" before "&Left")
 // so that the parser doesn't match "&Left" when it should match "&LeftSemi"
 join_type     = { "&Inner" | "&LeftSemi" | "&LeftAnti" | "&LeftSingle" | "&LeftMark" | "&Left" | "&RightSemi" | "&RightAnti" | "&RightSingle" | "&RightMark" | "&Right" | "&Outer" }
-join_relation = { "Join" ~ "[" ~ join_type ~ sp ~ "," ~ sp ~ expression ~ sp ~ output_emit ~ "]" }
+join_relation = { "Join" ~ "[" ~ join_type ~ sp ~ "," ~ sp ~ expression ~ sp ~ "=>" ~ sp ~ reference_list ~ "]" }
 
 // Extension relations for custom operators not covered by standard Substrait
 // Format: ExtensionType:ExtensionName[arguments, named_arguments => columns]

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -225,6 +225,22 @@ table_name = { (name ~ ("." ~ name)*) }
 named_column      = { name ~ ":" ~ type }
 named_column_list = { (named_column ~ ("," ~ sp ~ named_column)*)? }
 
+// -- Explicit emit mapping (`RelCommon.emit`) --
+//
+// For relations whose direct output domain is entirely determined by their
+// child (Filter, Sort, Fetch, Join), the trailing clause is either the
+// implicit direct passthrough (`=>`, collapsed to `Direct` when possible) or
+// an explicit emit mapping (`|>`, always preserved as `Emit` even if the
+// mapping happens to be the identity permutation).
+direct_emit   = { "=>" ~ sp ~ reference_list }
+explicit_emit = { "|>" ~ sp ~ reference_list }
+output_emit   = { direct_emit | explicit_emit }
+
+// For relations with their own direct output domain (Read, and eventually
+// Project/Aggregate), an explicit emit mapping is an optional trailing
+// addition after the domain is declared - it does not replace `=>`.
+explicit_emit_suffix = { (sp ~ "|>" ~ sp ~ reference_list)? }
+
 planNode = {
     // Specialized read relations must precede read_relation: all start with
     // "Read", and PEG tries alternatives in order — the longer prefixes
@@ -251,7 +267,7 @@ top_level_relation = {
 root_relation  = { "Root" ~ "[" ~ root_name_list ~ "]" }
 root_name_list = { (name ~ (sp ~ "," ~ sp ~ name)*)? }
 
-read_relation = { "Read" ~ "[" ~ table_name ~ sp ~ "=>" ~ sp ~ named_column_list ~ "]" }
+read_relation = { "Read" ~ "[" ~ table_name ~ sp ~ "=>" ~ sp ~ named_column_list ~ explicit_emit_suffix ~ "]" }
 
 // ExtensionTable read: Read:Extension[columns], with detail in a required + Ext addendum.
 extension_read_relation = { "Read:Extension" ~ "[" ~ named_column_list ~ "]" }
@@ -286,7 +302,7 @@ virtual_read_args     = { virtual_row_list | empty }
 virtual_row_list      = { virtual_row ~ (relation_comma ~ virtual_row)* }
 virtual_row           = { "(" ~ sp ~ expression_list? ~ sp ~ ")" }
 
-filter_relation = { "Filter" ~ "[" ~ expression ~ sp ~ "=>" ~ sp ~ reference_list ~ "]" }
+filter_relation = { "Filter" ~ "[" ~ expression ~ sp ~ output_emit ~ "]" }
 reference_list  = { (reference ~ (sp ~ "," ~ sp ~ reference)*)? }
 
 project_relation      = { "Project" ~ "[" ~ project_argument_list ~ "]" }
@@ -316,7 +332,7 @@ aggregate_measure = { function_call }
 empty = { "_" }
 
 // SortRel: Sort[($0, &AscNullsFirst), ($2, &DescNullsLast) => ...]
-sort_relation   = { "Sort" ~ "[" ~ sort_field_list ~ sp ~ "=>" ~ sp ~ reference_list ~ "]" }
+sort_relation   = { "Sort" ~ "[" ~ sort_field_list ~ sp ~ output_emit ~ "]" }
 sort_field_list = { (sort_field ~ (sp ~ "," ~ sp ~ sort_field)*)? }
 sort_field      = { "(" ~ sp ~ reference ~ sp ~ "," ~ sp ~ sort_direction ~ sp ~ ")" }
 sort_direction  = { "&AscNullsFirst" | "&AscNullsLast" | "&DescNullsFirst" | "&DescNullsLast" }
@@ -327,13 +343,13 @@ fetch_value          =  { integer | expression }
 fetch_named_arg      =  { fetch_arg_name ~ sp ~ "=" ~ sp ~ fetch_value }
 fetch_named_arg_list =  { fetch_named_arg ~ (sp ~ "," ~ sp ~ fetch_named_arg)* }
 fetch_args           = _{ fetch_named_arg_list | empty }
-fetch_relation       =  { "Fetch" ~ "[" ~ fetch_args ~ sp ~ "=>" ~ sp ~ reference_list ~ "]" }
+fetch_relation       =  { "Fetch" ~ "[" ~ fetch_args ~ sp ~ output_emit ~ "]" }
 
 // JoinRel: Join[&Inner, eq($0, $2) => $0, $1, $2, $3]
 // Note: Longer prefixes must come before shorter ones (e.g., "&LeftSemi" before "&Left")
 // so that the parser doesn't match "&Left" when it should match "&LeftSemi"
 join_type     = { "&Inner" | "&LeftSemi" | "&LeftAnti" | "&LeftSingle" | "&LeftMark" | "&Left" | "&RightSemi" | "&RightAnti" | "&RightSingle" | "&RightMark" | "&Right" | "&Outer" }
-join_relation = { "Join" ~ "[" ~ join_type ~ sp ~ "," ~ sp ~ expression ~ sp ~ "=>" ~ sp ~ reference_list ~ "]" }
+join_relation = { "Join" ~ "[" ~ join_type ~ sp ~ "," ~ sp ~ expression ~ sp ~ output_emit ~ "]" }
 
 // Extension relations for custom operators not covered by standard Substrait
 // Format: ExtensionType:ExtensionName[arguments, named_arguments => columns]

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -266,8 +266,8 @@ fn parse_read_output(
     }
 }
 
-fn parse_read_emit_suffix(suffix: Pair<Rule>) -> Option<(EmitKind, usize)> {
-    assert_eq!(suffix.as_rule(), Rule::read_emit_suffix);
+fn parse_emit_suffix(suffix: Pair<Rule>) -> Option<(EmitKind, usize)> {
+    assert_eq!(suffix.as_rule(), Rule::emit_suffix);
     let reference_list = suffix.into_inner().next()?;
     assert_eq!(reference_list.as_rule(), Rule::reference_list);
     let output_mapping = parse_output_mapping(reference_list);

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -233,33 +233,41 @@ fn parse_emit(reference_list: Pair<Rule>, direct_output_count: usize) -> (EmitKi
     (emit, output_count)
 }
 
-/// Parse an `output_emit` pair (`direct_emit` | `explicit_emit`) for relations
-/// whose direct output domain is entirely determined by their child(ren)
-/// `direct_emit` (`=>`): the mapping collapses to `Direct` when it is the identity permutation,
-/// `explicit_emit (`|>`) always produces `Emit`, even for an identity mapping
-fn parse_output_emit(output_emit: Pair<Rule>, direct_output_count: usize) -> (EmitKind, usize) {
-    assert_eq!(output_emit.as_rule(), Rule::output_emit);
-    let clause = unwrap_single_pair(output_emit);
-    match clause.as_rule() {
-        Rule::direct_emit => {
-            let reference_list = unwrap_single_pair(clause);
-            parse_emit(reference_list, direct_output_count)
+fn parse_read_output(
+    extensions: &SimpleExtensions,
+    output: Pair<Rule>,
+) -> Result<(Vec<Column>, Option<RelCommon>, usize), MessageParseError> {
+    assert_eq!(output.as_rule(), Rule::read_output);
+    let output = unwrap_single_pair(output);
+    match output.as_rule() {
+        Rule::read_implicit_output => {
+            let mut iter = RuleIter::from(output.into_inner());
+            let columns = iter.parse_next_scoped::<NamedColumnList>(extensions)?.0;
+            iter.done();
+            let output_count = columns.len();
+            Ok((columns, None, output_count))
         }
-        Rule::explicit_emit => {
-            let reference_list = unwrap_single_pair(clause);
-            let output_mapping = parse_output_mapping(reference_list);
-            let output_count = output_mapping.len();
-            (EmitKind::Emit(Emit { output_mapping }), output_count)
+        Rule::read_direct_output => {
+            let mut iter = RuleIter::from(output.into_inner());
+            let columns = iter.parse_next_scoped::<NamedColumnList>(extensions)?.0;
+            let emit_suffix = iter.pop(Rule::read_emit_suffix);
+            iter.done();
+
+            let direct_output_count = columns.len();
+            let (emit, output_count) = parse_read_emit_suffix(emit_suffix)
+                .unwrap_or((EmitKind::Direct(Direct {}), direct_output_count));
+            let common = Some(RelCommon {
+                emit_kind: Some(emit),
+                ..Default::default()
+            });
+            Ok((columns, common, output_count))
         }
-        other => unreachable!("Unexpected rule in output_emit: {other:?}"),
+        other => unreachable!("Unexpected rule in read_output: {other:?}"),
     }
 }
 
-/// Parse an `explicit_emit_suffix` pair for relations with their own direct
-/// output domain (Read, and eventually Project/Aggregate). Returns `None` if
-/// the optional `|>` clause is absent
-fn parse_explicit_emit_suffix(suffix: Pair<Rule>) -> Option<(EmitKind, usize)> {
-    assert_eq!(suffix.as_rule(), Rule::explicit_emit_suffix);
+fn parse_read_emit_suffix(suffix: Pair<Rule>) -> Option<(EmitKind, usize)> {
+    assert_eq!(suffix.as_rule(), Rule::read_emit_suffix);
     let reference_list = suffix.into_inner().next()?;
     assert_eq!(reference_list.as_rule(), Rule::reference_list);
     let output_mapping = parse_output_mapping(reference_list);
@@ -359,21 +367,10 @@ impl RelationParsePair for ReadRel {
 
         let mut iter = RuleIter::from(pair.into_inner());
         let table = iter.parse_next::<TableName>().0;
-        let columns = iter.parse_next_scoped::<NamedColumnList>(extensions)?.0;
-        let emit_suffix_pair = iter.pop(Rule::explicit_emit_suffix);
+        let output_pair = iter.pop(Rule::read_output);
         iter.done();
 
-        let direct_output_count = columns.len();
-        let (common, output_count) = match parse_explicit_emit_suffix(emit_suffix_pair) {
-            Some((emit, output_count)) => (
-                Some(RelCommon {
-                    emit_kind: Some(emit),
-                    ..Default::default()
-                }),
-                output_count,
-            ),
-            None => (None, direct_output_count),
-        };
+        let (columns, common, output_count) = parse_read_output(extensions, output_pair)?;
 
         Ok((
             ReadRel {
@@ -593,10 +590,10 @@ impl RelationParsePair for FilterRel {
         let input = expect_one_child(Self::message(), &pair, input_children)?;
         let mut iter = RuleIter::from(pair.into_inner());
         let condition = iter.parse_next_scoped::<Expression>(extensions)?;
-        let output_emit_pair = iter.pop(Rule::output_emit);
+        let references_pair = iter.pop(Rule::reference_list);
         iter.done();
 
-        let (emit, output_count) = parse_output_emit(output_emit_pair, input_field_count);
+        let (emit, output_count) = parse_emit(references_pair, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
@@ -950,13 +947,13 @@ impl RelationParsePair for SortRel {
         let input = expect_one_child(Self::message(), &pair, input_children)?;
         let mut iter = RuleIter::from(pair.into_inner());
         let sort_field_list_pair = iter.pop(Rule::sort_field_list);
-        let output_emit_pair = iter.pop(Rule::output_emit);
+        let references_pair = iter.pop(Rule::reference_list);
         let mut sorts = Vec::new();
         for sort_field_pair in sort_field_list_pair.into_inner() {
             let sort_field = SortField::parse_pair(extensions, sort_field_pair)?;
             sorts.push(sort_field);
         }
-        let (emit, output_count) = parse_output_emit(output_emit_pair, input_field_count);
+        let (emit, output_count) = parse_emit(references_pair, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
@@ -1126,8 +1123,8 @@ impl RelationParsePair for FetchRel {
             }
         };
 
-        let output_emit_pair = iter.pop(Rule::output_emit);
-        let (emit, output_count) = parse_output_emit(output_emit_pair, input_field_count);
+        let references_pair = iter.pop(Rule::reference_list);
+        let (emit, output_count) = parse_emit(references_pair, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
@@ -1225,13 +1222,13 @@ impl RelationParsePair for JoinRel {
         let mut iter = RuleIter::from(pair.into_inner());
         let join_type = iter.parse_next::<join_rel::JoinType>();
         let condition = iter.parse_next_scoped::<Expression>(extensions)?;
-        let output_emit_pair = iter.pop(Rule::output_emit);
+        let references_pair = iter.pop(Rule::reference_list);
         iter.done();
 
         // TODO: For semi/anti joins, the direct output width differs from
         // left+right — `input_field_count` would misclassify the emit as Direct.
         // Revisit when those join types are supported.
-        let (emit, output_count) = parse_output_emit(output_emit_pair, input_field_count);
+        let (emit, output_count) = parse_emit(references_pair, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
@@ -1300,7 +1297,7 @@ mod tests {
             &extensions,
             parse_exact(
                 Rule::read_relation,
-                "Read[ab.cd.ef => a:i32, b:string?, c:i64 |> $2, $0]",
+                "Read[ab.cd.ef +> a:i32, b:string?, c:i64 |> $2, $0]",
             ),
             vec![],
             0,
@@ -1324,7 +1321,7 @@ mod tests {
             &extensions,
             parse_exact(
                 Rule::read_relation,
-                "Read[ab.cd.ef => a:i32, b:string? |> $0, $1]",
+                "Read[ab.cd.ef +> a:i32, b:string? |> $0, $1]",
             ),
             vec![],
             0,
@@ -1335,6 +1332,36 @@ mod tests {
         assert!(
             matches!(emit_kind, EmitKind::Emit(_)),
             "Expected explicit Emit to survive even with an identity mapping, got {emit_kind:?}"
+        );
+    }
+
+    #[test]
+    fn test_parse_read_relation_explicit_direct() {
+        let extensions = SimpleExtensions::default();
+        let (read, output_count) = ReadRel::parse_pair_with_context(
+            &extensions,
+            parse_exact(Rule::read_relation, "Read[ab.cd.ef +> a:i32, b:string?]"),
+            vec![],
+            0,
+        )
+        .unwrap();
+        assert_eq!(output_count, 2);
+        let emit_kind = read.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
+        assert!(
+            matches!(emit_kind, EmitKind::Direct(_)),
+            "Expected +> without |> to produce Direct, got {emit_kind:?}"
+        );
+    }
+
+    #[test]
+    fn test_parse_read_relation_rejects_arrow_with_emit() {
+        let parsed = ExpressionParser::parse(
+            Rule::read_relation,
+            "Read[ab.cd.ef => a:i32, b:string? |> $0, $1]",
+        );
+        assert!(
+            parsed.is_err(),
+            "Read cannot combine legacy => output with explicit |>"
         );
     }
 
@@ -1371,44 +1398,6 @@ mod tests {
             matches!(emit_kind, EmitKind::Direct(_)),
             "Expected Direct for identity emit, got {emit_kind:?}"
         );
-    }
-
-    #[test]
-    fn test_parse_filter_relation_explicit_emit_not_collapsed() {
-        // `|>` with an identity mapping must stay Emit, unlike the `=>` form
-        // above which collapses identity mappings to Direct.
-        let extensions = SimpleExtensions::default();
-        let filter = FilterRel::parse_pair_with_context(
-            &extensions,
-            parse_exact(Rule::filter_relation, "Filter[$1 |> $0, $1, $2]"),
-            vec![example_read_relation().into_rel(None)],
-            3,
-        )
-        .unwrap()
-        .0;
-        let emit_kind = filter.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
-        match emit_kind {
-            EmitKind::Emit(emit) => assert_eq!(emit.output_mapping, vec![0, 1, 2]),
-            other => panic!("Expected EmitKind::Emit, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_parse_filter_relation_explicit_emit_reorders() {
-        let extensions = SimpleExtensions::default();
-        let (filter, output_count) = FilterRel::parse_pair_with_context(
-            &extensions,
-            parse_exact(Rule::filter_relation, "Filter[$1 |> $2, $0]"),
-            vec![example_read_relation().into_rel(None)],
-            3,
-        )
-        .unwrap();
-        assert_eq!(output_count, 2);
-        let emit_kind = filter.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
-        match emit_kind {
-            EmitKind::Emit(emit) => assert_eq!(emit.output_mapping, vec![2, 0]),
-            other => panic!("Expected EmitKind::Emit, got {other:?}"),
-        }
     }
 
     #[test]
@@ -1649,49 +1638,6 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_sort_relation_explicit_emit() {
-        let extensions = SimpleExtensions::default();
-        let (sort, output_count) = SortRel::parse_pair_with_context(
-            &extensions,
-            parse_exact(Rule::sort_relation, "Sort[($0, &AscNullsFirst) |> $1, $0]"),
-            vec![example_read_relation().into_rel(None)],
-            3,
-        )
-        .unwrap();
-        assert_eq!(sort.sorts.len(), 1);
-        assert_eq!(output_count, 2);
-        let emit_kind = sort.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
-        match emit_kind {
-            EmitKind::Emit(emit) => assert_eq!(emit.output_mapping, vec![1, 0]),
-            other => panic!("Expected EmitKind::Emit, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_fetch_relation_explicit_emit_not_collapsed() {
-        let extensions = SimpleExtensions::default();
-        let fetch_rel = FetchRel::parse_pair_with_context(
-            &extensions,
-            parse_exact(Rule::fetch_relation, "Fetch[limit=10 |> $0, $1, $2]"),
-            vec![example_read_relation().into_rel(None)],
-            3,
-        )
-        .unwrap()
-        .0;
-        let emit_kind = fetch_rel
-            .common
-            .as_ref()
-            .unwrap()
-            .emit_kind
-            .as_ref()
-            .unwrap();
-        assert!(
-            matches!(emit_kind, EmitKind::Emit(_)),
-            "Expected explicit Emit to survive even with an identity mapping, got {emit_kind:?}"
-        );
-    }
-
-    #[test]
     fn test_fetch_relation_positive_values() {
         let extensions = SimpleExtensions::default();
 
@@ -1849,35 +1795,6 @@ mod tests {
         };
         // Output mapping should be [0, 1, 2]
         assert_eq!(emit, &[0, 1, 2]);
-    }
-
-    #[test]
-    fn test_parse_join_relation_explicit_emit_not_collapsed() {
-        let extensions = TestContext::new()
-            .with_urn(1, "https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml")
-            .with_function(1, 10, "eq")
-            .extensions;
-
-        let left_rel = example_read_relation().into_rel(None);
-        let right_rel = example_read_relation().into_rel(None);
-
-        let join = JoinRel::parse_pair_with_context(
-            &extensions,
-            parse_exact(
-                Rule::join_relation,
-                "Join[&Inner, eq($0, $3):boolean |> $0, $1, $2, $3, $4, $5]",
-            ),
-            vec![left_rel, right_rel],
-            6,
-        )
-        .unwrap()
-        .0;
-
-        let emit_kind = join.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
-        assert!(
-            matches!(emit_kind, EmitKind::Emit(_)),
-            "Expected explicit Emit to survive even with an identity mapping, got {emit_kind:?}"
-        );
     }
 
     #[test]

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -233,6 +233,40 @@ fn parse_emit(reference_list: Pair<Rule>, direct_output_count: usize) -> (EmitKi
     (emit, output_count)
 }
 
+/// Parse an `output_emit` pair (`direct_emit` | `explicit_emit`) for relations
+/// whose direct output domain is entirely determined by their child(ren)
+/// `direct_emit` (`=>`): the mapping collapses to `Direct` when it is the identity permutation, 
+/// `explicit_emit (`|>`) always produces `Emit`, even for an identity mapping
+fn parse_output_emit(output_emit: Pair<Rule>, direct_output_count: usize) -> (EmitKind, usize) {
+    assert_eq!(output_emit.as_rule(), Rule::output_emit);
+    let clause = unwrap_single_pair(output_emit);
+    match clause.as_rule() {
+        Rule::direct_emit => {
+            let reference_list = unwrap_single_pair(clause);
+            parse_emit(reference_list, direct_output_count)
+        }
+        Rule::explicit_emit => {
+            let reference_list = unwrap_single_pair(clause);
+            let output_mapping = parse_output_mapping(reference_list);
+            let output_count = output_mapping.len();
+            (EmitKind::Emit(Emit { output_mapping }), output_count)
+        }
+        other => unreachable!("Unexpected rule in output_emit: {other:?}"),
+    }
+}
+
+/// Parse an `explicit_emit_suffix` pair for relations with their own direct
+/// output domain (Read, and eventually Project/Aggregate). Returns `None` if
+/// the optional `|>` clause is absent
+fn parse_explicit_emit_suffix(suffix: Pair<Rule>) -> Option<(EmitKind, usize)> {
+    assert_eq!(suffix.as_rule(), Rule::explicit_emit_suffix);
+    let reference_list = suffix.into_inner().next()?;
+    assert_eq!(reference_list.as_rule(), Rule::reference_list);
+    let output_mapping = parse_output_mapping(reference_list);
+    let output_count = output_mapping.len();
+    Some((EmitKind::Emit(Emit { output_mapping }), output_count))
+}
+
 /// Extracts named arguments from pest pairs with duplicate detection and completeness checking.
 ///
 /// Usage: `extractor.pop("limit", Rule::fetch_value).0.pop("offset", Rule::fetch_value).0.done()`
@@ -326,9 +360,21 @@ impl RelationParsePair for ReadRel {
         let mut iter = RuleIter::from(pair.into_inner());
         let table = iter.parse_next::<TableName>().0;
         let columns = iter.parse_next_scoped::<NamedColumnList>(extensions)?.0;
+        let emit_suffix_pair = iter.pop(Rule::explicit_emit_suffix);
         iter.done();
 
-        let output_count = columns.len();
+        let direct_output_count = columns.len();
+        let (common, output_count) = match parse_explicit_emit_suffix(emit_suffix_pair) {
+            Some((emit, output_count)) => (
+                Some(RelCommon {
+                    emit_kind: Some(emit),
+                    ..Default::default()
+                }),
+                output_count,
+            ),
+            None => (None, direct_output_count),
+        };
+
         Ok((
             ReadRel {
                 base_schema: Some(build_named_struct(columns)),
@@ -336,6 +382,7 @@ impl RelationParsePair for ReadRel {
                     names: table,
                     advanced_extension: None,
                 })),
+                common,
                 ..Default::default()
             },
             output_count,
@@ -546,11 +593,10 @@ impl RelationParsePair for FilterRel {
         let input = expect_one_child(Self::message(), &pair, input_children)?;
         let mut iter = RuleIter::from(pair.into_inner());
         let condition = iter.parse_next_scoped::<Expression>(extensions)?;
-        // references (which become the emit)
-        let references_pair = iter.pop(Rule::reference_list);
+        let output_emit_pair = iter.pop(Rule::output_emit);
         iter.done();
 
-        let (emit, output_count) = parse_emit(references_pair, input_field_count);
+        let (emit, output_count) = parse_output_emit(output_emit_pair, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
@@ -904,13 +950,13 @@ impl RelationParsePair for SortRel {
         let input = expect_one_child(Self::message(), &pair, input_children)?;
         let mut iter = RuleIter::from(pair.into_inner());
         let sort_field_list_pair = iter.pop(Rule::sort_field_list);
-        let reference_list_pair = iter.pop(Rule::reference_list);
+        let output_emit_pair = iter.pop(Rule::output_emit);
         let mut sorts = Vec::new();
         for sort_field_pair in sort_field_list_pair.into_inner() {
             let sort_field = SortField::parse_pair(extensions, sort_field_pair)?;
             sorts.push(sort_field);
         }
-        let (emit, output_count) = parse_emit(reference_list_pair, input_field_count);
+        let (emit, output_count) = parse_output_emit(output_emit_pair, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
@@ -1080,8 +1126,8 @@ impl RelationParsePair for FetchRel {
             }
         };
 
-        let reference_list_pair = iter.pop(Rule::reference_list);
-        let (emit, output_count) = parse_emit(reference_list_pair, input_field_count);
+        let output_emit_pair = iter.pop(Rule::output_emit);
+        let (emit, output_count) = parse_output_emit(output_emit_pair, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
@@ -1179,13 +1225,13 @@ impl RelationParsePair for JoinRel {
         let mut iter = RuleIter::from(pair.into_inner());
         let join_type = iter.parse_next::<join_rel::JoinType>();
         let condition = iter.parse_next_scoped::<Expression>(extensions)?;
-        let reference_list_pair = iter.pop(Rule::reference_list);
+        let output_emit_pair = iter.pop(Rule::output_emit);
         iter.done();
 
         // TODO: For semi/anti joins, the direct output width differs from
         // left+right — `input_field_count` would misclassify the emit as Direct.
         // Revisit when those join types are supported.
-        let (emit, output_count) = parse_emit(reference_list_pair, input_field_count);
+        let (emit, output_count) = parse_output_emit(output_emit_pair, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
@@ -1244,6 +1290,52 @@ mod tests {
             .unwrap()
             .types;
         assert_eq!(columns.len(), 2);
+        assert!(read.common.is_none());
+    }
+
+    #[test]
+    fn test_parse_read_relation_explicit_emit() {
+        let extensions = SimpleExtensions::default();
+        let read = ReadRel::parse_pair_with_context(
+            &extensions,
+            parse_exact(
+                Rule::read_relation,
+                "Read[ab.cd.ef => a:i32, b:string?, c:i64 |> $2, $0]",
+            ),
+            vec![],
+            0,
+        )
+        .unwrap();
+        let (read, output_count) = read;
+        assert_eq!(output_count, 2);
+        let emit_kind = read.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
+        match emit_kind {
+            EmitKind::Emit(emit) => assert_eq!(emit.output_mapping, vec![2, 0]),
+            other => panic!("Expected EmitKind::Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_read_relation_explicit_identity_emit_not_collapsed() {
+        // An explicit `|>` with an identity mapping must stay `Emit`, not
+        // collapse to `Direct` - that's the whole point of `|>`.
+        let extensions = SimpleExtensions::default();
+        let read = ReadRel::parse_pair_with_context(
+            &extensions,
+            parse_exact(
+                Rule::read_relation,
+                "Read[ab.cd.ef => a:i32, b:string? |> $0, $1]",
+            ),
+            vec![],
+            0,
+        )
+        .unwrap()
+        .0;
+        let emit_kind = read.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
+        assert!(
+            matches!(emit_kind, EmitKind::Emit(_)),
+            "Expected explicit Emit to survive even with an identity mapping, got {emit_kind:?}"
+        );
     }
 
     /// Produces a ReadRel with 3 columns: a:i32, b:string?, c:i64
@@ -1279,6 +1371,44 @@ mod tests {
             matches!(emit_kind, EmitKind::Direct(_)),
             "Expected Direct for identity emit, got {emit_kind:?}"
         );
+    }
+
+    #[test]
+    fn test_parse_filter_relation_explicit_emit_not_collapsed() {
+        // `|>` with an identity mapping must stay Emit, unlike the `=>` form
+        // above which collapses identity mappings to Direct.
+        let extensions = SimpleExtensions::default();
+        let filter = FilterRel::parse_pair_with_context(
+            &extensions,
+            parse_exact(Rule::filter_relation, "Filter[$1 |> $0, $1, $2]"),
+            vec![example_read_relation().into_rel(None)],
+            3,
+        )
+        .unwrap()
+        .0;
+        let emit_kind = filter.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
+        match emit_kind {
+            EmitKind::Emit(emit) => assert_eq!(emit.output_mapping, vec![0, 1, 2]),
+            other => panic!("Expected EmitKind::Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_filter_relation_explicit_emit_reorders() {
+        let extensions = SimpleExtensions::default();
+        let (filter, output_count) = FilterRel::parse_pair_with_context(
+            &extensions,
+            parse_exact(Rule::filter_relation, "Filter[$1 |> $2, $0]"),
+            vec![example_read_relation().into_rel(None)],
+            3,
+        )
+        .unwrap();
+        assert_eq!(output_count, 2);
+        let emit_kind = filter.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
+        match emit_kind {
+            EmitKind::Emit(emit) => assert_eq!(emit.output_mapping, vec![2, 0]),
+            other => panic!("Expected EmitKind::Emit, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1519,6 +1649,49 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_sort_relation_explicit_emit() {
+        let extensions = SimpleExtensions::default();
+        let (sort, output_count) = SortRel::parse_pair_with_context(
+            &extensions,
+            parse_exact(Rule::sort_relation, "Sort[($0, &AscNullsFirst) |> $1, $0]"),
+            vec![example_read_relation().into_rel(None)],
+            3,
+        )
+        .unwrap();
+        assert_eq!(sort.sorts.len(), 1);
+        assert_eq!(output_count, 2);
+        let emit_kind = sort.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
+        match emit_kind {
+            EmitKind::Emit(emit) => assert_eq!(emit.output_mapping, vec![1, 0]),
+            other => panic!("Expected EmitKind::Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_fetch_relation_explicit_emit_not_collapsed() {
+        let extensions = SimpleExtensions::default();
+        let fetch_rel = FetchRel::parse_pair_with_context(
+            &extensions,
+            parse_exact(Rule::fetch_relation, "Fetch[limit=10 |> $0, $1, $2]"),
+            vec![example_read_relation().into_rel(None)],
+            3,
+        )
+        .unwrap()
+        .0;
+        let emit_kind = fetch_rel
+            .common
+            .as_ref()
+            .unwrap()
+            .emit_kind
+            .as_ref()
+            .unwrap();
+        assert!(
+            matches!(emit_kind, EmitKind::Emit(_)),
+            "Expected explicit Emit to survive even with an identity mapping, got {emit_kind:?}"
+        );
+    }
+
+    #[test]
     fn test_fetch_relation_positive_values() {
         let extensions = SimpleExtensions::default();
 
@@ -1676,6 +1849,35 @@ mod tests {
         };
         // Output mapping should be [0, 1, 2]
         assert_eq!(emit, &[0, 1, 2]);
+    }
+
+    #[test]
+    fn test_parse_join_relation_explicit_emit_not_collapsed() {
+        let extensions = TestContext::new()
+            .with_urn(1, "https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml")
+            .with_function(1, 10, "eq")
+            .extensions;
+
+        let left_rel = example_read_relation().into_rel(None);
+        let right_rel = example_read_relation().into_rel(None);
+
+        let join = JoinRel::parse_pair_with_context(
+            &extensions,
+            parse_exact(
+                Rule::join_relation,
+                "Join[&Inner, eq($0, $3):boolean |> $0, $1, $2, $3, $4, $5]",
+            ),
+            vec![left_rel, right_rel],
+            6,
+        )
+        .unwrap()
+        .0;
+
+        let emit_kind = join.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
+        assert!(
+            matches!(emit_kind, EmitKind::Emit(_)),
+            "Expected explicit Emit to survive even with an identity mapping, got {emit_kind:?}"
+        );
     }
 
     #[test]

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -233,28 +233,28 @@ fn parse_emit(reference_list: Pair<Rule>, direct_output_count: usize) -> (EmitKi
     (emit, output_count)
 }
 
-fn parse_read_output(
+fn parse_output(
     extensions: &SimpleExtensions,
     output: Pair<Rule>,
 ) -> Result<(Vec<Column>, Option<RelCommon>, usize), MessageParseError> {
-    assert_eq!(output.as_rule(), Rule::read_output);
+    assert_eq!(output.as_rule(), Rule::output);
     let output = unwrap_single_pair(output);
     match output.as_rule() {
-        Rule::read_implicit_output => {
+        Rule::implicit_output => {
             let mut iter = RuleIter::from(output.into_inner());
             let columns = iter.parse_next_scoped::<NamedColumnList>(extensions)?.0;
             iter.done();
             let output_count = columns.len();
             Ok((columns, None, output_count))
         }
-        Rule::read_direct_output => {
+        Rule::direct_output => {
             let mut iter = RuleIter::from(output.into_inner());
             let columns = iter.parse_next_scoped::<NamedColumnList>(extensions)?.0;
-            let emit_suffix = iter.pop(Rule::read_emit_suffix);
+            let emit_suffix = iter.pop(Rule::emit_suffix);
             iter.done();
 
             let direct_output_count = columns.len();
-            let (emit, output_count) = parse_read_emit_suffix(emit_suffix)
+            let (emit, output_count) = parse_emit_suffix(emit_suffix)
                 .unwrap_or((EmitKind::Direct(Direct {}), direct_output_count));
             let common = Some(RelCommon {
                 emit_kind: Some(emit),
@@ -262,7 +262,7 @@ fn parse_read_output(
             });
             Ok((columns, common, output_count))
         }
-        other => unreachable!("Unexpected rule in read_output: {other:?}"),
+        other => unreachable!("Unexpected rule in output: {other:?}"),
     }
 }
 
@@ -367,10 +367,10 @@ impl RelationParsePair for ReadRel {
 
         let mut iter = RuleIter::from(pair.into_inner());
         let table = iter.parse_next::<TableName>().0;
-        let output_pair = iter.pop(Rule::read_output);
+        let output_pair = iter.pop(Rule::output);
         iter.done();
 
-        let (columns, common, output_count) = parse_read_output(extensions, output_pair)?;
+        let (columns, common, output_count) = parse_output(extensions, output_pair)?;
 
         Ok((
             ReadRel {

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -235,7 +235,7 @@ fn parse_emit(reference_list: Pair<Rule>, direct_output_count: usize) -> (EmitKi
 
 /// Parse an `output_emit` pair (`direct_emit` | `explicit_emit`) for relations
 /// whose direct output domain is entirely determined by their child(ren)
-/// `direct_emit` (`=>`): the mapping collapses to `Direct` when it is the identity permutation, 
+/// `direct_emit` (`=>`): the mapping collapses to `Direct` when it is the identity permutation,
 /// `explicit_emit (`|>`) always produces `Emit`, even for an identity mapping
 fn parse_output_emit(output_emit: Pair<Rule>, direct_output_count: usize) -> (EmitKind, usize) {
     assert_eq!(output_emit.as_rule(), Rule::output_emit);

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -175,35 +175,76 @@ fn schema_to_values<'a>(schema: &'a NamedStruct) -> Vec<Value<'a>> {
     values
 }
 
+/// How a relation header renders its output.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum OutputSyntax {
+    /// Output columns are rendered as final visible output: `=> output_columns`.
+    #[default]
+    Implicit,
+    /// Output columns are rendered as the direct output domain: `+> columns`,
+    /// with `|> order` appended when an explicit emit mapping is present.
+    Explicit,
+}
+
 struct Emitted<'a> {
-    pub values: &'a [Value<'a>],
-    pub emit: Option<&'a EmitKind>,
+    values: &'a [Value<'a>],
+    emit: Option<&'a EmitKind>,
+    output_syntax: Option<OutputSyntax>,
 }
 
 impl<'a> Emitted<'a> {
-    pub fn new(values: &'a [Value<'a>], emit: Option<&'a EmitKind>) -> Self {
-        Self { values, emit }
+    pub fn columns(values: &'a [Value<'a>], emit: Option<&'a EmitKind>) -> Self {
+        Self {
+            values,
+            emit,
+            output_syntax: None,
+        }
     }
 
-    pub fn write_direct<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
+    pub fn output_clause(
+        values: &'a [Value<'a>],
+        emit: Option<&'a EmitKind>,
+        output_syntax: OutputSyntax,
+    ) -> Self {
+        Self {
+            values,
+            emit,
+            output_syntax: Some(output_syntax),
+        }
+    }
+
+    fn write_output_clause<S: Scope, W: fmt::Write>(
+        &self,
+        ctx: &S,
+        w: &mut W,
+        output_syntax: OutputSyntax,
+    ) -> fmt::Result {
+        match output_syntax {
+            OutputSyntax::Implicit => {
+                write!(w, "=> ")?;
+                self.write_implicit_columns(ctx, w)
+            }
+            OutputSyntax::Explicit => {
+                write!(w, "+> ")?;
+                self.write_direct_columns(ctx, w)?;
+                self.write_emit_suffix(ctx, w)
+            }
+        }
+    }
+
+    fn write_direct_columns<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
         write!(w, "{}", ctx.separated(self.values.iter(), ", "))
     }
-}
 
-impl<'a> Textify for Emitted<'a> {
-    fn name() -> &'static str {
-        "Emitted"
-    }
-
-    fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
+    fn write_implicit_columns<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
         if ctx.options().show_emit {
-            return self.write_direct(ctx, w);
+            return self.write_direct_columns(ctx, w);
         }
 
         let indices = match &self.emit {
             Some(EmitKind::Emit(e)) => &e.output_mapping,
-            Some(EmitKind::Direct(_)) => return self.write_direct(ctx, w),
-            None => return self.write_direct(ctx, w),
+            Some(EmitKind::Direct(_)) => return self.write_direct_columns(ctx, w),
+            None => return self.write_direct_columns(ctx, w),
         };
 
         for (i, &index) in indices.iter().enumerate() {
@@ -226,6 +267,32 @@ impl<'a> Textify for Emitted<'a> {
 
         Ok(())
     }
+
+    fn write_emit_suffix<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
+        let Some(EmitKind::Emit(emit)) = self.emit else {
+            return Ok(());
+        };
+        let mapping = emit
+            .output_mapping
+            .iter()
+            .copied()
+            .map(Value::Reference)
+            .collect::<Vec<_>>();
+        write!(w, " |> {}", ctx.separated(mapping.iter(), ", "))
+    }
+}
+
+impl<'a> Textify for Emitted<'a> {
+    fn name() -> &'static str {
+        "Emitted"
+    }
+
+    fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
+        match self.output_syntax {
+            Some(output_syntax) => self.write_output_clause(ctx, w, output_syntax),
+            None => self.write_implicit_columns(ctx, w),
+        }
+    }
 }
 
 /// How an argument list renders inside a relation's `[...]`.
@@ -234,9 +301,6 @@ pub enum ArgsLayout {
     /// `arg, arg, arg` on a single line.
     #[default]
     Inline,
-    /// `arg +> col, col`, used by named `Read` when the direct output domain
-    /// must be shown separately from an explicit emit mapping.
-    DirectDomain,
     /// One `- arg` per line, used for `Read:Virtual` rows. See
     /// [`Relation::write_header`] for the exact layout.
     Rows,
@@ -261,16 +325,6 @@ impl<'a> Arguments<'a> {
             positional,
             named,
             layout: ArgsLayout::Inline,
-        }
-    }
-
-    /// An explicit direct-domain argument list (`arg +> col, col`), currently
-    /// used by named `Read` when `RelCommon.emit_kind` is present.
-    pub fn direct_domain(positional: Vec<Value<'a>>, named: Vec<NamedArg<'a>>) -> Self {
-        Arguments {
-            positional,
-            named,
-            layout: ArgsLayout::DirectDomain,
         }
     }
 
@@ -319,6 +373,9 @@ pub struct Relation<'a> {
     pub columns: Vec<Value<'a>>,
     /// The emit kind, if any. If none, use the columns directly.
     pub emit: Option<&'a EmitKind>,
+    /// Whether output columns are rendered as visible output or as a direct
+    /// output domain plus optional explicit emit mapping.
+    output_syntax: OutputSyntax,
     /// `+`-prefixed addendum lines to emit between this relation's header and
     /// children.  This owns the canonical ordering for `+ Ext`, `+ Enh`, and
     /// `+ Opt` lines rather than making the generic relation shape grow one
@@ -362,15 +419,13 @@ impl Relation<'_> {
         let name = &self.name;
         match &self.arguments {
             None => {
-                let cols = Emitted::new(&self.columns, self.emit);
+                let cols = Emitted::columns(&self.columns, self.emit);
                 let cols = ctx.display(&cols);
                 write!(w, "{indent}{name}[{cols}]")
             }
             Some(args) if args.layout == ArgsLayout::Rows => {
                 // One `- row` per line, one indent level deeper, with a trailing
-                // comma on every row but the last, then `- => cols]`.
-                let cols = Emitted::new(&self.columns, self.emit);
-                let cols = ctx.display(&cols);
+                // comma on every row but the last, then `- <output> cols]`.
                 let child = ctx.push_indent();
                 let child_indent = child.indent();
                 writeln!(w, "{indent}{name}[")?;
@@ -380,35 +435,17 @@ impl Relation<'_> {
                     let comma = if i == last { "" } else { "," };
                     writeln!(w, "{child_indent}- {row}{comma}")?;
                 }
-                write!(w, "{child_indent}- => {cols}]")
-            }
-            Some(args) if args.layout == ArgsLayout::DirectDomain => {
-                let args = ctx.display(args);
-                let cols = ctx.separated(self.columns.iter(), ", ");
-                write!(w, "{indent}{name}[{args} +> {cols}")?;
-                self.write_emit_suffix(ctx, w)?;
-                write!(w, "]")
+                let output = Emitted::output_clause(&self.columns, self.emit, self.output_syntax);
+                let output = ctx.display(&output);
+                write!(w, "{child_indent}- {output}]")
             }
             Some(args) => {
                 let args = ctx.display(args);
-                let cols = Emitted::new(&self.columns, self.emit);
-                let cols = ctx.display(&cols);
-                write!(w, "{indent}{name}[{args} => {cols}]")
+                let output = Emitted::output_clause(&self.columns, self.emit, self.output_syntax);
+                let output = ctx.display(&output);
+                write!(w, "{indent}{name}[{args} {output}]")
             }
         }
-    }
-
-    fn write_emit_suffix<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
-        let Some(EmitKind::Emit(emit)) = self.emit else {
-            return Ok(());
-        };
-        let mapping = emit
-            .output_mapping
-            .iter()
-            .copied()
-            .map(Value::Reference)
-            .collect::<Vec<_>>();
-        write!(w, " |> {}", ctx.separated(mapping.iter(), ", "))
     }
 
     /// Write each child relation at one indent level deeper than `ctx`.
@@ -441,16 +478,17 @@ impl<'a> Relation<'a> {
         match &rel.read_type {
             Some(ReadType::NamedTable(table)) => {
                 let table_name = Value::TableName(table.names.iter().map(|n| Name(n)).collect());
-                let arguments = if emit.is_some() {
-                    Arguments::direct_domain(vec![table_name], vec![])
+                let output_syntax = if emit.is_some() {
+                    OutputSyntax::Explicit
                 } else {
-                    Arguments::inline(vec![table_name], vec![])
+                    OutputSyntax::Implicit
                 };
                 Relation {
                     name: Cow::Borrowed("Read"),
-                    arguments: Some(arguments),
+                    arguments: Some(Arguments::inline(vec![table_name], vec![])),
                     columns,
                     emit,
+                    output_syntax,
                     addenda: AddendumLines::from_advanced_extension(
                         ctx,
                         rel.advanced_extension.as_ref(),
@@ -482,6 +520,7 @@ impl<'a> Relation<'a> {
                     arguments: Some(arguments),
                     columns,
                     emit,
+                    output_syntax: OutputSyntax::Implicit,
                     addenda: AddendumLines::from_advanced_extension(
                         ctx,
                         rel.advanced_extension.as_ref(),
@@ -500,6 +539,7 @@ impl<'a> Relation<'a> {
                     arguments: None,
                     columns,
                     emit,
+                    output_syntax: OutputSyntax::Implicit,
                     addenda: AddendumLines::extension_table(
                         ctx,
                         decoded,
@@ -519,6 +559,7 @@ impl<'a> Relation<'a> {
                     arguments: Some(Arguments::inline(vec![Value::Missing(err)], vec![])),
                     columns,
                     emit,
+                    output_syntax: OutputSyntax::Implicit,
                     addenda: AddendumLines::from_advanced_extension(
                         ctx,
                         rel.advanced_extension.as_ref(),
@@ -591,6 +632,7 @@ impl<'a> Relation<'a> {
             arguments,
             columns,
             emit,
+            output_syntax: OutputSyntax::Implicit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -611,6 +653,7 @@ impl<'a> Relation<'a> {
             arguments: None,
             columns,
             emit: get_emit(rel.common.as_ref()),
+            output_syntax: OutputSyntax::Implicit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -640,6 +683,7 @@ impl<'a> Relation<'a> {
                     arguments: None,
                     columns: vec![],
                     emit: None,
+                    output_syntax: OutputSyntax::Implicit,
                     addenda: AddendumLines::none(),
                     children: vec![],
                 }
@@ -707,6 +751,7 @@ impl<'a> Relation<'a> {
                     arguments: Some(Arguments::inline(positional, named)),
                     columns,
                     emit: None,
+                    output_syntax: OutputSyntax::Implicit,
                     // Extension relations use `detail` rather than
                     // `advanced_extension`; the field does not exist on these
                     // proto types.
@@ -725,6 +770,7 @@ impl<'a> Relation<'a> {
                         error.to_string(),
                     ))],
                     emit: None,
+                    output_syntax: OutputSyntax::Implicit,
                     addenda: AddendumLines::none(),
                     children,
                 }
@@ -807,6 +853,7 @@ impl<'a> Relation<'a> {
             arguments,
             columns: all_outputs,
             emit,
+            output_syntax: OutputSyntax::Implicit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -912,6 +959,7 @@ impl<'a> Relation<'a> {
             arguments,
             columns: col_values,
             emit,
+            output_syntax: OutputSyntax::Implicit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -964,6 +1012,7 @@ impl<'a> Relation<'a> {
             arguments: Some(Arguments::inline(vec![], named_args)),
             columns,
             emit,
+            output_syntax: OutputSyntax::Implicit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -1072,6 +1121,7 @@ impl<'a> Relation<'a> {
             arguments,
             columns,
             emit,
+            output_syntax: OutputSyntax::Implicit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -239,6 +239,13 @@ pub enum ArgsLayout {
     Rows,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum OutputSyntax {
+    #[default]
+    Implicit,
+    DirectDomain,
+}
+
 #[derive(Debug, Clone)]
 pub struct Arguments<'a> {
     /// Positional arguments (e.g., a filter condition, group-bys, etc.)
@@ -306,6 +313,7 @@ pub struct Relation<'a> {
     pub columns: Vec<Value<'a>>,
     /// The emit kind, if any. If none, use the columns directly.
     pub emit: Option<&'a EmitKind>,
+    output_syntax: OutputSyntax,
     /// `+`-prefixed addendum lines to emit between this relation's header and
     /// children.  This owns the canonical ordering for `+ Ext`, `+ Enh`, and
     /// `+ Opt` lines rather than making the generic relation shape grow one
@@ -345,17 +353,19 @@ impl Relation<'_> {
     /// Does not write a trailing newline; callers are responsible for any
     /// newline that follows (either from an addendum or from the next child).
     pub fn write_header<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
-        let cols = Emitted::new(&self.columns, self.emit);
         let indent = ctx.indent();
         let name = &self.name;
-        let cols = ctx.display(&cols);
         match &self.arguments {
             None => {
+                let cols = Emitted::new(&self.columns, self.emit);
+                let cols = ctx.display(&cols);
                 write!(w, "{indent}{name}[{cols}]")
             }
             Some(args) if args.layout == ArgsLayout::Rows => {
                 // One `- row` per line, one indent level deeper, with a trailing
                 // comma on every row but the last, then `- => cols]`.
+                let cols = Emitted::new(&self.columns, self.emit);
+                let cols = ctx.display(&cols);
                 let child = ctx.push_indent();
                 let child_indent = child.indent();
                 writeln!(w, "{indent}{name}[")?;
@@ -367,11 +377,33 @@ impl Relation<'_> {
                 }
                 write!(w, "{child_indent}- => {cols}]")
             }
+            Some(args) if self.output_syntax == OutputSyntax::DirectDomain => {
+                let args = ctx.display(args);
+                let cols = ctx.separated(self.columns.iter(), ", ");
+                write!(w, "{indent}{name}[{args} +> {cols}")?;
+                self.write_emit_suffix(ctx, w)?;
+                write!(w, "]")
+            }
             Some(args) => {
                 let args = ctx.display(args);
+                let cols = Emitted::new(&self.columns, self.emit);
+                let cols = ctx.display(&cols);
                 write!(w, "{indent}{name}[{args} => {cols}]")
             }
         }
+    }
+
+    fn write_emit_suffix<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
+        let Some(EmitKind::Emit(emit)) = self.emit else {
+            return Ok(());
+        };
+        let mapping = emit
+            .output_mapping
+            .iter()
+            .copied()
+            .map(Value::Reference)
+            .collect::<Vec<_>>();
+        write!(w, " |> {}", ctx.separated(mapping.iter(), ", "))
     }
 
     /// Write each child relation at one indent level deeper than `ctx`.
@@ -409,6 +441,11 @@ impl<'a> Relation<'a> {
                     arguments: Some(Arguments::inline(vec![table_name], vec![])),
                     columns,
                     emit,
+                    output_syntax: if emit.is_some() {
+                        OutputSyntax::DirectDomain
+                    } else {
+                        OutputSyntax::Implicit
+                    },
                     addenda: AddendumLines::from_advanced_extension(
                         ctx,
                         rel.advanced_extension.as_ref(),
@@ -440,6 +477,7 @@ impl<'a> Relation<'a> {
                     arguments: Some(arguments),
                     columns,
                     emit,
+                    output_syntax: OutputSyntax::Implicit,
                     addenda: AddendumLines::from_advanced_extension(
                         ctx,
                         rel.advanced_extension.as_ref(),
@@ -458,6 +496,7 @@ impl<'a> Relation<'a> {
                     arguments: None,
                     columns,
                     emit,
+                    output_syntax: OutputSyntax::Implicit,
                     addenda: AddendumLines::extension_table(
                         ctx,
                         decoded,
@@ -477,6 +516,7 @@ impl<'a> Relation<'a> {
                     arguments: Some(Arguments::inline(vec![Value::Missing(err)], vec![])),
                     columns,
                     emit,
+                    output_syntax: OutputSyntax::Implicit,
                     addenda: AddendumLines::from_advanced_extension(
                         ctx,
                         rel.advanced_extension.as_ref(),
@@ -549,6 +589,7 @@ impl<'a> Relation<'a> {
             arguments,
             columns,
             emit,
+            output_syntax: OutputSyntax::Implicit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -569,6 +610,7 @@ impl<'a> Relation<'a> {
             arguments: None,
             columns,
             emit: get_emit(rel.common.as_ref()),
+            output_syntax: OutputSyntax::Implicit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -598,6 +640,7 @@ impl<'a> Relation<'a> {
                     arguments: None,
                     columns: vec![],
                     emit: None,
+                    output_syntax: OutputSyntax::Implicit,
                     addenda: AddendumLines::none(),
                     children: vec![],
                 }
@@ -665,6 +708,7 @@ impl<'a> Relation<'a> {
                     arguments: Some(Arguments::inline(positional, named)),
                     columns,
                     emit: None,
+                    output_syntax: OutputSyntax::Implicit,
                     // Extension relations use `detail` rather than
                     // `advanced_extension`; the field does not exist on these
                     // proto types.
@@ -683,6 +727,7 @@ impl<'a> Relation<'a> {
                         error.to_string(),
                     ))],
                     emit: None,
+                    output_syntax: OutputSyntax::Implicit,
                     addenda: AddendumLines::none(),
                     children,
                 }
@@ -765,6 +810,7 @@ impl<'a> Relation<'a> {
             arguments,
             columns: all_outputs,
             emit,
+            output_syntax: OutputSyntax::Implicit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -870,6 +916,7 @@ impl<'a> Relation<'a> {
             arguments,
             columns: col_values,
             emit,
+            output_syntax: OutputSyntax::Implicit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -922,6 +969,7 @@ impl<'a> Relation<'a> {
             arguments: Some(Arguments::inline(vec![], named_args)),
             columns,
             emit,
+            output_syntax: OutputSyntax::Implicit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -1030,6 +1078,7 @@ impl<'a> Relation<'a> {
             arguments,
             columns,
             emit,
+            output_syntax: OutputSyntax::Implicit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -1164,6 +1164,7 @@ impl<'a> Relation<'a> {
             arguments,
             columns,
             emit,
+            output_syntax: OutputSyntax::Implicit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -1184,6 +1185,7 @@ impl<'a> Relation<'a> {
             arguments: None,
             columns,
             emit: get_emit(rel.common.as_ref()),
+            output_syntax: OutputSyntax::Implicit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -234,16 +234,12 @@ pub enum ArgsLayout {
     /// `arg, arg, arg` on a single line.
     #[default]
     Inline,
+    /// `arg +> col, col`, used by named `Read` when the direct output domain
+    /// must be shown separately from an explicit emit mapping.
+    DirectDomain,
     /// One `- arg` per line, used for `Read:Virtual` rows. See
     /// [`Relation::write_header`] for the exact layout.
     Rows,
-}
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-enum OutputSyntax {
-    #[default]
-    Implicit,
-    DirectDomain,
 }
 
 #[derive(Debug, Clone)]
@@ -265,6 +261,16 @@ impl<'a> Arguments<'a> {
             positional,
             named,
             layout: ArgsLayout::Inline,
+        }
+    }
+
+    /// An explicit direct-domain argument list (`arg +> col, col`), currently
+    /// used by named `Read` when `RelCommon.emit_kind` is present.
+    pub fn direct_domain(positional: Vec<Value<'a>>, named: Vec<NamedArg<'a>>) -> Self {
+        Arguments {
+            positional,
+            named,
+            layout: ArgsLayout::DirectDomain,
         }
     }
 
@@ -313,7 +319,6 @@ pub struct Relation<'a> {
     pub columns: Vec<Value<'a>>,
     /// The emit kind, if any. If none, use the columns directly.
     pub emit: Option<&'a EmitKind>,
-    output_syntax: OutputSyntax,
     /// `+`-prefixed addendum lines to emit between this relation's header and
     /// children.  This owns the canonical ordering for `+ Ext`, `+ Enh`, and
     /// `+ Opt` lines rather than making the generic relation shape grow one
@@ -377,7 +382,7 @@ impl Relation<'_> {
                 }
                 write!(w, "{child_indent}- => {cols}]")
             }
-            Some(args) if self.output_syntax == OutputSyntax::DirectDomain => {
+            Some(args) if args.layout == ArgsLayout::DirectDomain => {
                 let args = ctx.display(args);
                 let cols = ctx.separated(self.columns.iter(), ", ");
                 write!(w, "{indent}{name}[{args} +> {cols}")?;
@@ -436,16 +441,16 @@ impl<'a> Relation<'a> {
         match &rel.read_type {
             Some(ReadType::NamedTable(table)) => {
                 let table_name = Value::TableName(table.names.iter().map(|n| Name(n)).collect());
+                let arguments = if emit.is_some() {
+                    Arguments::direct_domain(vec![table_name], vec![])
+                } else {
+                    Arguments::inline(vec![table_name], vec![])
+                };
                 Relation {
                     name: Cow::Borrowed("Read"),
-                    arguments: Some(Arguments::inline(vec![table_name], vec![])),
+                    arguments: Some(arguments),
                     columns,
                     emit,
-                    output_syntax: if emit.is_some() {
-                        OutputSyntax::DirectDomain
-                    } else {
-                        OutputSyntax::Implicit
-                    },
                     addenda: AddendumLines::from_advanced_extension(
                         ctx,
                         rel.advanced_extension.as_ref(),
@@ -477,7 +482,6 @@ impl<'a> Relation<'a> {
                     arguments: Some(arguments),
                     columns,
                     emit,
-                    output_syntax: OutputSyntax::Implicit,
                     addenda: AddendumLines::from_advanced_extension(
                         ctx,
                         rel.advanced_extension.as_ref(),
@@ -496,7 +500,6 @@ impl<'a> Relation<'a> {
                     arguments: None,
                     columns,
                     emit,
-                    output_syntax: OutputSyntax::Implicit,
                     addenda: AddendumLines::extension_table(
                         ctx,
                         decoded,
@@ -516,7 +519,6 @@ impl<'a> Relation<'a> {
                     arguments: Some(Arguments::inline(vec![Value::Missing(err)], vec![])),
                     columns,
                     emit,
-                    output_syntax: OutputSyntax::Implicit,
                     addenda: AddendumLines::from_advanced_extension(
                         ctx,
                         rel.advanced_extension.as_ref(),
@@ -589,7 +591,6 @@ impl<'a> Relation<'a> {
             arguments,
             columns,
             emit,
-            output_syntax: OutputSyntax::Implicit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -610,7 +611,6 @@ impl<'a> Relation<'a> {
             arguments: None,
             columns,
             emit: get_emit(rel.common.as_ref()),
-            output_syntax: OutputSyntax::Implicit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -640,7 +640,6 @@ impl<'a> Relation<'a> {
                     arguments: None,
                     columns: vec![],
                     emit: None,
-                    output_syntax: OutputSyntax::Implicit,
                     addenda: AddendumLines::none(),
                     children: vec![],
                 }
@@ -708,7 +707,6 @@ impl<'a> Relation<'a> {
                     arguments: Some(Arguments::inline(positional, named)),
                     columns,
                     emit: None,
-                    output_syntax: OutputSyntax::Implicit,
                     // Extension relations use `detail` rather than
                     // `advanced_extension`; the field does not exist on these
                     // proto types.
@@ -727,7 +725,6 @@ impl<'a> Relation<'a> {
                         error.to_string(),
                     ))],
                     emit: None,
-                    output_syntax: OutputSyntax::Implicit,
                     addenda: AddendumLines::none(),
                     children,
                 }
@@ -810,7 +807,6 @@ impl<'a> Relation<'a> {
             arguments,
             columns: all_outputs,
             emit,
-            output_syntax: OutputSyntax::Implicit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -916,7 +912,6 @@ impl<'a> Relation<'a> {
             arguments,
             columns: col_values,
             emit,
-            output_syntax: OutputSyntax::Implicit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -969,7 +964,6 @@ impl<'a> Relation<'a> {
             arguments: Some(Arguments::inline(vec![], named_args)),
             columns,
             emit,
-            output_syntax: OutputSyntax::Implicit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -1078,7 +1072,6 @@ impl<'a> Relation<'a> {
             arguments,
             columns,
             emit,
-            output_syntax: OutputSyntax::Implicit,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -478,6 +478,12 @@ impl<'a> Relation<'a> {
         match &rel.read_type {
             Some(ReadType::NamedTable(table)) => {
                 let table_name = Value::TableName(table.names.iter().map(|n| Name(n)).collect());
+                // XXX: For `ReadRel`s, we use `=>` if emit is None, `+>` if
+                // `emit` is `Some(Direct)`, and `+> … |>` if emit is
+                // `Some(Remap(…))`. However, we ignore the
+                // `OutputOptions::show_emit` option, and we haven't yet
+                // supported other operators; at some point, we should figure
+                // out our policy here and clean this up.
                 let output_syntax = if emit.is_some() {
                     OutputSyntax::Explicit
                 } else {

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -22,6 +22,24 @@ Root[c, d]
 }
 
 #[test]
+fn test_read_explicit_direct_roundtrip() {
+    let plan = r#"=== Plan
+Root[a, b]
+  Read[my.table +> a:i32, b:string?]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_read_explicit_emit_roundtrip() {
+    let plan = r#"=== Plan
+Root[c, a]
+  Read[my.table +> a:i32, b:string?, c:boolean |> $2, $0]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
 fn test_plan_with_extensions_roundtrip() {
     let plan = r#"=== Extensions
 URNs:


### PR DESCRIPTION
## Description

Added explicit output grammar and parsing support. When the parser encounters an emit, it will parse that emit and determine if it is a direct emit or explicit emit using `parse_output_emit`. I will be implementing textifying from substrait in another PR.
## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Example update
- [ ] Other (please describe)

## Testing

- [x] Added tests for new functionality
- [x] All existing tests pass
- [x] Ran examples to verify behavior

## Checklist

- [x] Code follows Rust conventions
- [x] Documentation updated if needed
- [x] No breaking changes (or breaking changes documented)
- [x] Pre-commit hooks pass

## Related Issues

Closes #(34)
https://github.com/DataDog/substrait-explain/issues/34