### PR TITLE
fix: fix aggregate expression outputs

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -460,19 +460,9 @@ count:():i64
 
 ### Aggregate Measures
 
-Aggregate measures are used in the output of Aggregate relations. They can be either field references (to pass through existing fields) or aggregate function calls (to compute aggregates).
+Aggregate measures are used in the output of Aggregate relations to compute aggregates. An aggregate measure is written as a plain `function_call` (see [Function Calls section](#function-calls)) in the output position of an Aggregate relation - the syntax is identical, e.g. `sum($2):i64`, `count($1):i64`, `avg($3):fp64`.
 
-#### Syntax
-
-- `aggregate_measure := name anchor? urn_anchor? "(" (expression ("," expression)*)? ")" ":" type` - aggregate function call with optional extension anchors and required output type
-- Field references: `$0`, `$1`, ...
-
-#### Examples
-
-- `sum($2):i64`
-- `count($1):i64`
-- `avg($3):fp64`
-- `$0` (field reference to grouping field)
+This syntax only captures a measure's `function_reference`, `arguments`, and `output_type`. The Substrait `Measure` message also carries a `filter` (a per-measure filter expression, separate from the aggregate function) and the `AggregateFunction` itself has `invocation` (e.g. `DISTINCT`), `phase`, and `sorts` (for ordered aggregates) - none of which can currently be expressed in this text format. Parsing always produces `invocation: UNSPECIFIED`, `phase: UNSPECIFIED`, no `sorts`, and no `filter`, regardless of what the original plan contained.
 
 ### IfThen
 
@@ -832,8 +822,8 @@ Root[result]
 - `grouping_sets := grouping_set_list / expression_list` - can be a list of grouping sets (each parenthesized), or a single unparenthesized list for the common, single-set case
 - `grouping_set_list := grouping_set ("," grouping_set)*`
 - `grouping_set := "(" expression_list ")" / "_"` - a grouping set can be (1) a list of expressions, or (2) `_`, the standard we use for empty lists
-- `aggregate_output := (reference | aggregate_measure) ("," (reference | aggregate_measure))*` - comma-separated list of output items
-- `aggregate_measure` - field references or aggregate function calls. See [Aggregate Measures section](#aggregate-measures)
+- `aggregate_output := expression ("," expression)*` - comma-separated list of output items
+- Each output item is either an aggregate function call (which becomes a new measure), or an expression that must match one of the `grouping_sets` expressions by value - since an Aggregate relation's output schema is always exactly `grouping_expressions + measures`. See [Aggregate Measures section](#aggregate-measures)
 
 #### Example
 

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -462,7 +462,7 @@ count:():i64
 
 Aggregate measures are used in the output of Aggregate relations to compute aggregates. An aggregate measure is written as a plain `function_call` (see [Function Calls section](#function-calls)) in the output position of an Aggregate relation - the syntax is identical, e.g. `sum($2):i64`, `count($1):i64`, `avg($3):fp64`.
 
-This syntax only captures a measure's `function_reference`, `arguments`, and `output_type`. The Substrait `Measure` message also carries a `filter` (a per-measure filter expression, separate from the aggregate function) and the `AggregateFunction` itself has `invocation` (e.g. `DISTINCT`), `phase`, and `sorts` (for ordered aggregates) - none of which can currently be expressed in this text format. Parsing always produces `invocation: UNSPECIFIED`, `phase: UNSPECIFIED`, no `sorts`, and no `filter`, regardless of what the original plan contained.
+This syntax only captures a measure's `function_reference`, `arguments`, and `output_type`. The Substrait `Measure` message also carries a `filter` (a per-measure filter expression, separate from the aggregate function) and the `AggregateFunction` itself has `invocation` (e.g. `DISTINCT`), `phase`, and `sorts` (for ordered aggregates), which are currently unsupported. Parsing always produces `invocation: UNSPECIFIED`, `phase: UNSPECIFIED`, no `sorts`, and no `filter`, regardless of what the original plan contained.
 
 ### IfThen
 

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -308,10 +308,7 @@ grouping_set_list  = { grouping_set ~ sp ~ ("," ~ sp ~ grouping_set)* }
 grouping_set       = { ("(" ~ sp ~ expression_list ~ sp ~ ")") | empty }
 expression_list    = { expression ~ sp ~ ("," ~ sp ~ expression)* }
 
-aggregate_output      = { (aggregate_output_item ~ (sp ~ "," ~ sp ~ aggregate_output_item)*)? }
-aggregate_output_item = { reference | aggregate_measure }
-// TODO: Add support for filter, invocation, etc.
-aggregate_measure = { function_call }
+aggregate_output      = { (expression ~ (sp ~ "," ~ sp ~ expression)*)? }
 
 // Empty grouping symbol
 empty = { "_" }

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -308,6 +308,7 @@ grouping_set_list  = { grouping_set ~ sp ~ ("," ~ sp ~ grouping_set)* }
 grouping_set       = { ("(" ~ sp ~ expression_list ~ sp ~ ")") | empty }
 expression_list    = { expression ~ sp ~ ("," ~ sp ~ expression)* }
 
+// TODO: Add support for filter invocation, etc.
 aggregate_output      = { (expression ~ (sp ~ "," ~ sp ~ expression)*)? }
 
 // Empty grouping symbol

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -652,7 +652,7 @@ impl ParsePair for CompoundName {
 
 impl ScopedParsePair for Measure {
     fn rule() -> Rule {
-        Rule::aggregate_measure
+        Rule::function_call
     }
 
     fn message() -> &'static str {
@@ -665,12 +665,8 @@ impl ScopedParsePair for Measure {
     ) -> Result<Self, MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
 
-        // Extract the inner function_call from aggregate_measure
-        let function_call_pair = unwrap_single_pair(pair);
-        assert_eq!(function_call_pair.as_rule(), Rule::function_call);
-
         // Parse as ScalarFunction, then convert to AggregateFunction
-        let scalar = ScalarFunction::parse_pair(extensions, function_call_pair)?;
+        let scalar = ScalarFunction::parse_pair(extensions, pair)?;
         Ok(Measure {
             measure: Some(AggregateFunction {
                 function_reference: scalar.function_reference,

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -502,42 +502,6 @@ impl ScopedParsePair for Cast {
     }
 }
 
-/// Parses an already-unwrapped inner pair of `Rule::expression`.
-pub(crate) fn parse_expression_inner(
-    extensions: &SimpleExtensions,
-    inner: pest::iterators::Pair<Rule>,
-) -> Result<Expression, MessageParseError> {
-    match inner.as_rule() {
-        Rule::literal => Ok(Expression {
-            rex_type: Some(RexType::Literal(Literal::parse_pair(extensions, inner)?)),
-        }),
-        Rule::function_call => Ok(Expression {
-            rex_type: Some(RexType::ScalarFunction(ScalarFunction::parse_pair(
-                extensions, inner,
-            )?)),
-        }),
-        Rule::reference => Ok(Expression {
-            rex_type: Some(RexType::Selection(Box::new(FieldReference::parse_pair(
-                inner,
-            )))),
-        }),
-        Rule::if_then => Ok(Expression {
-            rex_type: Some(RexType::IfThen(Box::new(IfThen::parse_pair(
-                extensions, inner,
-            )?))),
-        }),
-        Rule::cast_expression => Ok(Expression {
-            rex_type: Some(RexType::Cast(Box::new(Cast::parse_pair(
-                extensions, inner,
-            )?))),
-        }),
-        _ => unreachable!(
-            "Grammar guarantees expression can only be literal, function_call, reference, if_then, or cast_expression, got: {:?}",
-            inner.as_rule()
-        ),
-    }
-}
-
 impl ScopedParsePair for Expression {
     fn rule() -> Rule {
         Rule::expression
@@ -552,7 +516,36 @@ impl ScopedParsePair for Expression {
         pair: pest::iterators::Pair<Rule>,
     ) -> Result<Self, MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
-        parse_expression_inner(extensions, unwrap_single_pair(pair))
+        let inner = unwrap_single_pair(pair);
+        match inner.as_rule() {
+            Rule::literal => Ok(Expression {
+                rex_type: Some(RexType::Literal(Literal::parse_pair(extensions, inner)?)),
+            }),
+            Rule::function_call => Ok(Expression {
+                rex_type: Some(RexType::ScalarFunction(ScalarFunction::parse_pair(
+                    extensions, inner,
+                )?)),
+            }),
+            Rule::reference => Ok(Expression {
+                rex_type: Some(RexType::Selection(Box::new(FieldReference::parse_pair(
+                    inner,
+                )))),
+            }),
+            Rule::if_then => Ok(Expression {
+                rex_type: Some(RexType::IfThen(Box::new(IfThen::parse_pair(
+                    extensions, inner,
+                )?))),
+            }),
+            Rule::cast_expression => Ok(Expression {
+                rex_type: Some(RexType::Cast(Box::new(Cast::parse_pair(
+                    extensions, inner,
+                )?))),
+            }),
+            _ => unreachable!(
+                "Grammar guarantees expression can only be literal, function_call, reference, if_then, or cast_expression, got: {:?}",
+                inner.as_rule()
+            ),
+        }
     }
 }
 

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -502,6 +502,42 @@ impl ScopedParsePair for Cast {
     }
 }
 
+/// Parses an already-unwrapped inner pair of `Rule::expression`.
+pub(crate) fn parse_expression_inner(
+    extensions: &SimpleExtensions,
+    inner: pest::iterators::Pair<Rule>,
+) -> Result<Expression, MessageParseError> {
+    match inner.as_rule() {
+        Rule::literal => Ok(Expression {
+            rex_type: Some(RexType::Literal(Literal::parse_pair(extensions, inner)?)),
+        }),
+        Rule::function_call => Ok(Expression {
+            rex_type: Some(RexType::ScalarFunction(ScalarFunction::parse_pair(
+                extensions, inner,
+            )?)),
+        }),
+        Rule::reference => Ok(Expression {
+            rex_type: Some(RexType::Selection(Box::new(FieldReference::parse_pair(
+                inner,
+            )))),
+        }),
+        Rule::if_then => Ok(Expression {
+            rex_type: Some(RexType::IfThen(Box::new(IfThen::parse_pair(
+                extensions, inner,
+            )?))),
+        }),
+        Rule::cast_expression => Ok(Expression {
+            rex_type: Some(RexType::Cast(Box::new(Cast::parse_pair(
+                extensions, inner,
+            )?))),
+        }),
+        _ => unreachable!(
+            "Grammar guarantees expression can only be literal, function_call, reference, if_then, or cast_expression, got: {:?}",
+            inner.as_rule()
+        ),
+    }
+}
+
 impl ScopedParsePair for Expression {
     fn rule() -> Rule {
         Rule::expression
@@ -516,36 +552,7 @@ impl ScopedParsePair for Expression {
         pair: pest::iterators::Pair<Rule>,
     ) -> Result<Self, MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
-        let inner = unwrap_single_pair(pair);
-        match inner.as_rule() {
-            Rule::literal => Ok(Expression {
-                rex_type: Some(RexType::Literal(Literal::parse_pair(extensions, inner)?)),
-            }),
-            Rule::function_call => Ok(Expression {
-                rex_type: Some(RexType::ScalarFunction(ScalarFunction::parse_pair(
-                    extensions, inner,
-                )?)),
-            }),
-            Rule::reference => Ok(Expression {
-                rex_type: Some(RexType::Selection(Box::new(FieldReference::parse_pair(
-                    inner,
-                )))),
-            }),
-            Rule::if_then => Ok(Expression {
-                rex_type: Some(RexType::IfThen(Box::new(IfThen::parse_pair(
-                    extensions, inner,
-                )?))),
-            }),
-            Rule::cast_expression => Ok(Expression {
-                rex_type: Some(RexType::Cast(Box::new(Cast::parse_pair(
-                    extensions, inner,
-                )?))),
-            }),
-            _ => unreachable!(
-                "Grammar guarantees expression can only be literal, function_call, reference, if_then, or cast_expression, got: {:?}",
-                inner.as_rule()
-            ),
-        }
+        parse_expression_inner(extensions, unwrap_single_pair(pair))
     }
 }
 

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -21,7 +21,7 @@ use crate::extensions::any::Any;
 use crate::extensions::registry::ExtensionError;
 use crate::extensions::{AddendumKind, ExtensionArgs, ExtensionRegistry, SimpleExtensions};
 use crate::parser::errors::{ParseContext, ParseError};
-use crate::parser::expressions::{FieldIndex, Name};
+use crate::parser::expressions::{FieldIndex, Name, parse_expression_inner};
 
 /// Parsing context for relations that includes extensions, registry, and optional warning collection
 pub struct RelationParsingContext<'a> {
@@ -700,6 +700,14 @@ impl RelationParsePair for AggregateRel {
     }
 }
 
+/// Encodes an expression to bytes for use as a structural-equality map key.
+/// TODO: use a better key here than encoding to bytes. Ideally, substrait-rs
+/// would support `PartialEq` and `Hash`, but as there isn't an easy way to do
+/// that now, we'll skip.
+fn expression_key(expression: &Expression) -> Vec<u8> {
+    expression.encode_to_vec()
+}
+
 /// Parses the output section of an aggregate (everything after `=>`).
 ///
 /// For example, in `Aggregate[($0, $1), _ => sum($2), $0, count($2)]`,
@@ -711,13 +719,13 @@ fn parse_aggregate_output(
 ) -> Result<(Vec<aggregate_rel::Measure>, Vec<i32>), MessageParseError> {
     assert_eq!(output_pair.as_rule(), Rule::aggregate_output);
 
-    //  every output item is either:
+    // every output item is either:
     // - a function call, which becomes a new aggregate measure, or
     // - an expression which must already be one of `grouping_expressions`.
     let grouping_positions: HashMap<Vec<u8>, usize> = grouping_expressions
         .iter()
         .enumerate()
-        .map(|(index, expression)| (expression.encode_to_vec(), index))
+        .map(|(index, expression)| (expression_key(expression), index))
         .collect();
 
     let mut measures = Vec::new();
@@ -726,21 +734,23 @@ fn parse_aggregate_output(
     for output_item in output_pair.into_inner() {
         assert_eq!(output_item.as_rule(), Rule::expression);
         let span = output_item.as_span();
-        let is_function_call = matches!(
-            output_item.clone().into_inner().next().map(|p| p.as_rule()),
-            Some(Rule::function_call)
-        );
+        let inner_item = unwrap_single_pair(output_item);
 
-        if is_function_call {
-            let function_call_pair = unwrap_single_pair(output_item);
-            let measure = aggregate_rel::Measure::parse_pair(extensions, function_call_pair)?;
+        if inner_item.as_rule() == Rule::function_call {
+            let expression = parse_expression_inner(extensions, inner_item.clone())?;
+            if let Some(&index) = grouping_positions.get(&expression_key(&expression)) {
+                output_mapping.push(index as i32);
+                continue;
+            }
+
+            let measure = aggregate_rel::Measure::parse_pair(extensions, inner_item)?;
             output_mapping.push(grouping_expressions.len() as i32 + measures.len() as i32);
             measures.push(measure);
             continue;
         }
 
-        let expression = Expression::parse_pair(extensions, output_item)?;
-        match grouping_positions.get(&expression.encode_to_vec()) {
+        let expression = parse_expression_inner(extensions, inner_item)?;
+        match grouping_positions.get(&expression_key(&expression)) {
             Some(&index) => output_mapping.push(index as i32),
             None => {
                 return Err(MessageParseError::invalid(
@@ -830,10 +840,7 @@ fn build_grouping_fields(expression_sets: &[Vec<Expression>]) -> (Vec<Grouping>,
             let expression_references = set
                 .iter()
                 .map(|exp| {
-                    // TODO: use a better key here than encoding to bytes.
-                    // Ideally, substrait-rs would support `PartialEq` and `Hash`,
-                    // but as there isn't an easy way to do that now, we'll skip.
-                    let key = exp.encode_to_vec();
+                    let key = expression_key(exp);
                     let next_idx = expressions.len() as u32;
                     *seen.entry(key).or_insert_with(|| {
                         expressions.push(exp.clone());
@@ -1596,7 +1603,85 @@ mod tests {
             3,
         );
 
-        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert!(error.to_string().contains(
+            "output expression is not an aggregate measure and does not match any grouping expression"
+        ));
+    }
+
+    #[test]
+    fn test_parse_aggregate_relation_output_with_literal_expression() {
+        let extensions = TestContext::new()
+            .with_urn(1, "https://github.com/substrait-io/substrait/blob/main/extensions/functions_aggregate.yaml")
+            .with_function(1, 10, "sum")
+            .extensions;
+
+        // The first grouping expression is a literal, not a reference or a
+        // function call, so it can only match the output item by structural
+        // equality (encode_to_vec).
+        let aggregate = AggregateRel::parse_pair_with_context(
+            &extensions,
+            parse_exact(
+                Rule::aggregate_relation,
+                "Aggregate[42, $0 => $0, 42, sum($1):i64]",
+            ),
+            vec![example_read_relation().into_rel(None)],
+            3,
+        )
+        .unwrap()
+        .0;
+
+        assert_eq!(aggregate.grouping_expressions.len(), 2);
+        let emit_kind = &aggregate
+            .common
+            .as_ref()
+            .unwrap()
+            .emit_kind
+            .as_ref()
+            .unwrap();
+        let emit = match emit_kind {
+            EmitKind::Emit(emit) => &emit.output_mapping,
+            _ => panic!("Expected EmitKind::Emit, got {emit_kind:?}"),
+        };
+        // direct schema is [42, $0, sum($1)]; output is [$0, 42, sum($1)] -> [1, 0, 2]
+        assert_eq!(emit, &[1, 0, 2]);
+    }
+
+    #[test]
+    fn test_parse_aggregate_relation_function_call_is_not_a_measure() {
+        let extensions = TestContext::new()
+            .with_urn(1, "https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml")
+            .with_urn(2, "https://github.com/substrait-io/substrait/blob/main/extensions/functions_aggregate.yaml")
+            .with_function(1, 10, "eq")
+            .with_function(2, 11, "sum")
+            .extensions;
+
+        // `eq($0, $1)` is both the grouping expression and repeated
+        // verbatim in the output, so it must resolve to the grouping
+        // position rather than being parsed as a second, duplicate
+        // aggregate measure.
+        let aggregate = AggregateRel::parse_pair_with_context(
+            &extensions,
+            parse_exact(
+                Rule::aggregate_relation,
+                "Aggregate[eq($0, $1):boolean => eq($0, $1):boolean, sum($2):i64]",
+            ),
+            vec![example_read_relation().into_rel(None)],
+            3,
+        )
+        .unwrap()
+        .0;
+
+        assert_eq!(aggregate.grouping_expressions.len(), 1);
+        assert_eq!(aggregate.measures.len(), 1);
+        let emit_kind = &aggregate
+            .common
+            .as_ref()
+            .unwrap()
+            .emit_kind
+            .as_ref()
+            .unwrap();
+        assert!(matches!(emit_kind, EmitKind::Direct(_)));
     }
 
     #[test]

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -676,7 +676,7 @@ impl RelationParsePair for AggregateRel {
         let (groupings, grouping_expressions) = build_grouping_fields(&grouping_sets);
 
         let (measures, output_mapping) =
-            parse_aggregate_measures(extensions, output_pair, &grouping_expressions)?;
+            parse_aggregate_output(extensions, output_pair, &grouping_expressions)?;
 
         let output_count = output_mapping.len();
         let direct_count = grouping_expressions.len() + measures.len();
@@ -704,31 +704,51 @@ impl RelationParsePair for AggregateRel {
 ///
 /// For example, in `Aggregate[($0, $1), _ => sum($2), $0, count($2)]`,
 /// this parses `sum($2), $0, count($2)`.
-fn parse_aggregate_measures(
+fn parse_aggregate_output(
     extensions: &SimpleExtensions,
     output_pair: Pair<'_, Rule>,
     grouping_expressions: &[Expression],
 ) -> Result<(Vec<aggregate_rel::Measure>, Vec<i32>), MessageParseError> {
     assert_eq!(output_pair.as_rule(), Rule::aggregate_output);
+
+    //  every output item is either:
+    // - a function call, which becomes a new aggregate measure, or
+    // - an expression which must already be one of `grouping_expressions`.
+    let grouping_positions: HashMap<Vec<u8>, usize> = grouping_expressions
+        .iter()
+        .enumerate()
+        .map(|(index, expression)| (expression.encode_to_vec(), index))
+        .collect();
+
     let mut measures = Vec::new();
     let mut output_mapping = Vec::new();
 
-    for aggregate_output_item in output_pair.into_inner() {
-        let inner_item = unwrap_single_pair(aggregate_output_item);
-        match inner_item.as_rule() {
-            Rule::reference => {
-                let field_index = FieldIndex::parse_pair(inner_item);
-                output_mapping.push(field_index.0);
+    for output_item in output_pair.into_inner() {
+        assert_eq!(output_item.as_rule(), Rule::expression);
+        let span = output_item.as_span();
+        let is_function_call = matches!(
+            output_item.clone().into_inner().next().map(|p| p.as_rule()),
+            Some(Rule::function_call)
+        );
+
+        if is_function_call {
+            let function_call_pair = unwrap_single_pair(output_item);
+            let measure = aggregate_rel::Measure::parse_pair(extensions, function_call_pair)?;
+            output_mapping.push(grouping_expressions.len() as i32 + measures.len() as i32);
+            measures.push(measure);
+            continue;
+        }
+
+        let expression = Expression::parse_pair(extensions, output_item)?;
+        match grouping_positions.get(&expression.encode_to_vec()) {
+            Some(&index) => output_mapping.push(index as i32),
+            None => {
+                return Err(MessageParseError::invalid(
+                    "AggregateRel",
+                    span,
+                    "output expression is not an aggregate measure and does not match any grouping expression",
+                ));
             }
-            Rule::aggregate_measure => {
-                let measure = aggregate_rel::Measure::parse_pair(extensions, inner_item)?;
-                output_mapping.push(grouping_expressions.len() as i32 + measures.len() as i32);
-                measures.push(measure);
-            }
-            _ => panic!(
-                "Unexpected inner output item rule: {:?}",
-                inner_item.as_rule()
-            ),
         }
     }
 
@@ -1517,6 +1537,66 @@ mod tests {
         assert_eq!(aggregate.groupings.len(), 1);
         // expression_references must be positions [0, 1], not raw field indices [2, 0]
         assert_eq!(aggregate.groupings[0].expression_references, vec![0, 1]);
+    }
+
+    #[test]
+    fn test_parse_aggregate_relation_output_reference_uses_grouping_position() {
+        let extensions = TestContext::new()
+            .with_urn(1, "https://github.com/substrait-io/substrait/blob/main/extensions/functions_aggregate.yaml")
+            .with_function(1, 10, "sum")
+            .extensions;
+
+        // grouping_expressions ends up as [$2, $0] (grouping's textual order),
+        // so `$0`/`$2` in the output must resolve to their grouping
+        // positions (1 and 0 respectively), not their literal reference
+        // indices. Output order is swapped relative to grouping order so
+        // the resulting mapping isn't an identity (which would collapse to
+        // EmitKind::Direct and give us nothing to assert on).
+        let aggregate = AggregateRel::parse_pair_with_context(
+            &extensions,
+            parse_exact(
+                Rule::aggregate_relation,
+                "Aggregate[$2, $0 => $0, $2, sum($1):i64]",
+            ),
+            vec![example_read_relation().into_rel(None)],
+            3,
+        )
+        .unwrap()
+        .0;
+
+        assert_eq!(aggregate.grouping_expressions.len(), 2);
+        let emit_kind = &aggregate
+            .common
+            .as_ref()
+            .unwrap()
+            .emit_kind
+            .as_ref()
+            .unwrap();
+        let emit = match emit_kind {
+            EmitKind::Emit(emit) => &emit.output_mapping,
+            _ => panic!("Expected EmitKind::Emit, got {emit_kind:?}"),
+        };
+        // direct schema is [$2, $0, sum($1)]; output is [$0, $2, sum($1)] -> [1, 0, 2]
+        assert_eq!(emit, &[1, 0, 2]);
+    }
+
+    #[test]
+    fn test_parse_aggregate_relation_output_not_in_grouping_expressions_errors() {
+        let extensions = TestContext::new()
+            .with_urn(1, "https://github.com/substrait-io/substrait/blob/main/extensions/functions_aggregate.yaml")
+            .with_function(1, 10, "sum")
+            .extensions;
+
+        // $1 is not part of the grouping expressions ($0) and is not an
+        // aggregate measure, so it has no valid slot in the output schema.
+        let result = AggregateRel::parse_pair_with_context(
+            &extensions,
+            parse_exact(Rule::aggregate_relation, "Aggregate[$0 => $1, sum($1):i64]"),
+            vec![example_read_relation().into_rel(None)],
+            3,
+        );
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -21,7 +21,7 @@ use crate::extensions::any::Any;
 use crate::extensions::registry::ExtensionError;
 use crate::extensions::{AddendumKind, ExtensionArgs, ExtensionRegistry, SimpleExtensions};
 use crate::parser::errors::{ParseContext, ParseError};
-use crate::parser::expressions::{FieldIndex, Name, parse_expression_inner};
+use crate::parser::expressions::{FieldIndex, Name};
 
 /// Parsing context for relations that includes extensions, registry, and optional warning collection
 pub struct RelationParsingContext<'a> {
@@ -720,8 +720,15 @@ fn parse_aggregate_output(
     assert_eq!(output_pair.as_rule(), Rule::aggregate_output);
 
     // every output item is either:
-    // - a function call, which becomes a new aggregate measure, or
-    // - an expression which must already be one of `grouping_expressions`.
+    // - an expression which must already be one of `grouping_expressions`,
+    // - a new function call, which we assume must be an aggregate measure.
+    //
+    // While it would probably be best to check if a function call was an
+    // aggregate function, the substrait-explain text does not distinguish
+    // between aggregate measures and grouping expressions, and the
+    // `SimpleExtensions` do not have that information either (neither here in
+    // the Registry nor in the actual Protobuf `ExtensionFunction` definition),
+    // so we can only check whether it's a previous expression.
     let grouping_positions: HashMap<Vec<u8>, usize> = grouping_expressions
         .iter()
         .enumerate()
@@ -734,10 +741,10 @@ fn parse_aggregate_output(
     for output_item in output_pair.into_inner() {
         assert_eq!(output_item.as_rule(), Rule::expression);
         let span = output_item.as_span();
-        let inner_item = unwrap_single_pair(output_item);
+        let inner_item = unwrap_single_pair(output_item.clone());
 
         if inner_item.as_rule() == Rule::function_call {
-            let expression = parse_expression_inner(extensions, inner_item.clone())?;
+            let expression = Expression::parse_pair(extensions, output_item)?;
             if let Some(&index) = grouping_positions.get(&expression_key(&expression)) {
                 output_mapping.push(index as i32);
                 continue;
@@ -749,7 +756,7 @@ fn parse_aggregate_output(
             continue;
         }
 
-        let expression = parse_expression_inner(extensions, inner_item)?;
+        let expression = Expression::parse_pair(extensions, output_item)?;
         match grouping_positions.get(&expression_key(&expression)) {
             Some(&index) => output_mapping.push(index as i32),
             None => {

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -720,8 +720,15 @@ fn parse_aggregate_output(
     assert_eq!(output_pair.as_rule(), Rule::aggregate_output);
 
     // every output item is either:
-    // - a function call, which becomes a new aggregate measure, or
-    // - an expression which must already be one of `grouping_expressions`.
+    // - an expression which must already be one of `grouping_expressions`,
+    // - a new function call, which we assume must be an aggregate measure.
+    //
+    // While it would probably be best to check if a function call was an
+    // aggregate function, the substrait-explain text does not distinguish
+    // between aggregate measures and grouping expressions, and the
+    // `SimpleExtensions` do not have that information either (neither here in
+    // the Registry nor in the actual Protobuf `ExtensionFunction` definition),
+    // so we can only check whether it's a previous expression.
     let grouping_positions: HashMap<Vec<u8>, usize> = grouping_expressions
         .iter()
         .enumerate()
@@ -732,8 +739,7 @@ fn parse_aggregate_output(
     let mut output_mapping = Vec::new();
 
     for output_item in output_pair.into_inner() {
-        assert_eq!(output_item.as_rule(), Rule::expression);
-        let span = output_item.as_span();
+        let expression = Expression::parse_pair(extensions, output_item.clone())?;
         let inner_item = unwrap_single_pair(output_item);
 
         if inner_item.as_rule() == Rule::function_call {

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::fmt;
 use std::fmt::Debug;
@@ -722,7 +722,18 @@ impl<'a> Relation<'a> {
             for group in &rel.groupings {
                 let mut grouping_set: Vec<Value> = vec![];
                 for i in &group.expression_references {
-                    grouping_set.push(Value::Reference(*i as i32));
+                    let value = match rel.grouping_expressions.get(*i as usize) {
+                        Some(expr) => Value::Expression(expr),
+                        None => Value::Missing(PlanError::invalid(
+                            "AggregateRel",
+                            Some("groupings.expression_references"),
+                            format!(
+                                "expression_reference {i} is out of bounds for grouping_expressions of length {}",
+                                rel.grouping_expressions.len()
+                            ),
+                        )),
+                    };
+                    grouping_set.push(value);
                 }
                 grouping_sets.push(grouping_set);
             }
@@ -775,9 +786,10 @@ impl<'a> Relation<'a> {
         let mut grouping_sets: Vec<Vec<Value>> = vec![];
         let mut expression_list: Vec<Value> = Vec::new();
 
-        // groupings might have the same expressions in their set so we use a map to get unique expressions
-        let mut expression_index_map = HashMap::new();
-        let mut i: i32 = 0; // index for the unique expression in the grouping_expressions list
+        // groupings might have the same expressions in their set, so we track
+        // which byte-encoded expressions have already been added to
+        // `expression_list` to keep it deduplicated.
+        let mut seen_expressions = HashSet::new();
 
         for group in &rel.groupings {
             let mut grouping_set: Vec<Value> = vec![];
@@ -786,16 +798,10 @@ impl<'a> Relation<'a> {
                 // TODO: use a better key here than encoding to bytes.
                 // Ideally, substrait-rs would support `PartialEq` and `Hash`,
                 // but as there isn't an easy way to do that now, we'll skip.
-                let key = exp.encode_to_vec();
-                expression_index_map.entry(key.clone()).or_insert_with(|| {
-                    let value = Value::Expression(exp);
-                    expression_list.push(value); // new unique expression found
-                    // mapping the byte encoded expression to its index in the group_expression list
-                    let index = i;
-                    i += 1;
-                    index // is expression returned by this closure and inserted into map
-                });
-                grouping_set.push(Value::Reference(expression_index_map[&key]));
+                if seen_expressions.insert(exp.encode_to_vec()) {
+                    expression_list.push(Value::Expression(exp)); // new unique expression found
+                }
+                grouping_set.push(Value::Expression(exp));
             }
             grouping_sets.push(grouping_set);
         }
@@ -1585,6 +1591,83 @@ Filter[gt($0, 10:i32):boolean => $0, $1]
                 "Aggregate[($0, $1), ($0, $1), ($1), ($1, $1), _ => $0, $1, count($2):i64]"
             )
         );
+    }
+
+    #[test]
+    fn test_deprecated_reordered_grouping() {
+        // Protobuf plan that uses the deprecated per-Grouping
+        // `grouping_expressions`, leaving `AggregateRel.grouping_expressions`
+        // empty. The lone unique expression here is $5, but it is the first
+        // (index 0) expression discovered during deduplication - so if the
+        // grouping set were rendered from that dedup index rather than from
+        // the expression itself, it would wrongly print as `$0` instead of
+        // `$5`.
+        let ctx = TestContext::new();
+        let grouping_expr_5 = create_exp(5);
+
+        let grouping_sets = vec![aggregate_rel::Grouping {
+            #[allow(deprecated)]
+            grouping_expressions: vec![grouping_expr_5],
+            expression_references: vec![],
+        }];
+
+        let aggregate_rel = create_aggregate_rel(vec![], grouping_sets, vec![], None);
+        let rel = Rel {
+            rel_type: Some(RelType::Aggregate(Box::new(aggregate_rel))),
+        };
+        let (result, errors) = ctx.textify(&rel);
+
+        assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
+        assert!(result.contains("Aggregate[$5 => $5]"));
+    }
+
+    #[test]
+    fn test_reordered_grouping_textifies_expression_not_raw_index() {
+        let ctx = TestContext::new()
+            .with_urn(1, "https://github.com/substrait-io/substrait/blob/main/extensions/functions_aggregate.yaml")
+            .with_function(1, 11, "count");
+
+        let agg_fn2 = get_aggregate_func(11, 1);
+
+        // grouping_expressions is [$2, $0] (textual order); the single
+        // grouping set references both by index into grouping_expressions:
+        // [0, 1]. Those indexes must resolve back through
+        // grouping_expressions ([$2, $0]), not be printed directly as `$0,
+        // $1`.
+        let grouping_expressions = vec![
+            Expression {
+                rex_type: Some(RexType::Selection(Box::new(
+                    FieldIndex(2).to_field_reference(),
+                ))),
+            },
+            Expression {
+                rex_type: Some(RexType::Selection(Box::new(
+                    FieldIndex(0).to_field_reference(),
+                ))),
+            },
+        ];
+
+        let grouping_sets = vec![Grouping {
+            #[allow(deprecated)]
+            grouping_expressions: vec![],
+            expression_references: vec![0, 1],
+        }];
+
+        let measures = vec![aggregate_rel::Measure {
+            measure: Some(agg_fn2),
+            filter: None,
+        }];
+
+        let aggregate_rel =
+            create_aggregate_rel(grouping_expressions, grouping_sets, measures, None);
+
+        let rel = Rel {
+            rel_type: Some(RelType::Aggregate(Box::new(aggregate_rel))),
+        };
+        let (result, errors) = ctx.textify(&rel);
+
+        assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
+        assert!(result.contains("Aggregate[$2, $0 => $2, $0, count($1):i64]"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fix Aggregate output/grouping-expression handling

Aggregate relation output items were mishandled in two ways:

1. Parser: a function_call output item was always parsed as a new measure, even when it structurally matched an existing grouping expression; should instead map back to that grouping position, not double as a measure.
2. Textifier: grouping-expression output items were rendered as raw $i field references using the expression's dedup/reference index, instead of resolving through grouping_expressions and printing the actual expression — producing syntactically valid but semantically wrong output whenever the index didn't coincidentally match the field number. Fixed in both the current and deprecated grouping code paths.
3.  non-function-call output expressions (literals, etc.) matching a grouping expression by structural equality are now supported, error messages on unmatched output expressions are asserted in tests.

## Type of Change

- [x] Bug fix

## Testing

- [x] Added tests for new functionality
- [x] All existing tests pass

## Related Issues

Closes #175
