### PR TITLE
feat: interval day to second support

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -241,9 +241,49 @@ A literal can be an integer, float, boolean, string, or null. Literals may inclu
   - A type annotation is required for `null`
 - **`typed_literal`**` := string ":" type`
   - String literals with type annotations for non-primitive types
-  - Examples: `'2023-01-01':date`, `'2023-12-25T14:30:45.123':timestamp`, `'2023-01-01T12:00:00.123456789':precisiontimestamp<9>`, `'14:30:45.123456':precisiontime<6>`
+  - Examples: `'2023-01-01':date`, `'2023-12-25T14:30:45.123':timestamp`, `'2023-01-01T12:00:00.123456789':precisiontimestamp<9>`, `'14:30:45.123456':precisiontime<6>`, `'5d 3s':interval_day<0>`
 
-All basic literal types (`integer`, `float`, `boolean`, and `string`) are supported, plus `date`, `time`, `timestamp`, `precisiontime`, `precisiontimestamp`, `precisiontimestamptz`, and typed null literals. Other Substrait literal types (e.g., `interval_year`, `decimal`, `uuid`) are not yet implemented. The deprecated `timestamp_tz` literal is also not yet implemented; use `precisiontimestamptz<6>` instead.
+All basic literal types (`integer`, `float`, `boolean`, and `string`) are supported, plus `date`, `time`, `timestamp`, `precisiontime`, `precisiontimestamp`, `precisiontimestamptz`, `interval_day`, and typed null literals. Other Substrait literal types (e.g., `interval_year`, `decimal`, `uuid`) are not yet implemented. The deprecated `timestamp_tz` literal is also not yet implemented; use `precisiontimestamptz<6>` instead.
+
+#### `interval_day` Typed Literals
+
+`interval_day` string literals represent Substrait `IntervalDayToSecond` values.
+The string holds up to three duration terms:
+
+```text
+interval_day_literal := (duration_days (" " duration_seconds)? (" " duration_subseconds)?)
+                      / (duration_seconds (" " duration_subseconds)?)
+                      / duration_subseconds
+duration_days        := "-"? digit+ "d"
+duration_seconds     := "-"? digit+ "s"
+duration_subseconds  := "-"? digit+ subsecond_unit
+subsecond_unit       := "ms" / "us" / "ns" / "ps"
+```
+
+Each term is optional, but at least one is required, and terms appear in
+descending order: days, then seconds, then sub-seconds. Terms are separated by
+exactly one space, with no leading or trailing whitespace. Each term carries its
+own optional sign, matching the separate Substrait fields for days, seconds, and
+sub-seconds.
+
+Sub-second precision comes from the type ascription, not the string, so an
+`interval_day` literal always names its precision: `interval_day<precision>`,
+with `precision` an integer from 0 to 12. A sub-second term's unit must agree
+with that precision - `ms` is precision 3, `us` is 6, `ns` is 9, and `ps` is 12 -
+so there is only one place a value's precision can come from.
+
+Examples:
+
+- `'5d':interval_day<0>`
+- `'4d 5s':interval_day<6>`
+- `'123456789ns':interval_day<9>`
+- `'5d 3s 100ms':interval_day<3>`
+- `'-5d 3s':interval_day<0>`
+- `'5d':interval_day?<6>` (nullable)
+
+Only non-zero components are written on output, since precision travels in the
+type suffix: an interval of 5 days at nanosecond precision is `'5d':interval_day<9>`,
+not `'5d 0ns':interval_day<9>`. An all-zero interval is written `'0s'`.
 
 ## Types
 
@@ -283,6 +323,9 @@ From [official Substrait grammar](https://raw.githubusercontent.com/substrait-io
 - `string`, `binary`
 - `timestamp`, `timestamp_tz`, `date`, `time`
 - `interval_year`, `uuid`
+
+`interval_day` is not in this list: it is parameterized by sub-second precision,
+so it is written as a compound type (see below).
 
 #### Nullability
 
@@ -349,6 +392,11 @@ precisiontimestamp?<9>
 precisiontimestamptz<3>
 precisiontimestamptz?<3>
 ```
+
+`interval_day` takes an integer sub-second precision from 0 to 12 (0 = seconds,
+3 = milliseconds, 6 = microseconds, 9 = nanoseconds, 12 = picoseconds), e.g.
+`interval_day<9>`, `interval_day?<0>`. The parameter is required, as it is for
+every other parameterized type.
 
 #### Examples
 

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -267,10 +267,16 @@ own optional sign, matching the separate Substrait fields for days, seconds, and
 sub-seconds.
 
 Sub-second precision comes from the type ascription, not the string, so an
-`interval_day` literal always names its precision: `interval_day<precision>`,
-with `precision` an integer from 0 to 12. A sub-second term's unit must agree
-with that precision - `ms` is precision 3, `us` is 6, `ns` is 9, and `ps` is 12 -
-so there is only one place a value's precision can come from.
+`interval_day` literal always names its precision: `interval_day<precision>`.
+A literal's precision must be one of 0 (seconds), 3 (milliseconds), 6
+(microseconds), 9 (nanoseconds), or 12 (picoseconds) - the precisions that have
+a unit to write a value in. Unlike `precisiontimestamp` and `precisiontime`
+literals, `interval_day` accepts 12: sub-seconds are stored as a plain integer
+count rather than going through `chrono`.
+
+A sub-second term's unit must agree with the ascribed precision - `ms` is
+precision 3, `us` is 6, `ns` is 9, and `ps` is 12 - so there is only one place a
+value's precision can come from.
 
 Examples:
 
@@ -393,10 +399,11 @@ precisiontimestamptz<3>
 precisiontimestamptz?<3>
 ```
 
-`interval_day` takes an integer sub-second precision from 0 to 12 (0 = seconds,
-3 = milliseconds, 6 = microseconds, 9 = nanoseconds, 12 = picoseconds), e.g.
+`interval_day` takes an integer sub-second precision from 0 to 12, e.g.
 `interval_day<9>`, `interval_day?<0>`. The parameter is required, as it is for
-every other parameterized type.
+every other parameterized type. Writing an `interval_day` *literal* additionally
+requires a precision that has a unit to write values in; see
+[`interval_day` Typed Literals](#interval_day-typed-literals).
 
 #### Examples
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub use extensions::{AnyConvertible, Explainable, ExtensionRegistry};
 pub mod extensions;
 pub mod grammar;
 mod parser;
+mod precision;
 mod textify;
 
 #[cfg(test)]

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -57,6 +57,33 @@ reference = { "$" ~ integer }
 // Literal
 literal = { (float | integer | boolean | string_literal | null) ~ (":" ~ sp ~ type)? }
 
+// -- interval_day durations --
+//
+// The contents of an `interval_day` literal string, e.g. "5d", "4d 5s",
+// "5d 3s 100ns". A day term, a seconds term, and a sub-second term, in that
+// order; each is optional, but at least one is required, so each unit can
+// appear at most once.
+//
+// This rule is deliberately not referenced from `literal`: the string is
+// unescaped first, then re-parsed with this rule as the start rule. Terms are
+// separated by exactly one space, with no leading or trailing whitespace -
+// literals don't need the looser whitespace the surrounding grammar allows.
+interval_day_duration = {
+    SOI ~ (
+        duration_days ~ (whitespace ~ duration_seconds)? ~ (whitespace ~ duration_subseconds)?
+      | duration_seconds ~ (whitespace ~ duration_subseconds)?
+      | duration_subseconds
+    ) ~ EOI
+}
+
+duration_days       = { integer ~ "d" }
+duration_seconds    = { integer ~ "s" }
+duration_subseconds = { integer ~ subsecond_unit }
+
+// The sub-second units that correspond to a writable `interval_day` precision:
+// ms = 3, us = 6, ns = 9, ps = 12.
+subsecond_unit = { "ms" | "us" | "ns" | "ps" }
+
 // -- Components for types and functions
 anchor     = { "#" ~ sp ~ integer }
 urn_anchor = { "@" ~ sp ~ integer }
@@ -125,10 +152,14 @@ precision_timestamp_tz_type = { ^"precisiontimestamptz" ~ nullability ~ "<" ~ in
 precision_timestamp_type    = { ^"precisiontimestamp"   ~ nullability ~ "<" ~ integer ~ ">" }
 precision_time_type         = { ^"precisiontime"        ~ nullability ~ "<" ~ integer ~ ">" }
 
+// interval_day takes an integer sub-second precision parameter, like the
+// precision timestamp types above.
+// Example: interval_day<6>, interval_day?<9>
+interval_day_type = { ^"interval_day" ~ nullability ~ "<" ~ integer ~ ">" }
+
 // A compound type expression, composed of a name, optional parameters, and optional nullability.
 // Example: LIST?<fp64?>, MAP<i64, string>
-// TODO: interval_day
-compound_type = { list_type | map_type | struct_type | precision_timestamp_tz_type | precision_timestamp_type | precision_time_type }
+compound_type = { list_type | map_type | struct_type | precision_timestamp_tz_type | precision_timestamp_type | precision_time_type | interval_day_type }
 
 // A user-defined type expression. The u! prefix is optional and ignored for lookup purposes;
 // both "json" and "u!json" resolve to the same extension.

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -57,33 +57,6 @@ reference = { "$" ~ integer }
 // Literal
 literal = { (float | integer | boolean | string_literal | null) ~ (":" ~ sp ~ type)? }
 
-// -- interval_day durations --
-//
-// The contents of an `interval_day` literal string, e.g. "5d", "4d 5s",
-// "5d 3s 100ns". A day term, a seconds term, and a sub-second term, in that
-// order; each is optional, but at least one is required, so each unit can
-// appear at most once.
-//
-// This rule is deliberately not referenced from `literal`: the string is
-// unescaped first, then re-parsed with this rule as the start rule. Terms are
-// separated by exactly one space, with no leading or trailing whitespace -
-// literals don't need the looser whitespace the surrounding grammar allows.
-interval_day_duration = {
-    SOI ~ (
-        duration_days ~ (whitespace ~ duration_seconds)? ~ (whitespace ~ duration_subseconds)?
-      | duration_seconds ~ (whitespace ~ duration_subseconds)?
-      | duration_subseconds
-    ) ~ EOI
-}
-
-duration_days       = { integer ~ "d" }
-duration_seconds    = { integer ~ "s" }
-duration_subseconds = { integer ~ subsecond_unit }
-
-// The sub-second units that correspond to a writable `interval_day` precision:
-// ms = 3, us = 6, ns = 9, ps = 12.
-subsecond_unit = { "ms" | "us" | "ns" | "ps" }
-
 // -- Components for types and functions
 anchor     = { "#" ~ sp ~ integer }
 urn_anchor = { "@" ~ sp ~ integer }
@@ -439,3 +412,31 @@ extension_column  = { named_column | reference | expression }
 // - + Ext:BlobStoreRead['path/to/file']
 addendum      = { "+" ~ sp ~ addendum_type ~ ":" ~ name ~ "[" ~ arguments ~ "]" }
 addendum_type = { "Enh" | "Opt" | "Ext" }
+
+
+/////////////// -- interval_day durations Specifications -- ///////////////
+
+// The contents of an `interval_day` literal string, e.g. "5d", "4d 5s",
+// "5d 3s 100ns". A day term, a seconds term, and a sub-second term, in that
+// order; each is optional, but at least one is required, so each unit can
+// appear at most once.
+//
+// This rule is deliberately not referenced from `literal`: the string is
+// unescaped first, then re-parsed with this rule as the start rule. Terms are
+// separated by exactly one space, with no leading or trailing whitespace -
+// literals don't need the looser whitespace the surrounding grammar allows.
+interval_day_duration = {
+    SOI ~ (
+        duration_days ~ (whitespace ~ duration_seconds)? ~ (whitespace ~ duration_subseconds)?
+      | duration_seconds ~ (whitespace ~ duration_subseconds)?
+      | duration_subseconds
+    ) ~ EOI
+}
+
+duration_days       = { integer ~ "d" }
+duration_seconds    = { integer ~ "s" }
+duration_subseconds = { integer ~ subsecond_unit }
+
+// The sub-second units that correspond to a writable `interval_day` precision:
+// ms = 3, us = 6, ns = 9, ps = 12.
+subsecond_unit = { "ms" | "us" | "ns" | "ps" }

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -2,8 +2,10 @@ use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime};
 use substrait::proto::aggregate_rel::Measure;
 use substrait::proto::expression::field_reference::{ReferenceType, RootReference, RootType};
 use substrait::proto::expression::if_then::IfClause;
+use substrait::proto::expression::literal::interval_day_to_second::PrecisionMode;
 use substrait::proto::expression::literal::{
-    interval_day_to_second::PrecisionMode, IntervalDayToSecond, LiteralType, PrecisionTime as LitPrecisionTime, PrecisionTimestamp as LitPrecisionTimestamp,
+    IntervalDayToSecond, LiteralType, PrecisionTime as LitPrecisionTime,
+    PrecisionTimestamp as LitPrecisionTimestamp,
 };
 use substrait::proto::expression::{
     Cast, FieldReference, IfThen, Literal, ReferenceSegment, RexType, ScalarFunction, cast,
@@ -20,7 +22,7 @@ use super::{
 };
 use crate::extensions::SimpleExtensions;
 use crate::extensions::simple::{CompoundName, ExtensionKind};
-use crate::precision::Precision;
+use crate::precision::SupportedPrecision;
 
 /// A field index (e.g., parsed from "$0" -> 0).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -240,15 +242,24 @@ fn to_string_literal(
         Kind::IntervalDay(i) => {
             // Sub-second precision comes from the type ascription, as it does for
             // every other parameterized type: `'5d 100ns':interval_day<9>`. The
-            // grammar requires the parameter, so `precision` is always set here
-            // for text input; a caller-constructed type might not have it.
-            let precision = i.precision.and_then(Precision::new).ok_or_else(|| {
-                MessageParseError::invalid(
-                    "interval_day_literal_type",
-                    value.as_span(),
-                    "interval_day literals require an explicit sub-second precision between 0 and 12, e.g. 'interval_day<6>'",
-                )
-            })?;
+            // grammar requires the parameter, so it is always present for text
+            // input; a caller-constructed type might not have it.
+            //
+            // Unlike the chrono-backed literals, picoseconds are representable
+            // here: `subseconds` is a plain integer count.
+            let precision = i
+                .precision
+                .and_then(SupportedPrecision::from_units)
+                .ok_or_else(|| {
+                    MessageParseError::invalid(
+                        "interval_day_literal_type",
+                        value.as_span(),
+                        format!(
+                            "Invalid precision {} for an interval_day literal; expected one of 0 (seconds), 3 (milliseconds), 6 (microseconds), 9 (nanoseconds), or 12 (picoseconds)",
+                            i.precision.map_or("<unset>".to_string(), |p| p.to_string())
+                        ),
+                    )
+                })?;
             let interval = parse_interval_day_duration(&string_value, precision, value.as_span())?;
             Ok(Literal {
                 literal_type: Some(LiteralType::IntervalDayToSecond(interval)),
@@ -393,26 +404,6 @@ fn parse_timestamp_to_microseconds(
     parse_timestamp_to_precision_units(timestamp_str, 6, "timestamp", span)
 }
 
-#[derive(Debug, Clone, Copy)]
-enum SupportedPrecision {
-    Seconds,      // 0
-    Milliseconds, // 3
-    Microseconds, // 6
-    Nanoseconds,  // 9
-}
-
-impl SupportedPrecision {
-    /// The Substrait precision unit exponent (`0`, `3`, `6`, or `9`).
-    fn units(self) -> i32 {
-        match self {
-            SupportedPrecision::Seconds => 0,
-            SupportedPrecision::Milliseconds => 3,
-            SupportedPrecision::Microseconds => 6,
-            SupportedPrecision::Nanoseconds => 9,
-        }
-    }
-}
-
 /// Convert a `chrono::Duration` to the units implied by `precision`.
 /// Errors if `duration` overflows the target unit's i64 range, or if `duration`
 /// carries a fractional component finer than `precision` can represent (e.g.
@@ -469,6 +460,15 @@ fn duration_to_precision_units(
         // Nanoseconds is the finest precision chrono can represent, so there's
         // no finer fractional component that could be silently dropped here.
         SupportedPrecision::Nanoseconds => duration.num_nanoseconds().ok_or_else(out_of_range),
+        // `check_supported_precision` rejects picoseconds before we get here,
+        // since chrono has no sub-nanosecond resolution to convert into.
+        SupportedPrecision::Picoseconds => Err(MessageParseError::invalid(
+            "precision_literal_unsupported_precision",
+            span,
+            format!(
+                "precision 12 (picoseconds) is not supported for {literal_kind} literals; chrono only supports nanosecond (precision 9) resolution"
+            ),
+        )),
     }
 }
 
@@ -477,29 +477,25 @@ fn check_supported_precision(
     literal_kind: &'static str,
     span: pest::Span,
 ) -> Result<SupportedPrecision, MessageParseError> {
-    match precision {
-        0 => return Ok(SupportedPrecision::Seconds),
-        3 => return Ok(SupportedPrecision::Milliseconds),
-        6 => return Ok(SupportedPrecision::Microseconds),
-        9 => return Ok(SupportedPrecision::Nanoseconds),
-        _ => {}
-    }
-    if precision == 12 {
-        return Err(MessageParseError::invalid(
+    match SupportedPrecision::from_units(precision) {
+        // chrono has no sub-nanosecond resolution, so the literals that go
+        // through it can't represent picoseconds.
+        Some(SupportedPrecision::Picoseconds) => Err(MessageParseError::invalid(
             "precision_literal_unsupported_precision",
             span,
             format!(
                 "precision 12 (picoseconds) is not supported for {literal_kind} literals; chrono only supports nanosecond (precision 9) resolution"
             ),
-        ));
+        )),
+        Some(precision) => Ok(precision),
+        None => Err(MessageParseError::invalid(
+            "precision_literal_invalid_precision",
+            span,
+            format!(
+                "Invalid precision {precision} for a {literal_kind} literal; expected one of 0 (seconds), 3 (milliseconds), 6 (microseconds), or 9 (nanoseconds)"
+            ),
+        )),
     }
-    Err(MessageParseError::invalid(
-        "precision_literal_invalid_precision",
-        span,
-        format!(
-            "Invalid precision {precision} for a {literal_kind} literal; expected one of 0 (seconds), 3 (milliseconds), 6 (microseconds), or 9 (nanoseconds)"
-        ),
-    ))
 }
 
 /// Parse a timestamp string using chrono to a value in the given precision's units since the Unix epoch.
@@ -599,7 +595,7 @@ fn parse_duration_number<T: std::str::FromStr>(
 /// agrees with `precision`.
 fn parse_interval_day_duration(
     duration_str: &str,
-    precision: Precision,
+    precision: SupportedPrecision,
     span: pest::Span,
 ) -> Result<IntervalDayToSecond, MessageParseError> {
     let parsed =
@@ -621,7 +617,7 @@ fn parse_interval_day_duration(
         days: 0,
         seconds: 0,
         subseconds: 0,
-        precision_mode: Some(PrecisionMode::Precision(precision.value())),
+        precision_mode: Some(PrecisionMode::Precision(precision.units())),
     };
 
     for term in pair.into_inner() {
@@ -641,7 +637,7 @@ fn parse_interval_day_duration(
                 iter.done();
 
                 let unit = unit.as_str();
-                let unit_precision = Precision::from_subsecond_unit(unit)
+                let unit_precision = SupportedPrecision::from_subsecond_unit(unit)
                     .expect("the grammar restricts sub-second units to ms/us/ns/ps");
                 // Precision has a single source - the type - so a unit that
                 // disagrees with it is ambiguous rather than redundant.
@@ -1404,9 +1400,6 @@ mod tests {
             ("'-500000000ns':interval_day<9>", 0, 0, -500_000_000, 9),
             // Nullability is written before the precision parameter.
             ("'5d':interval_day?<6>", 5, 0, 0, 6),
-            // A precision with no duration unit is fine as long as there is no
-            // sub-second term to write.
-            ("'5d 3s':interval_day<4>", 5, 3, 0, 4),
             // This crate converts rather than validates, so values outside the
             // Substrait ranges parse as long as the proto fields can hold them.
             ("'3650001d':interval_day<0>", 3_650_001, 0, 0, 0),
@@ -1436,8 +1429,9 @@ mod tests {
             "'5d\t3s':interval_day<0>",
             // The sub-second unit has to agree with the type's precision.
             "'100ns':interval_day<6>",
-            "'100ns':interval_day<4>",
-            // Out-of-range precision is rejected by the type, not the string.
+            // Precisions with no duration unit, so no value can be written at
+            // them; 13 and -1 are also outside the type's own 0..=12 range.
+            "'5d 3s':interval_day<4>",
             "'5d':interval_day<13>",
             "'5d':interval_day<-1>",
             // Values the proto fields cannot hold.

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime};
+use pest::Parser as PestParser;
 use substrait::proto::aggregate_rel::Measure;
 use substrait::proto::expression::field_reference::{ReferenceType, RootReference, RootType};
 use substrait::proto::expression::if_then::IfClause;
@@ -563,54 +564,94 @@ fn parse_time_to_precision_units(
     ))
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum IntervalDayError {
+    /// A term's number overflows the protobuf field that holds it: `days` and
+    /// `seconds` are `i32`, `subseconds` is `i64`.
+    TermOverflow {
+        unit: &'static str,
+        number: String,
+        bits: usize,
+    },
+    /// A sub-second unit that disagrees with the ascribed precision.
+    UnitPrecisionMismatch {
+        unit: &'static str,
+        unit_precision: SupportedPrecision,
+        precision: SupportedPrecision,
+    },
+}
+
+impl std::fmt::Display for IntervalDayError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IntervalDayError::TermOverflow { unit, number, bits } => write!(
+                f,
+                "the '{unit}' term {number} does not fit in a {bits}-bit integer"
+            ),
+            IntervalDayError::UnitPrecisionMismatch {
+                unit,
+                unit_precision,
+                precision,
+            } => write!(
+                f,
+                "the sub-second unit '{unit}' means precision {unit_precision}, but the type is interval_day<{precision}>"
+            ),
+        }
+    }
+}
+
 /// Parse the integer part of a duration term, e.g. the `-5` of `-5d`.
 ///
 /// The grammar guarantees an optionally-signed run of digits, so the only way
 /// this can fail is a value too large for the protobuf field it is stored in.
 fn parse_duration_number<T: std::str::FromStr>(
     number: &str,
-    unit: &str,
-    duration_str: &str,
-    span: pest::Span,
-) -> Result<T, MessageParseError> {
-    number.parse().map_err(|_| {
-        MessageParseError::invalid(
-            "interval_day_duration",
-            span,
-            format!(
-                "Invalid duration '{duration_str}': the '{unit}' term {number} does not fit in a {}-bit integer",
-                std::mem::size_of::<T>() * 8
-            ),
-        )
+    unit: &'static str,
+) -> Result<T, IntervalDayError> {
+    number.parse().map_err(|_| IntervalDayError::TermOverflow {
+        unit,
+        number: number.to_string(),
+        bits: std::mem::size_of::<T>() * 8,
     })
 }
 
 /// Parse the contents of an `interval_day` literal string - e.g. "5d",
 /// "4d 5s", "5d 3s 100ns", "-5d -3s" - into an `IntervalDayToSecond` with the
 /// sub-second precision taken from the literal's type ascription.
-///
-/// The shape of the string is enforced by [`Rule::interval_day_duration`],
-/// which fixes term order and allows each unit at most once, so this only has
-/// to convert the matched terms and check that a sub-second unit, if present,
-/// agrees with `precision`.
 fn parse_interval_day_duration(
     duration_str: &str,
     precision: SupportedPrecision,
     span: pest::Span,
 ) -> Result<IntervalDayToSecond, MessageParseError> {
-    let parsed =
-        <ExpressionParser as pest::Parser<Rule>>::parse(Rule::interval_day_duration, duration_str);
-    let mut pairs = parsed.map_err(|e| {
+    let mut pairs = ExpressionParser::parse(Rule::interval_day_duration, duration_str).map_err(
+        |e| {
+            MessageParseError::invalid(
+                "interval_day_duration",
+                span,
+                format!(
+                    "Invalid duration '{duration_str}': {}. Expected one to three terms, separated by single spaces, in the order days ('d'), seconds ('s'), sub-seconds ('ms', 'us', 'ns', or 'ps'); e.g. '5d', '4d 5s', '5d 3s 100ns'",
+                    e.variant.message()
+                ),
+            )
+        },
+    )?;
+    let pair = pairs.next().expect("interval_day_duration matched");
+
+    interval_day_from_pair(pair, precision).map_err(|e| {
         MessageParseError::invalid(
             "interval_day_duration",
             span,
-            format!(
-                "Invalid duration '{duration_str}': {}. Expected one to three terms, separated by single spaces, in the order days ('d'), seconds ('s'), sub-seconds ('ms', 'us', 'ns', or 'ps'); e.g. '5d', '4d 5s', '5d 3s 100ns'",
-                e.variant.message()
-            ),
+            format!("Invalid duration '{duration_str}': {e}"),
         )
-    })?;
-    let pair = pairs.next().expect("interval_day_duration matched");
+    })
+}
+
+/// Convert a matched [`Rule::interval_day_duration`] into an
+/// `IntervalDayToSecond` at `precision`.
+fn interval_day_from_pair(
+    pair: pest::iterators::Pair<Rule>,
+    precision: SupportedPrecision,
+) -> Result<IntervalDayToSecond, IntervalDayError> {
     assert_eq!(pair.as_rule(), Rule::interval_day_duration);
 
     let mut interval = IntervalDayToSecond {
@@ -624,11 +665,11 @@ fn parse_interval_day_duration(
         match term.as_rule() {
             Rule::duration_days => {
                 let number = unwrap_single_pair(term);
-                interval.days = parse_duration_number(number.as_str(), "d", duration_str, span)?;
+                interval.days = parse_duration_number(number.as_str(), "d")?;
             }
             Rule::duration_seconds => {
                 let number = unwrap_single_pair(term);
-                interval.seconds = parse_duration_number(number.as_str(), "s", duration_str, span)?;
+                interval.seconds = parse_duration_number(number.as_str(), "s")?;
             }
             Rule::duration_subseconds => {
                 let mut iter = RuleIter::from(term.into_inner());
@@ -636,22 +677,21 @@ fn parse_interval_day_duration(
                 let unit = iter.pop(Rule::subsecond_unit);
                 iter.done();
 
-                let unit = unit.as_str();
-                let unit_precision = SupportedPrecision::from_subsecond_unit(unit)
+                let unit_precision = SupportedPrecision::from_subsecond_unit(unit.as_str())
                     .expect("the grammar restricts sub-second units to ms/us/ns/ps");
+                let unit = unit_precision
+                    .subsecond_unit()
+                    .expect("a sub-second precision has a sub-second unit");
                 // Precision has a single source - the type - so a unit that
                 // disagrees with it is ambiguous rather than redundant.
                 if unit_precision != precision {
-                    return Err(MessageParseError::invalid(
-                        "interval_day_duration",
-                        span,
-                        format!(
-                            "Invalid duration '{duration_str}': the sub-second unit '{unit}' means precision {unit_precision}, but the type is interval_day<{precision}>"
-                        ),
-                    ));
+                    return Err(IntervalDayError::UnitPrecisionMismatch {
+                        unit,
+                        unit_precision,
+                        precision,
+                    });
                 }
-                interval.subseconds =
-                    parse_duration_number(number.as_str(), unit, duration_str, span)?;
+                interval.subseconds = parse_duration_number(number.as_str(), unit)?;
             }
             // `interval_day_duration` is anchored with `EOI` so that trailing
             // input is a parse error rather than silently ignored.

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -3,7 +3,7 @@ use substrait::proto::aggregate_rel::Measure;
 use substrait::proto::expression::field_reference::{ReferenceType, RootReference, RootType};
 use substrait::proto::expression::if_then::IfClause;
 use substrait::proto::expression::literal::{
-    LiteralType, PrecisionTime as LitPrecisionTime, PrecisionTimestamp as LitPrecisionTimestamp,
+    interval_day_to_second::PrecisionMode, IntervalDayToSecond, LiteralType, PrecisionTime as LitPrecisionTime, PrecisionTimestamp as LitPrecisionTimestamp,
 };
 use substrait::proto::expression::{
     Cast, FieldReference, IfThen, Literal, ReferenceSegment, RexType, ScalarFunction, cast,
@@ -15,11 +15,12 @@ use substrait::proto::{AggregateFunction, Expression, FunctionArgument, Type};
 
 use super::types::get_and_validate_anchor;
 use super::{
-    MessageParseError, ParsePair, Rule, RuleIter, ScopedParsePair, unescape_string,
-    unwrap_single_pair,
+    ExpressionParser, MessageParseError, ParsePair, Rule, RuleIter, ScopedParsePair,
+    unescape_string, unwrap_single_pair,
 };
 use crate::extensions::SimpleExtensions;
 use crate::extensions::simple::{CompoundName, ExtensionKind};
+use crate::precision::Precision;
 
 /// A field index (e.g., parsed from "$0" -> 0).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -234,6 +235,25 @@ fn to_string_literal(
                 literal_type: Some(LiteralType::Date(date_days)),
                 nullable: d.nullability != Nullability::Required as i32,
                 type_variation_reference: d.type_variation_reference,
+            })
+        }
+        Kind::IntervalDay(i) => {
+            // Sub-second precision comes from the type ascription, as it does for
+            // every other parameterized type: `'5d 100ns':interval_day<9>`. The
+            // grammar requires the parameter, so `precision` is always set here
+            // for text input; a caller-constructed type might not have it.
+            let precision = i.precision.and_then(Precision::new).ok_or_else(|| {
+                MessageParseError::invalid(
+                    "interval_day_literal_type",
+                    value.as_span(),
+                    "interval_day literals require an explicit sub-second precision between 0 and 12, e.g. 'interval_day<6>'",
+                )
+            })?;
+            let interval = parse_interval_day_duration(&string_value, precision, value.as_span())?;
+            Ok(Literal {
+                literal_type: Some(LiteralType::IntervalDayToSecond(interval)),
+                nullable: i.nullability != Nullability::Required as i32,
+                type_variation_reference: i.type_variation_reference,
             })
         }
         #[allow(deprecated)]
@@ -545,6 +565,112 @@ fn parse_time_to_precision_units(
         span,
         format!("Invalid time format: '{time_str}'. Expected HH:MM:SS or HH:MM:SS.fff"),
     ))
+}
+
+/// Parse the integer part of a duration term, e.g. the `-5` of `-5d`.
+///
+/// The grammar guarantees an optionally-signed run of digits, so the only way
+/// this can fail is a value too large for the protobuf field it is stored in.
+fn parse_duration_number<T: std::str::FromStr>(
+    number: &str,
+    unit: &str,
+    duration_str: &str,
+    span: pest::Span,
+) -> Result<T, MessageParseError> {
+    number.parse().map_err(|_| {
+        MessageParseError::invalid(
+            "interval_day_duration",
+            span,
+            format!(
+                "Invalid duration '{duration_str}': the '{unit}' term {number} does not fit in a {}-bit integer",
+                std::mem::size_of::<T>() * 8
+            ),
+        )
+    })
+}
+
+/// Parse the contents of an `interval_day` literal string - e.g. "5d",
+/// "4d 5s", "5d 3s 100ns", "-5d -3s" - into an `IntervalDayToSecond` with the
+/// sub-second precision taken from the literal's type ascription.
+///
+/// The shape of the string is enforced by [`Rule::interval_day_duration`],
+/// which fixes term order and allows each unit at most once, so this only has
+/// to convert the matched terms and check that a sub-second unit, if present,
+/// agrees with `precision`.
+fn parse_interval_day_duration(
+    duration_str: &str,
+    precision: Precision,
+    span: pest::Span,
+) -> Result<IntervalDayToSecond, MessageParseError> {
+    let parsed =
+        <ExpressionParser as pest::Parser<Rule>>::parse(Rule::interval_day_duration, duration_str);
+    let mut pairs = parsed.map_err(|e| {
+        MessageParseError::invalid(
+            "interval_day_duration",
+            span,
+            format!(
+                "Invalid duration '{duration_str}': {}. Expected one to three terms, separated by single spaces, in the order days ('d'), seconds ('s'), sub-seconds ('ms', 'us', 'ns', or 'ps'); e.g. '5d', '4d 5s', '5d 3s 100ns'",
+                e.variant.message()
+            ),
+        )
+    })?;
+    let pair = pairs.next().expect("interval_day_duration matched");
+    assert_eq!(pair.as_rule(), Rule::interval_day_duration);
+
+    let mut interval = IntervalDayToSecond {
+        days: 0,
+        seconds: 0,
+        subseconds: 0,
+        precision_mode: Some(PrecisionMode::Precision(precision.value())),
+    };
+
+    for term in pair.into_inner() {
+        match term.as_rule() {
+            Rule::duration_days => {
+                let number = unwrap_single_pair(term);
+                interval.days = parse_duration_number(number.as_str(), "d", duration_str, span)?;
+            }
+            Rule::duration_seconds => {
+                let number = unwrap_single_pair(term);
+                interval.seconds = parse_duration_number(number.as_str(), "s", duration_str, span)?;
+            }
+            Rule::duration_subseconds => {
+                let mut iter = RuleIter::from(term.into_inner());
+                let number = iter.pop(Rule::integer);
+                let unit = iter.pop(Rule::subsecond_unit);
+                iter.done();
+
+                let unit = unit.as_str();
+                let unit_precision = Precision::from_subsecond_unit(unit)
+                    .expect("the grammar restricts sub-second units to ms/us/ns/ps");
+                // Precision has a single source - the type - so a unit that
+                // disagrees with it is ambiguous rather than redundant.
+                if unit_precision != precision {
+                    return Err(MessageParseError::invalid(
+                        "interval_day_duration",
+                        span,
+                        format!(
+                            "Invalid duration '{duration_str}': the sub-second unit '{unit}' means precision {unit_precision}, but the type is interval_day<{precision}>"
+                        ),
+                    ));
+                }
+                interval.subseconds =
+                    parse_duration_number(number.as_str(), unit, duration_str, span)?;
+            }
+            // `interval_day_duration` is anchored with `EOI` so that trailing
+            // input is a parse error rather than silently ignored.
+            Rule::EOI => {}
+            rule => unreachable!("unexpected rule in interval_day_duration: {rule:?}"),
+        }
+    }
+
+    // TODO: Range validation. Substrait bounds `interval_day` to
+    // [-3,650,000..3,650,000] days and defines `subseconds` as the fraction of a
+    // second below `precision`, but this crate converts rather than validates:
+    // out-of-range values have an unambiguous text form, so parse them and leave
+    // range checking to consumers. The conversions above reject only what the
+    // protobuf fields cannot hold.
+    Ok(interval)
 }
 
 impl ScopedParsePair for Literal {
@@ -1235,6 +1361,117 @@ mod tests {
         let pair = parse_exact(Rule::literal, "'2300-01-01T00:00:00':precisiontimestamp<9>");
         let err = Literal::parse_pair(&extensions, pair).unwrap_err();
         assert!(err.to_string().contains("out of range"));
+    }
+
+    fn parse_interval_day_literal(input: &str) -> Result<IntervalDayToSecond, MessageParseError> {
+        let extensions = SimpleExtensions::default();
+        let pair = parse_exact(Rule::literal, input);
+        let result = Literal::parse_pair(&extensions, pair)?;
+        match result.literal_type {
+            Some(LiteralType::IntervalDayToSecond(interval)) => Ok(interval),
+            other => panic!("Expected IntervalDayToSecond literal type, got: {other:?}"),
+        }
+    }
+
+    fn assert_interval_day(input: &str, days: i32, seconds: i32, subseconds: i64, precision: i32) {
+        let interval = parse_interval_day_literal(input).unwrap();
+        assert_eq!(
+            interval,
+            IntervalDayToSecond {
+                days,
+                seconds,
+                subseconds,
+                precision_mode: Some(PrecisionMode::Precision(precision)),
+            },
+            "input: {input}"
+        );
+    }
+
+    #[test]
+    fn test_parse_interval_day_literals() {
+        for (input, days, seconds, subseconds, precision) in [
+            // Precision comes from the type ascription, so a value with no
+            // sub-second term can still carry a sub-second precision.
+            ("'5d':interval_day<0>", 5, 0, 0, 0),
+            ("'5d':interval_day<9>", 5, 0, 0, 9),
+            ("'4d 5s':interval_day<0>", 4, 5, 0, 0),
+            ("'123ms':interval_day<3>", 0, 0, 123, 3),
+            ("'123456us':interval_day<6>", 0, 0, 123_456, 6),
+            ("'123456789ns':interval_day<9>", 0, 0, 123_456_789, 9),
+            ("'5d 3s 100ns':interval_day<9>", 5, 3, 100, 9),
+            // Each term carries its own sign, matching the separate proto fields.
+            ("'-5d 3s':interval_day<0>", -5, 3, 0, 0),
+            ("'-500000000ns':interval_day<9>", 0, 0, -500_000_000, 9),
+            // Nullability is written before the precision parameter.
+            ("'5d':interval_day?<6>", 5, 0, 0, 6),
+            // A precision with no duration unit is fine as long as there is no
+            // sub-second term to write.
+            ("'5d 3s':interval_day<4>", 5, 3, 0, 4),
+            // This crate converts rather than validates, so values outside the
+            // Substrait ranges parse as long as the proto fields can hold them.
+            ("'3650001d':interval_day<0>", 3_650_001, 0, 0, 0),
+            ("'1000000000ns':interval_day<9>", 0, 0, 1_000_000_000, 9),
+        ] {
+            assert_interval_day(input, days, seconds, subseconds, precision);
+        }
+    }
+
+    #[test]
+    fn test_parse_interval_day_literal_errors() {
+        for input in [
+            // Shape errors, all caught by the interval_day_duration rule.
+            "'':interval_day<0>",
+            "'5x':interval_day<0>",
+            "'5':interval_day<0>",
+            // Each unit may appear at most once...
+            "'5d 3d':interval_day<0>",
+            "'5s 3s':interval_day<0>",
+            "'3ms 5us':interval_day<3>",
+            // ...and terms must be in descending order.
+            "'3s 5d':interval_day<0>",
+            "'100ns 5d 3s':interval_day<9>",
+            // Terms are separated by exactly one space, with none around them.
+            "'5d   3s':interval_day<0>",
+            "'  5d 3s  ':interval_day<0>",
+            "'5d\t3s':interval_day<0>",
+            // The sub-second unit has to agree with the type's precision.
+            "'100ns':interval_day<6>",
+            "'100ns':interval_day<4>",
+            // Out-of-range precision is rejected by the type, not the string.
+            "'5d':interval_day<13>",
+            "'5d':interval_day<-1>",
+            // Values the proto fields cannot hold.
+            "'2200000000s':interval_day<0>",
+            "'99999999999d':interval_day<0>",
+            "'99999999999999999999ns':interval_day<9>",
+        ] {
+            assert!(
+                parse_interval_day_literal(input).is_err(),
+                "expected {input} to fail"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_interval_day_literal_requires_precision() {
+        // Bare `interval_day` has no precision, so it isn't a type name; it falls
+        // through to the user-defined type rule and fails to resolve.
+        let err = parse_interval_day_literal("'5d':interval_day")
+            .expect_err("bare interval_day should not be a known type");
+        assert!(
+            err.to_string().contains("interval_day"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_parse_interval_day_literal_unit_precision_mismatch_message() {
+        let err = parse_interval_day_literal("'100ns':interval_day<6>")
+            .expect_err("a sub-second unit that disagrees with the type should fail");
+        assert!(
+            err.to_string().contains("means precision 9"),
+            "unexpected error: {err}"
+        );
     }
 
     /// Helper function to create a literal boolean expression

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -6,7 +6,6 @@ use super::{ParsePair, Rule, ScopedParsePair, iter_pairs, unwrap_single_pair};
 use crate::extensions::SimpleExtensions;
 use crate::extensions::simple::{ExtensionKind, MissingReference};
 use crate::parser::MessageParseError;
-use crate::precision::Precision;
 
 /// Given a name (plain or compound) and an optional anchor, resolve and
 /// validate the extension anchor.
@@ -198,14 +197,18 @@ fn parse_compound_type(
     }
 }
 
-/// Parse a sub-second precision parameter into a validated [`Precision`].
+/// Parse a sub-second precision type parameter.
+///
+/// Substrait allows any precision from 0 to 12 on a type, so this stays a plain
+/// integer. Narrowing to a precision that a *value* can actually be written at
+/// is [`crate::precision::SupportedPrecision`]'s job, and only literals need it.
 fn parse_precision(
     precision_pair: Pair<Rule>,
     context: &'static str,
-) -> Result<Precision, MessageParseError> {
+) -> Result<i32, MessageParseError> {
     let precision_span = precision_pair.as_span();
-    let value = precision_pair.as_str().parse::<i32>().ok();
-    value.and_then(Precision::new).ok_or_else(|| {
+    let precision = precision_pair.as_str().parse::<i32>().ok();
+    precision.filter(|p| (0..=12).contains(p)).ok_or_else(|| {
         MessageParseError::invalid(
             context,
             precision_span,
@@ -222,7 +225,7 @@ fn parse_precision_type(pair: Pair<Rule>) -> Result<Type, MessageParseError> {
     let mut iter = iter_pairs(pair.into_inner());
     let nullability = iter.parse_next::<Nullability>();
     let precision_pair = iter.pop(Rule::integer);
-    let precision = parse_precision(precision_pair, "precision time type")?.value();
+    let precision = parse_precision(precision_pair, "precision time type")?;
     iter.done();
     let kind = match rule {
         Rule::precision_timestamp_type => {
@@ -254,7 +257,7 @@ fn parse_interval_day_type(pair: Pair<Rule>) -> Result<Type, MessageParseError> 
     let mut iter = iter_pairs(pair.into_inner());
     let nullability = iter.parse_next::<Nullability>();
     let precision_pair = iter.pop(Rule::integer);
-    let precision = parse_precision(precision_pair, "interval day type")?.value();
+    let precision = parse_precision(precision_pair, "interval day type")?;
     iter.done();
     Ok(Type {
         kind: Some(Kind::IntervalDay(proto::r#type::IntervalDay {

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -6,6 +6,7 @@ use super::{ParsePair, Rule, ScopedParsePair, iter_pairs, unwrap_single_pair};
 use crate::extensions::SimpleExtensions;
 use crate::extensions::simple::{ExtensionKind, MissingReference};
 use crate::parser::MessageParseError;
+use crate::precision::Precision;
 
 /// Given a name (plain or compound) and an optional anchor, resolve and
 /// validate the extension anchor.
@@ -192,8 +193,28 @@ fn parse_compound_type(
         Rule::precision_timestamp_tz_type
         | Rule::precision_timestamp_type
         | Rule::precision_time_type => parse_precision_type(inner),
+        Rule::interval_day_type => parse_interval_day_type(inner),
         _ => unimplemented!("{:?}", inner.as_rule()),
     }
+}
+
+/// Parse a sub-second precision parameter into a validated [`Precision`].
+fn parse_precision(
+    precision_pair: Pair<Rule>,
+    context: &'static str,
+) -> Result<Precision, MessageParseError> {
+    let precision_span = precision_pair.as_span();
+    let value = precision_pair.as_str().parse::<i32>().ok();
+    value.and_then(Precision::new).ok_or_else(|| {
+        MessageParseError::invalid(
+            context,
+            precision_span,
+            format!(
+                "precision must be between 0 and 12, got {}",
+                precision_pair.as_str()
+            ),
+        )
+    })
 }
 
 fn parse_precision_type(pair: Pair<Rule>) -> Result<Type, MessageParseError> {
@@ -201,15 +222,7 @@ fn parse_precision_type(pair: Pair<Rule>) -> Result<Type, MessageParseError> {
     let mut iter = iter_pairs(pair.into_inner());
     let nullability = iter.parse_next::<Nullability>();
     let precision_pair = iter.pop(Rule::integer);
-    let precision_span = precision_pair.as_span();
-    let precision = precision_pair.as_str().parse::<i32>().unwrap();
-    if !(0..=12).contains(&precision) {
-        return Err(MessageParseError::invalid(
-            "precision time type",
-            precision_span,
-            format!("precision must be between 0 and 12, got {precision}"),
-        ));
-    }
+    let precision = parse_precision(precision_pair, "precision time type")?.value();
     iter.done();
     let kind = match rule {
         Rule::precision_timestamp_type => {
@@ -234,6 +247,22 @@ fn parse_precision_type(pair: Pair<Rule>) -> Result<Type, MessageParseError> {
         _ => unreachable!("parse_precision_type called with rule {:?}", rule),
     };
     Ok(Type { kind: Some(kind) })
+}
+
+fn parse_interval_day_type(pair: Pair<Rule>) -> Result<Type, MessageParseError> {
+    assert_eq!(pair.as_rule(), Rule::interval_day_type);
+    let mut iter = iter_pairs(pair.into_inner());
+    let nullability = iter.parse_next::<Nullability>();
+    let precision_pair = iter.pop(Rule::integer);
+    let precision = parse_precision(precision_pair, "interval day type")?.value();
+    iter.done();
+    Ok(Type {
+        kind: Some(Kind::IntervalDay(proto::r#type::IntervalDay {
+            nullability: nullability.into(),
+            type_variation_reference: 0,
+            precision: Some(precision),
+        })),
+    })
 }
 
 fn parse_list_type(
@@ -412,6 +441,40 @@ mod tests {
                 })))
             }
         );
+    }
+
+    #[test]
+    fn test_parse_interval_day_type() {
+        for (input, nullability, precision) in [
+            ("interval_day<9>", Nullability::Required, 9),
+            ("interval_day?<6>", Nullability::Nullable, 6),
+        ] {
+            let mut pairs = ExpressionParser::parse(Rule::interval_day_type, input).unwrap();
+            let pair = pairs.next().unwrap();
+            assert_eq!(pairs.next(), None);
+            let t = parse_interval_day_type(pair).unwrap();
+            assert_eq!(
+                t,
+                Type {
+                    kind: Some(Kind::IntervalDay(proto::r#type::IntervalDay {
+                        nullability: nullability as i32,
+                        type_variation_reference: 0,
+                        precision: Some(precision),
+                    })),
+                },
+                "input: {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_interval_day_type_invalid_precision() {
+        for input in ["interval_day<13>", "interval_day<-1>"] {
+            let mut pairs = ExpressionParser::parse(Rule::interval_day_type, input).unwrap();
+            let pair = pairs.next().unwrap();
+            assert_eq!(pairs.next(), None);
+            assert!(parse_interval_day_type(pair).is_err(), "input: {input}");
+        }
     }
 
     #[test]

--- a/src/precision.rs
+++ b/src/precision.rs
@@ -1,0 +1,89 @@
+//! Sub-second precision, shared by the Substrait types that carry one.
+
+use std::fmt;
+
+/// The number of decimal digits used to express fractions of a second.
+///
+/// Substrait restricts precision to `0..=12` — seconds through picoseconds —
+/// for every type that carries one (`Type.IntervalDay.precision`,
+/// `Type.PrecisionTimestamp.precision`, `Type.PrecisionTime.precision`).
+/// Constructing a `Precision` checks that range once, so code holding one does
+/// not need to re-validate it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct Precision(i32);
+
+impl Precision {
+    /// The inclusive range Substrait allows for a precision value.
+    const RANGE: std::ops::RangeInclusive<i32> = 0..=12;
+
+    /// Microsecond precision, which Substrait uses as the meaning of interval
+    /// values recorded before `precision` existed.
+    pub const MICROSECONDS: Precision = Precision(6);
+
+    /// Returns `None` if `value` is outside Substrait's `0..=12` range.
+    pub fn new(value: i32) -> Option<Self> {
+        Self::RANGE.contains(&value).then_some(Precision(value))
+    }
+
+    /// The precision as the integer Substrait stores.
+    pub fn value(self) -> i32 {
+        self.0
+    }
+
+    /// The duration-string unit that expresses sub-seconds at this precision.
+    ///
+    /// Only the precisions that name a unit can carry a non-zero sub-second
+    /// term in an `interval_day` literal; e.g. at precision 4 there is no way
+    /// to write "1/10,000 of a second" as a duration term.
+    pub fn subsecond_unit(self) -> Option<&'static str> {
+        match self.0 {
+            3 => Some("ms"),
+            6 => Some("us"),
+            9 => Some("ns"),
+            12 => Some("ps"),
+            _ => None,
+        }
+    }
+
+    /// The precision implied by a duration-string sub-second unit.
+    pub fn from_subsecond_unit(unit: &str) -> Option<Self> {
+        match unit {
+            "ms" => Some(Precision(3)),
+            "us" => Some(Precision(6)),
+            "ns" => Some(Precision(9)),
+            "ps" => Some(Precision(12)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for Precision {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_precision_range() {
+        assert_eq!(Precision::new(0).map(Precision::value), Some(0));
+        assert_eq!(Precision::new(12).map(Precision::value), Some(12));
+        assert_eq!(Precision::new(-1), None);
+        assert_eq!(Precision::new(13), None);
+    }
+
+    #[test]
+    fn test_subsecond_unit_roundtrip() {
+        for unit in ["ms", "us", "ns", "ps"] {
+            let precision = Precision::from_subsecond_unit(unit).unwrap();
+            assert_eq!(precision.subsecond_unit(), Some(unit));
+        }
+        // Precisions that don't land on a unit boundary have no unit.
+        assert_eq!(Precision::new(0).unwrap().subsecond_unit(), None);
+        assert_eq!(Precision::new(4).unwrap().subsecond_unit(), None);
+        assert_eq!(Precision::from_subsecond_unit("s"), None);
+    }
+}

--- a/src/precision.rs
+++ b/src/precision.rs
@@ -1,65 +1,78 @@
-//! Sub-second precision, shared by the Substrait types that carry one.
+//! Sub-second precision for literal values, shared by the parser and textifier.
 
 use std::fmt;
 
-/// The number of decimal digits used to express fractions of a second.
+/// A sub-second precision that names a unit: the decimal exponent Substrait
+/// stores, and the duration suffix that writes it.
 ///
-/// Substrait restricts precision to `0..=12` — seconds through picoseconds —
-/// for every type that carries one (`Type.IntervalDay.precision`,
-/// `Type.PrecisionTimestamp.precision`, `Type.PrecisionTime.precision`).
-/// Constructing a `Precision` checks that range once, so code holding one does
-/// not need to re-validate it.
+/// Substrait allows any precision from 0 to 12 on a *type*, but a literal
+/// *value* has to be written down, and only these five have a unit to write it
+/// in. Constructing a `SupportedPrecision` checks that once, so code holding one
+/// can convert without re-checking.
+///
+/// Not every literal supports every variant: `chrono`-backed literals
+/// (timestamp, time) top out at nanoseconds, so they reject `Picoseconds`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct Precision(i32);
+pub(crate) enum SupportedPrecision {
+    Seconds,      // 0
+    Milliseconds, // 3
+    Microseconds, // 6
+    Nanoseconds,  // 9
+    Picoseconds,  // 12
+}
 
-impl Precision {
-    /// The inclusive range Substrait allows for a precision value.
-    const RANGE: std::ops::RangeInclusive<i32> = 0..=12;
-
-    /// Microsecond precision, which Substrait uses as the meaning of interval
-    /// values recorded before `precision` existed.
-    pub const MICROSECONDS: Precision = Precision(6);
-
-    /// Returns `None` if `value` is outside Substrait's `0..=12` range.
-    pub fn new(value: i32) -> Option<Self> {
-        Self::RANGE.contains(&value).then_some(Precision(value))
+impl SupportedPrecision {
+    /// The Substrait precision unit exponent (`0`, `3`, `6`, `9`, or `12`).
+    pub fn units(self) -> i32 {
+        match self {
+            SupportedPrecision::Seconds => 0,
+            SupportedPrecision::Milliseconds => 3,
+            SupportedPrecision::Microseconds => 6,
+            SupportedPrecision::Nanoseconds => 9,
+            SupportedPrecision::Picoseconds => 12,
+        }
     }
 
-    /// The precision as the integer Substrait stores.
-    pub fn value(self) -> i32 {
-        self.0
-    }
-
-    /// The duration-string unit that expresses sub-seconds at this precision.
-    ///
-    /// Only the precisions that name a unit can carry a non-zero sub-second
-    /// term in an `interval_day` literal; e.g. at precision 4 there is no way
-    /// to write "1/10,000 of a second" as a duration term.
-    pub fn subsecond_unit(self) -> Option<&'static str> {
-        match self.0 {
-            3 => Some("ms"),
-            6 => Some("us"),
-            9 => Some("ns"),
-            12 => Some("ps"),
+    /// Returns `None` for a precision with no unit to write it in.
+    pub fn from_units(units: i32) -> Option<Self> {
+        match units {
+            0 => Some(SupportedPrecision::Seconds),
+            3 => Some(SupportedPrecision::Milliseconds),
+            6 => Some(SupportedPrecision::Microseconds),
+            9 => Some(SupportedPrecision::Nanoseconds),
+            12 => Some(SupportedPrecision::Picoseconds),
             _ => None,
         }
     }
 
-    /// The precision implied by a duration-string sub-second unit.
+    /// The duration-string suffix for sub-seconds at this precision.
+    ///
+    /// `Seconds` has none: at precision 0 there is no sub-second component.
+    pub fn subsecond_unit(self) -> Option<&'static str> {
+        match self {
+            SupportedPrecision::Seconds => None,
+            SupportedPrecision::Milliseconds => Some("ms"),
+            SupportedPrecision::Microseconds => Some("us"),
+            SupportedPrecision::Nanoseconds => Some("ns"),
+            SupportedPrecision::Picoseconds => Some("ps"),
+        }
+    }
+
+    /// The precision implied by a duration-string sub-second suffix.
     pub fn from_subsecond_unit(unit: &str) -> Option<Self> {
         match unit {
-            "ms" => Some(Precision(3)),
-            "us" => Some(Precision(6)),
-            "ns" => Some(Precision(9)),
-            "ps" => Some(Precision(12)),
+            "ms" => Some(SupportedPrecision::Milliseconds),
+            "us" => Some(SupportedPrecision::Microseconds),
+            "ns" => Some(SupportedPrecision::Nanoseconds),
+            "ps" => Some(SupportedPrecision::Picoseconds),
             _ => None,
         }
     }
 }
 
-impl fmt::Display for Precision {
+impl fmt::Display for SupportedPrecision {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.units())
     }
 }
 
@@ -68,22 +81,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_precision_range() {
-        assert_eq!(Precision::new(0).map(Precision::value), Some(0));
-        assert_eq!(Precision::new(12).map(Precision::value), Some(12));
-        assert_eq!(Precision::new(-1), None);
-        assert_eq!(Precision::new(13), None);
+    fn test_units_roundtrip() {
+        for units in [0, 3, 6, 9, 12] {
+            let precision = SupportedPrecision::from_units(units).unwrap();
+            assert_eq!(precision.units(), units);
+        }
+        // In range for a type, but with no unit to write a value in.
+        assert_eq!(SupportedPrecision::from_units(4), None);
+        assert_eq!(SupportedPrecision::from_units(13), None);
+        assert_eq!(SupportedPrecision::from_units(-1), None);
     }
 
     #[test]
     fn test_subsecond_unit_roundtrip() {
         for unit in ["ms", "us", "ns", "ps"] {
-            let precision = Precision::from_subsecond_unit(unit).unwrap();
+            let precision = SupportedPrecision::from_subsecond_unit(unit).unwrap();
             assert_eq!(precision.subsecond_unit(), Some(unit));
         }
-        // Precisions that don't land on a unit boundary have no unit.
-        assert_eq!(Precision::new(0).unwrap().subsecond_unit(), None);
-        assert_eq!(Precision::new(4).unwrap().subsecond_unit(), None);
-        assert_eq!(Precision::from_subsecond_unit("s"), None);
+        // Precision 0 has no sub-second component, and "s" is not one.
+        assert_eq!(SupportedPrecision::Seconds.subsecond_unit(), None);
+        assert_eq!(SupportedPrecision::from_subsecond_unit("s"), None);
     }
 }

--- a/src/textify/expressions.rs
+++ b/src/textify/expressions.rs
@@ -3,8 +3,8 @@ use std::fmt::{self};
 use chrono::{DateTime, NaiveDate, NaiveTime};
 use expr::RexType;
 use substrait::proto::expression::field_reference::{ReferenceType, RootReference, RootType};
-use substrait::proto::expression::literal::LiteralType;
 use substrait::proto::expression::literal::interval_day_to_second::PrecisionMode;
+use substrait::proto::expression::literal::{IntervalDayToSecond, LiteralType};
 use substrait::proto::expression::{
     Cast, FieldReference, IfThen, ReferenceSegment, ScalarFunction, cast, reference_segment,
 };
@@ -197,9 +197,7 @@ fn precision_time_to_string(value: i64, precision: i32) -> Result<String, Precis
 /// also means microseconds: that is Substrait's documented meaning for interval
 /// values recorded before `precision_mode` existed, and it matches the default
 /// the type textifier uses for `Type.IntervalDay` with no precision.
-fn interval_day_precision_units(
-    interval: &substrait::proto::expression::literal::IntervalDayToSecond,
-) -> (i32, i64) {
+fn interval_day_precision_units(interval: &IntervalDayToSecond) -> (i32, i64) {
     #[allow(deprecated)]
     match interval.precision_mode {
         Some(PrecisionMode::Precision(p)) => (p, interval.subseconds),
@@ -209,7 +207,7 @@ fn interval_day_precision_units(
 }
 
 fn write_interval_day_to_second_literal<S: Scope, W: fmt::Write>(
-    interval: &substrait::proto::expression::literal::IntervalDayToSecond,
+    interval: &IntervalDayToSecond,
     ctx: &S,
     w: &mut W,
 ) -> fmt::Result {

--- a/src/textify/expressions.rs
+++ b/src/textify/expressions.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::fmt::{self};
 
 use chrono::{DateTime, NaiveDate, NaiveTime};
@@ -16,7 +15,7 @@ use substrait::proto::{
 
 use super::{PlanError, Scope, Textify, Visibility};
 use crate::extensions::simple::ExtensionKind;
-use crate::precision::Precision;
+use crate::precision::SupportedPrecision;
 use crate::textify::types::{Name, NamedAnchor, OutputType, escaped};
 
 // …(…) for function call
@@ -154,7 +153,7 @@ fn fractional_spec(precision: i32) -> &'static str {
 
 /// Convert a value in precision units since the Unix epoch, to a timestamp string.
 /// Errors if `value` is out of chrono's representable date range.
-fn precision_epoch_timestamp_to_string(
+fn precision_timestamp_to_string(
     value: i64,
     precision: i32,
 ) -> Result<String, PrecisionFormatError> {
@@ -176,7 +175,7 @@ fn precision_epoch_timestamp_to_string(
 /// it: at precision 12, `duration_from_precision_units` truncates towards zero,
 /// so a small negative `value` (e.g. `-1`) would otherwise round to a
 /// zero/non-negative duration and be wrongly accepted.
-fn interval_day_to_string(value: i64, precision: i32) -> Result<String, PrecisionFormatError> {
+fn precision_time_to_string(value: i64, precision: i32) -> Result<String, PrecisionFormatError> {
     if value < 0 {
         return Err(PrecisionFormatError::OutOfRange);
     }
@@ -191,44 +190,31 @@ fn interval_day_to_string(value: i64, precision: i32) -> Result<String, Precisio
     Ok(time.format(&format).to_string())
 }
 
-/// The sub-second precision and sub-second count of an `IntervalDayToSecond`.
+/// The precision and sub-second count of an `IntervalDayToSecond`, as stored.
 ///
 /// The deprecated `microseconds` precision mode is normalized to precision 6,
 /// since that field is microseconds by definition. An unset `precision_mode`
 /// also means microseconds: that is Substrait's documented meaning for interval
 /// values recorded before `precision_mode` existed, and it matches the default
 /// the type textifier uses for `Type.IntervalDay` with no precision.
-///
-/// Returns `None` when the stored precision is outside Substrait's `0..=12`
-/// range, which has no valid text form.
-fn interval_day_precision_and_subseconds(
+fn interval_day_precision_units(
     interval: &substrait::proto::expression::literal::IntervalDayToSecond,
-) -> Option<(Precision, i64)> {
+) -> (i32, i64) {
     #[allow(deprecated)]
-    let (precision, subseconds) = match interval.precision_mode {
-        Some(PrecisionMode::Precision(p)) => (Precision::new(p), interval.subseconds),
-        Some(PrecisionMode::Microseconds(us)) => (Some(Precision::MICROSECONDS), us as i64),
-        None => (Some(Precision::MICROSECONDS), interval.subseconds),
-    };
-    precision.map(|p| (p, subseconds))
+    match interval.precision_mode {
+        Some(PrecisionMode::Precision(p)) => (p, interval.subseconds),
+        Some(PrecisionMode::Microseconds(us)) => (6, us as i64),
+        None => (6, interval.subseconds),
+    }
 }
 
-/// Write an `IntervalDayToSecond` as a duration string, e.g. `'5d'`,
-/// `'4d 5s'`, `'5d 3s 100ns'`.
-///
-/// Only non-zero components are written; the sub-second precision travels in the
-/// literal's `interval_day<precision>` type suffix, so it survives a round trip
-/// without needing a zero sub-second term. An all-zero interval is written
-/// `'0s'`.
-///
-/// Values outside the Substrait ranges still have an unambiguous text form, so
-/// they are written as-is with an error pushed to the error accumulator.
 fn write_interval_day_to_second_literal<S: Scope, W: fmt::Write>(
     interval: &substrait::proto::expression::literal::IntervalDayToSecond,
     ctx: &S,
     w: &mut W,
 ) -> fmt::Result {
-    let Some((precision, subseconds)) = interval_day_precision_and_subseconds(interval) else {
+    let (units, subseconds) = interval_day_precision_units(interval);
+    let Some(precision) = SupportedPrecision::from_units(units) else {
         return write!(
             w,
             "{}",
@@ -236,8 +222,7 @@ fn write_interval_day_to_second_literal<S: Scope, W: fmt::Write>(
                 "LiteralType",
                 Some("IntervalDayToSecond.precision"),
                 format!(
-                    "IntervalDayToSecond precision {:?} is outside the Substrait range of 0 to 12",
-                    interval.precision_mode
+                    "IntervalDayToSecond precision {units} has no duration unit to write it in; expected one of 0, 3, 6, 9, or 12"
                 ),
             ))
         );
@@ -272,8 +257,8 @@ fn write_interval_day_to_second_literal<S: Scope, W: fmt::Write>(
         parts.push(format!("{}s", interval.seconds));
     }
     if subseconds != 0 {
-        // A precision that doesn't land on a unit boundary (e.g. 4) has no way
-        // to spell a sub-second term, so there is no text form to fall back to.
+        // Precision 0 has no sub-second component at all, so there is no term to
+        // write a non-zero `subseconds` as.
         let Some(unit) = precision.subsecond_unit() else {
             return write!(
                 w,
@@ -282,7 +267,7 @@ fn write_interval_day_to_second_literal<S: Scope, W: fmt::Write>(
                     "LiteralType",
                     Some("IntervalDayToSecond.subseconds"),
                     format!(
-                        "IntervalDayToSecond subseconds ({subseconds}) cannot be written at precision {precision}; only precisions 3, 6, 9, and 12 have a duration unit"
+                        "IntervalDayToSecond subseconds ({subseconds}) must be 0 at precision 0; there is no sub-second unit to write it in"
                     ),
                 ))
             );
@@ -291,7 +276,7 @@ fn write_interval_day_to_second_literal<S: Scope, W: fmt::Write>(
         // `subseconds` is the fraction of a second below `precision`, so whole
         // seconds belong in the `seconds` field. Still writable, so report and
         // keep going.
-        let subsecond_bound = 10_i64.pow(precision.value() as u32);
+        let subsecond_bound = 10_i64.pow(precision.units() as u32);
         if subseconds <= -subsecond_bound || subseconds >= subsecond_bound {
             ctx.push_error(
                 PlanError::invalid(
@@ -341,7 +326,7 @@ fn write_literal_value<S: Scope, W: fmt::Write>(
         LiteralType::Time(microseconds) => write_precision_literal(
             "Time",
             6,
-            precision_epoch_timestamp_to_string(*microseconds, 6),
+            precision_time_to_string(*microseconds, 6),
             ctx,
             w,
         ),
@@ -349,7 +334,7 @@ fn write_literal_value<S: Scope, W: fmt::Write>(
         LiteralType::Timestamp(microseconds) => write_precision_literal(
             "Timestamp",
             6,
-            precision_epoch_timestamp_to_string(*microseconds, 6),
+            precision_timestamp_to_string(*microseconds, 6),
             ctx,
             w,
         ),
@@ -365,21 +350,21 @@ fn write_literal_value<S: Scope, W: fmt::Write>(
         LiteralType::PrecisionTime(p) => write_precision_literal(
             "PrecisionTime",
             p.precision,
-            precision_epoch_timestamp_to_string(p.value, p.precision),
+            precision_time_to_string(p.value, p.precision),
             ctx,
             w,
         ),
         LiteralType::PrecisionTimestamp(p) => write_precision_literal(
             "PrecisionTimestamp",
             p.precision,
-            precision_epoch_timestamp_to_string(p.value, p.precision),
+            precision_timestamp_to_string(p.value, p.precision),
             ctx,
             w,
         ),
         LiteralType::PrecisionTimestampTz(p) => write_precision_literal(
             "PrecisionTimestampTz",
             p.precision,
-            precision_epoch_timestamp_to_string(p.value, p.precision),
+            precision_timestamp_to_string(p.value, p.precision),
             ctx,
             w,
         ),
@@ -427,6 +412,12 @@ fn write_literal_type_suffix<W: fmt::Write>(
         LiteralType::PrecisionTimestamp(p) => ("precisiontimestamp", Some(p.precision)),
         LiteralType::PrecisionTimestampTz(p) => ("precisiontimestamptz", Some(p.precision)),
         LiteralType::PrecisionTime(p) => ("precisiontime", Some(p.precision)),
+        // interval_day carries the value's sub-second precision, so the duration
+        // string doesn't have to encode it.
+        LiteralType::IntervalDayToSecond(interval) => (
+            "interval_day",
+            Some(interval_day_precision_units(interval).0),
+        ),
         _ => return Ok(()),
     };
 
@@ -989,9 +980,6 @@ mod tests {
             // An all-zero interval still needs a term to be a valid duration.
             (interval_day_literal(0, 0, 0, 0), "'0s':interval_day<0>"),
             (interval_day_literal(0, 0, 0, 9), "'0s':interval_day<9>"),
-            // A precision with no duration unit round-trips as long as there is
-            // no sub-second value to write.
-            (interval_day_literal(5, 0, 0, 4), "'5d':interval_day<4>"),
         ] {
             assert_eq!(ctx.textify_no_errors(&literal), expected);
         }
@@ -1047,14 +1035,15 @@ mod tests {
     #[test]
     fn test_interval_day_literal_textify_invalid_precision_is_error() {
         let ctx = TestContext::new();
-        // A precision outside 0..=12 has no valid text form at all, so there is
-        // nothing to write but an error token.
-        for precision in [-1, 13] {
+        // A precision with no duration unit has no way to write a sub-second
+        // value. Only the value becomes an error token; the suffix still reports
+        // the precision that was actually stored.
+        for precision in [4, 13, -1] {
             let literal = interval_day_literal(0, 0, 2, precision);
 
             let (text, errors) = ctx.textify(&literal);
 
-            assert_eq!(text, "!{LiteralType}");
+            assert_eq!(text, format!("!{{LiteralType}}:interval_day<{precision}>"));
             match errors.first() {
                 FormatError::Format(e) => {
                     assert_eq!(e.error_type, FormatErrorType::InvalidValue);
@@ -1066,16 +1055,15 @@ mod tests {
     }
 
     #[test]
-    fn test_interval_day_literal_textify_subseconds_without_unit_is_error() {
+    fn test_interval_day_literal_textify_subseconds_at_precision_zero_is_error() {
         let ctx = TestContext::new();
-        // Precision 4 is in range but has no duration unit, so a non-zero
-        // sub-second value has no text form. Only the value is replaced with an
-        // error token; the type suffix is still accurate.
-        let literal = interval_day_literal(0, 0, 2, 4);
+        // Precision 0 has no sub-second component, so a non-zero `subseconds`
+        // is invalid Substrait with no term to write it in.
+        let literal = interval_day_literal(0, 0, 2, 0);
 
         let (text, errors) = ctx.textify(&literal);
 
-        assert_eq!(text, "!{LiteralType}:interval_day<4>");
+        assert_eq!(text, "!{LiteralType}:interval_day<0>");
         match errors.first() {
             FormatError::Format(e) => {
                 assert_eq!(e.error_type, FormatErrorType::InvalidValue);
@@ -1176,49 +1164,49 @@ mod tests {
     #[test]
     fn test_precision_timestamp_to_string() {
         assert_eq!(
-            precision_epoch_timestamp_to_string(10, 0),
+            precision_timestamp_to_string(10, 0),
             Ok("1970-01-01T00:00:10".to_string())
         );
         assert_eq!(
-            precision_epoch_timestamp_to_string(123_456_789, 9),
+            precision_timestamp_to_string(123_456_789, 9),
             Ok("1970-01-01T00:00:00.123456789".to_string())
         );
         // Precision 12 (picoseconds) is truncated to nanoseconds (best-effort):
         // the trailing 500 picoseconds below don't survive.
         assert_eq!(
-            precision_epoch_timestamp_to_string(123_456_789_500, 12),
+            precision_timestamp_to_string(123_456_789_500, 12),
             Ok("1970-01-01T00:00:00.123456789".to_string())
         );
         assert_eq!(
-            precision_epoch_timestamp_to_string(0, 13),
+            precision_timestamp_to_string(0, 13),
             Err(PrecisionFormatError::UnsupportedPrecision)
         );
     }
 
     #[test]
     fn test_precision_time_to_string() {
-        assert_eq!(precision_epoch_timestamp_to_string(0, 0), Ok("00:00:00".to_string()));
+        assert_eq!(precision_time_to_string(0, 0), Ok("00:00:00".to_string()));
         assert_eq!(
             // 01:01:01 = 3661 seconds, in microseconds. The fractional part is
             // rendered at the declared precision width (6 digits).
-            precision_epoch_timestamp_to_string(3_661_000_000, 6),
+            precision_time_to_string(3_661_000_000, 6),
             Ok("01:01:01.000000".to_string())
         );
         assert_eq!(
             // 01:01:01 = 3661 seconds, in picoseconds, plus 500 ps that get
             // truncated away. Precision 12 renders at nanosecond width (9 digits).
-            precision_epoch_timestamp_to_string(3_661_000_000_000_500, 12),
+            precision_time_to_string(3_661_000_000_000_500, 12),
             Ok("01:01:01.000000000".to_string())
         );
         assert_eq!(
-            precision_epoch_timestamp_to_string(0, 13),
+            precision_time_to_string(0, 13),
             Err(PrecisionFormatError::UnsupportedPrecision)
         );
         // A negative value at precision 12 truncates towards zero when converted
         // to a `chrono::Duration` (-1 / 1000 == 0), so the sign must be checked
         // on the raw value, not the derived duration.
         assert_eq!(
-            precision_epoch_timestamp_to_string(-1, 12),
+            precision_time_to_string(-1, 12),
             Err(PrecisionFormatError::OutOfRange)
         );
     }

--- a/src/textify/expressions.rs
+++ b/src/textify/expressions.rs
@@ -1,9 +1,11 @@
+use std::borrow::Cow;
 use std::fmt::{self};
 
 use chrono::{DateTime, NaiveDate, NaiveTime};
 use expr::RexType;
 use substrait::proto::expression::field_reference::{ReferenceType, RootReference, RootType};
 use substrait::proto::expression::literal::LiteralType;
+use substrait::proto::expression::literal::interval_day_to_second::PrecisionMode;
 use substrait::proto::expression::{
     Cast, FieldReference, IfThen, ReferenceSegment, ScalarFunction, cast, reference_segment,
 };
@@ -14,6 +16,7 @@ use substrait::proto::{
 
 use super::{PlanError, Scope, Textify, Visibility};
 use crate::extensions::simple::ExtensionKind;
+use crate::precision::Precision;
 use crate::textify::types::{Name, NamedAnchor, OutputType, escaped};
 
 // …(…) for function call
@@ -151,7 +154,7 @@ fn fractional_spec(precision: i32) -> &'static str {
 
 /// Convert a value in precision units since the Unix epoch, to a timestamp string.
 /// Errors if `value` is out of chrono's representable date range.
-fn precision_timestamp_to_string(
+fn precision_epoch_timestamp_to_string(
     value: i64,
     precision: i32,
 ) -> Result<String, PrecisionFormatError> {
@@ -173,7 +176,7 @@ fn precision_timestamp_to_string(
 /// it: at precision 12, `duration_from_precision_units` truncates towards zero,
 /// so a small negative `value` (e.g. `-1`) would otherwise round to a
 /// zero/non-negative duration and be wrongly accepted.
-fn precision_time_to_string(value: i64, precision: i32) -> Result<String, PrecisionFormatError> {
+fn interval_day_to_string(value: i64, precision: i32) -> Result<String, PrecisionFormatError> {
     if value < 0 {
         return Err(PrecisionFormatError::OutOfRange);
     }
@@ -186,6 +189,132 @@ fn precision_time_to_string(value: i64, precision: i32) -> Result<String, Precis
 
     let format = format!("%H:%M:%S{}", fractional_spec(precision));
     Ok(time.format(&format).to_string())
+}
+
+/// The sub-second precision and sub-second count of an `IntervalDayToSecond`.
+///
+/// The deprecated `microseconds` precision mode is normalized to precision 6,
+/// since that field is microseconds by definition. An unset `precision_mode`
+/// also means microseconds: that is Substrait's documented meaning for interval
+/// values recorded before `precision_mode` existed, and it matches the default
+/// the type textifier uses for `Type.IntervalDay` with no precision.
+///
+/// Returns `None` when the stored precision is outside Substrait's `0..=12`
+/// range, which has no valid text form.
+fn interval_day_precision_and_subseconds(
+    interval: &substrait::proto::expression::literal::IntervalDayToSecond,
+) -> Option<(Precision, i64)> {
+    #[allow(deprecated)]
+    let (precision, subseconds) = match interval.precision_mode {
+        Some(PrecisionMode::Precision(p)) => (Precision::new(p), interval.subseconds),
+        Some(PrecisionMode::Microseconds(us)) => (Some(Precision::MICROSECONDS), us as i64),
+        None => (Some(Precision::MICROSECONDS), interval.subseconds),
+    };
+    precision.map(|p| (p, subseconds))
+}
+
+/// Write an `IntervalDayToSecond` as a duration string, e.g. `'5d'`,
+/// `'4d 5s'`, `'5d 3s 100ns'`.
+///
+/// Only non-zero components are written; the sub-second precision travels in the
+/// literal's `interval_day<precision>` type suffix, so it survives a round trip
+/// without needing a zero sub-second term. An all-zero interval is written
+/// `'0s'`.
+///
+/// Values outside the Substrait ranges still have an unambiguous text form, so
+/// they are written as-is with an error pushed to the error accumulator.
+fn write_interval_day_to_second_literal<S: Scope, W: fmt::Write>(
+    interval: &substrait::proto::expression::literal::IntervalDayToSecond,
+    ctx: &S,
+    w: &mut W,
+) -> fmt::Result {
+    let Some((precision, subseconds)) = interval_day_precision_and_subseconds(interval) else {
+        return write!(
+            w,
+            "{}",
+            ctx.failure(PlanError::invalid(
+                "LiteralType",
+                Some("IntervalDayToSecond.precision"),
+                format!(
+                    "IntervalDayToSecond precision {:?} is outside the Substrait range of 0 to 12",
+                    interval.precision_mode
+                ),
+            ))
+        );
+    };
+
+    // Substrait bounds interval_day to [-3,650,000..3,650,000] days, both for
+    // `days` alone and for `days` and `seconds` combined. Out-of-range values
+    // are still writable, so report them and keep going.
+    const MAX_DAYS: i64 = 3_650_000;
+    let total_seconds = interval.days as i64 * 86_400 + interval.seconds as i64;
+    if !(-MAX_DAYS..=MAX_DAYS).contains(&(interval.days as i64))
+        || !(-MAX_DAYS * 86_400..=MAX_DAYS * 86_400).contains(&total_seconds)
+    {
+        ctx.push_error(
+            PlanError::invalid(
+                "LiteralType",
+                Some("IntervalDayToSecond.days"),
+                format!(
+                    "IntervalDayToSecond days ({}) and seconds ({}) exceed the Substrait maximum of {MAX_DAYS} days",
+                    interval.days, interval.seconds
+                ),
+            )
+            .into(),
+        );
+    }
+
+    let mut parts = Vec::new();
+    if interval.days != 0 {
+        parts.push(format!("{}d", interval.days));
+    }
+    if interval.seconds != 0 {
+        parts.push(format!("{}s", interval.seconds));
+    }
+    if subseconds != 0 {
+        // A precision that doesn't land on a unit boundary (e.g. 4) has no way
+        // to spell a sub-second term, so there is no text form to fall back to.
+        let Some(unit) = precision.subsecond_unit() else {
+            return write!(
+                w,
+                "{}",
+                ctx.failure(PlanError::invalid(
+                    "LiteralType",
+                    Some("IntervalDayToSecond.subseconds"),
+                    format!(
+                        "IntervalDayToSecond subseconds ({subseconds}) cannot be written at precision {precision}; only precisions 3, 6, 9, and 12 have a duration unit"
+                    ),
+                ))
+            );
+        };
+
+        // `subseconds` is the fraction of a second below `precision`, so whole
+        // seconds belong in the `seconds` field. Still writable, so report and
+        // keep going.
+        let subsecond_bound = 10_i64.pow(precision.value() as u32);
+        if subseconds <= -subsecond_bound || subseconds >= subsecond_bound {
+            ctx.push_error(
+                PlanError::invalid(
+                    "LiteralType",
+                    Some("IntervalDayToSecond.subseconds"),
+                    format!(
+                        "IntervalDayToSecond subseconds ({subseconds}) is a whole second or more at precision {precision}; whole seconds belong in the seconds field"
+                    ),
+                )
+                .into(),
+            );
+        }
+
+        parts.push(format!("{subseconds}{unit}"));
+    }
+
+    let duration = if parts.is_empty() {
+        "0s".to_string()
+    } else {
+        parts.join(" ")
+    };
+
+    write!(w, "'{}'", escaped(&duration))
 }
 
 /// Write just the value portion of a literal, with no type suffix or
@@ -212,7 +341,7 @@ fn write_literal_value<S: Scope, W: fmt::Write>(
         LiteralType::Time(microseconds) => write_precision_literal(
             "Time",
             6,
-            precision_time_to_string(*microseconds, 6),
+            precision_epoch_timestamp_to_string(*microseconds, 6),
             ctx,
             w,
         ),
@@ -220,12 +349,14 @@ fn write_literal_value<S: Scope, W: fmt::Write>(
         LiteralType::Timestamp(microseconds) => write_precision_literal(
             "Timestamp",
             6,
-            precision_timestamp_to_string(*microseconds, 6),
+            precision_epoch_timestamp_to_string(*microseconds, 6),
             ctx,
             w,
         ),
         LiteralType::IntervalYearToMonth(_) => unimplemented_literal("IntervalYearToMonth", ctx, w),
-        LiteralType::IntervalDayToSecond(_) => unimplemented_literal("IntervalDayToSecond", ctx, w),
+        LiteralType::IntervalDayToSecond(interval) => {
+            write_interval_day_to_second_literal(interval, ctx, w)
+        }
         LiteralType::IntervalCompound(_) => unimplemented_literal("IntervalCompound", ctx, w),
         LiteralType::FixedChar(_) => unimplemented_literal("FixedChar", ctx, w),
         LiteralType::VarChar(_) => unimplemented_literal("VarChar", ctx, w),
@@ -234,21 +365,21 @@ fn write_literal_value<S: Scope, W: fmt::Write>(
         LiteralType::PrecisionTime(p) => write_precision_literal(
             "PrecisionTime",
             p.precision,
-            precision_time_to_string(p.value, p.precision),
+            precision_epoch_timestamp_to_string(p.value, p.precision),
             ctx,
             w,
         ),
         LiteralType::PrecisionTimestamp(p) => write_precision_literal(
             "PrecisionTimestamp",
             p.precision,
-            precision_timestamp_to_string(p.value, p.precision),
+            precision_epoch_timestamp_to_string(p.value, p.precision),
             ctx,
             w,
         ),
         LiteralType::PrecisionTimestampTz(p) => write_precision_literal(
             "PrecisionTimestampTz",
             p.precision,
-            precision_timestamp_to_string(p.value, p.precision),
+            precision_epoch_timestamp_to_string(p.value, p.precision),
             ctx,
             w,
         ),
@@ -265,7 +396,11 @@ fn write_literal_value<S: Scope, W: fmt::Write>(
     }
 }
 
-/// The type suffix for a literal (e.g., `"i32"`, `"fp64"`, `"date"`).
+/// The type suffix for a literal, including its nullability marker (e.g.
+/// `"i32"`, `"fp64?"`, `"date"`, `"interval_day?<6>"`).
+///
+/// Nullability is part of the suffix because a parameterized type writes it
+/// before the parameter list (`interval_day?<6>`, not `interval_day<6>?`).
 /// Returns `None` for unimplemented types whose [`write_literal_value`] already
 /// emitted an error token.
 fn write_literal_type_suffix<W: fmt::Write>(
@@ -809,6 +944,186 @@ mod tests {
         assert_eq!(ctx.textify_no_errors(&literal), "true");
     }
 
+    fn interval_day_literal(
+        days: i32,
+        seconds: i32,
+        subseconds: i64,
+        precision: i32,
+    ) -> expr::Literal {
+        non_nullable_literal(LiteralType::IntervalDayToSecond(
+            expr::literal::IntervalDayToSecond {
+                days,
+                seconds,
+                subseconds,
+                precision_mode: Some(PrecisionMode::Precision(precision)),
+            },
+        ))
+    }
+
+    #[test]
+    fn test_interval_day_literal_textify() {
+        let ctx = TestContext::new();
+
+        for (literal, expected) in [
+            // Only non-zero components are written: precision travels in the
+            // type suffix, so it survives without a zero sub-second term.
+            (interval_day_literal(5, 0, 0, 6), "'5d':interval_day<6>"),
+            (interval_day_literal(5, 0, 0, 0), "'5d':interval_day<0>"),
+            (interval_day_literal(4, 5, 0, 9), "'4d 5s':interval_day<9>"),
+            (
+                interval_day_literal(0, 0, 123, 3),
+                "'123ms':interval_day<3>",
+            ),
+            (
+                interval_day_literal(0, 0, 123_456, 6),
+                "'123456us':interval_day<6>",
+            ),
+            (
+                interval_day_literal(5, 3, 123_456_789, 9),
+                "'5d 3s 123456789ns':interval_day<9>",
+            ),
+            (
+                interval_day_literal(0, 0, -500, 12),
+                "'-500ps':interval_day<12>",
+            ),
+            // An all-zero interval still needs a term to be a valid duration.
+            (interval_day_literal(0, 0, 0, 0), "'0s':interval_day<0>"),
+            (interval_day_literal(0, 0, 0, 9), "'0s':interval_day<9>"),
+            // A precision with no duration unit round-trips as long as there is
+            // no sub-second value to write.
+            (interval_day_literal(5, 0, 0, 4), "'5d':interval_day<4>"),
+        ] {
+            assert_eq!(ctx.textify_no_errors(&literal), expected);
+        }
+    }
+
+    #[test]
+    fn test_interval_day_literal_textify_nullable() {
+        let ctx = TestContext::new();
+        let literal = nullable_literal(LiteralType::IntervalDayToSecond(
+            expr::literal::IntervalDayToSecond {
+                days: 5,
+                seconds: 0,
+                subseconds: 0,
+                precision_mode: Some(PrecisionMode::Precision(6)),
+            },
+        ));
+        // Nullability goes before the parameter list, as it does for types.
+        assert_eq!(ctx.textify_no_errors(&literal), "'5d':interval_day?<6>");
+    }
+
+    #[test]
+    fn test_interval_day_literal_textify_precision_modes() {
+        let ctx = TestContext::new();
+
+        // The deprecated `microseconds` mode is microseconds by definition, and an
+        // unset `precision_mode` means microseconds for compatibility - both are
+        // written as precision 6 so protobuf -> text -> protobuf keeps precision.
+        #[allow(deprecated)]
+        let deprecated_microseconds = non_nullable_literal(LiteralType::IntervalDayToSecond(
+            expr::literal::IntervalDayToSecond {
+                days: 5,
+                seconds: 0,
+                subseconds: 0,
+                precision_mode: Some(PrecisionMode::Microseconds(123)),
+            },
+        ));
+        assert_eq!(
+            ctx.textify_no_errors(&deprecated_microseconds),
+            "'5d 123us':interval_day<6>"
+        );
+
+        let unset = non_nullable_literal(LiteralType::IntervalDayToSecond(
+            expr::literal::IntervalDayToSecond {
+                days: 5,
+                seconds: 0,
+                subseconds: 123,
+                precision_mode: None,
+            },
+        ));
+        assert_eq!(ctx.textify_no_errors(&unset), "'5d 123us':interval_day<6>");
+    }
+
+    #[test]
+    fn test_interval_day_literal_textify_invalid_precision_is_error() {
+        let ctx = TestContext::new();
+        // A precision outside 0..=12 has no valid text form at all, so there is
+        // nothing to write but an error token.
+        for precision in [-1, 13] {
+            let literal = interval_day_literal(0, 0, 2, precision);
+
+            let (text, errors) = ctx.textify(&literal);
+
+            assert_eq!(text, "!{LiteralType}");
+            match errors.first() {
+                FormatError::Format(e) => {
+                    assert_eq!(e.error_type, FormatErrorType::InvalidValue);
+                    assert_eq!(e.lookup.as_deref(), Some("IntervalDayToSecond.precision"));
+                }
+                other => panic!("expected FormatError::Format, got: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_interval_day_literal_textify_subseconds_without_unit_is_error() {
+        let ctx = TestContext::new();
+        // Precision 4 is in range but has no duration unit, so a non-zero
+        // sub-second value has no text form. Only the value is replaced with an
+        // error token; the type suffix is still accurate.
+        let literal = interval_day_literal(0, 0, 2, 4);
+
+        let (text, errors) = ctx.textify(&literal);
+
+        assert_eq!(text, "!{LiteralType}:interval_day<4>");
+        match errors.first() {
+            FormatError::Format(e) => {
+                assert_eq!(e.error_type, FormatErrorType::InvalidValue);
+                assert_eq!(e.lookup.as_deref(), Some("IntervalDayToSecond.subseconds"));
+            }
+            other => panic!("expected FormatError::Format, got: {other:?}"),
+        }
+    }
+
+    /// Values outside the Substrait ranges still have an unambiguous text form,
+    /// so they are written and reported rather than replaced with an error token.
+    #[test]
+    fn test_interval_day_literal_textify_out_of_range_is_written_with_warning() {
+        let ctx = TestContext::new();
+
+        for (literal, expected, field) in [
+            // `days` alone exceeds the 3,650,000-day maximum.
+            (
+                interval_day_literal(3_650_001, 0, 0, 0),
+                "'3650001d':interval_day<0>",
+                "IntervalDayToSecond.days",
+            ),
+            // `days` and `seconds` are each in range, but combined they aren't.
+            (
+                interval_day_literal(3_649_999, 100_000, 0, 0),
+                "'3649999d 100000s':interval_day<0>",
+                "IntervalDayToSecond.days",
+            ),
+            // `subseconds` is a whole second or more at this precision.
+            (
+                interval_day_literal(0, 0, 1_000_000_000, 9),
+                "'1000000000ns':interval_day<9>",
+                "IntervalDayToSecond.subseconds",
+            ),
+        ] {
+            let (text, errors) = ctx.textify(&literal);
+
+            assert_eq!(text, expected);
+            match errors.first() {
+                FormatError::Format(e) => {
+                    assert_eq!(e.error_type, FormatErrorType::InvalidValue);
+                    assert_eq!(e.lookup.as_deref(), Some(field));
+                }
+                other => panic!("expected FormatError::Format, got: {other:?}"),
+            }
+        }
+    }
+
     fn nullable_literal(lit: expr::literal::LiteralType) -> expr::Literal {
         expr::Literal {
             nullable: true,
@@ -861,49 +1176,49 @@ mod tests {
     #[test]
     fn test_precision_timestamp_to_string() {
         assert_eq!(
-            precision_timestamp_to_string(10, 0),
+            precision_epoch_timestamp_to_string(10, 0),
             Ok("1970-01-01T00:00:10".to_string())
         );
         assert_eq!(
-            precision_timestamp_to_string(123_456_789, 9),
+            precision_epoch_timestamp_to_string(123_456_789, 9),
             Ok("1970-01-01T00:00:00.123456789".to_string())
         );
         // Precision 12 (picoseconds) is truncated to nanoseconds (best-effort):
         // the trailing 500 picoseconds below don't survive.
         assert_eq!(
-            precision_timestamp_to_string(123_456_789_500, 12),
+            precision_epoch_timestamp_to_string(123_456_789_500, 12),
             Ok("1970-01-01T00:00:00.123456789".to_string())
         );
         assert_eq!(
-            precision_timestamp_to_string(0, 13),
+            precision_epoch_timestamp_to_string(0, 13),
             Err(PrecisionFormatError::UnsupportedPrecision)
         );
     }
 
     #[test]
     fn test_precision_time_to_string() {
-        assert_eq!(precision_time_to_string(0, 0), Ok("00:00:00".to_string()));
+        assert_eq!(precision_epoch_timestamp_to_string(0, 0), Ok("00:00:00".to_string()));
         assert_eq!(
             // 01:01:01 = 3661 seconds, in microseconds. The fractional part is
             // rendered at the declared precision width (6 digits).
-            precision_time_to_string(3_661_000_000, 6),
+            precision_epoch_timestamp_to_string(3_661_000_000, 6),
             Ok("01:01:01.000000".to_string())
         );
         assert_eq!(
             // 01:01:01 = 3661 seconds, in picoseconds, plus 500 ps that get
             // truncated away. Precision 12 renders at nanosecond width (9 digits).
-            precision_time_to_string(3_661_000_000_000_500, 12),
+            precision_epoch_timestamp_to_string(3_661_000_000_000_500, 12),
             Ok("01:01:01.000000000".to_string())
         );
         assert_eq!(
-            precision_time_to_string(0, 13),
+            precision_epoch_timestamp_to_string(0, 13),
             Err(PrecisionFormatError::UnsupportedPrecision)
         );
         // A negative value at precision 12 truncates towards zero when converted
         // to a `chrono::Duration` (-1 / 1000 == 0), so the sign must be checked
         // on the raw value, not the derived duration.
         assert_eq!(
-            precision_time_to_string(-1, 12),
+            precision_epoch_timestamp_to_string(-1, 12),
             Err(PrecisionFormatError::OutOfRange)
         );
     }

--- a/src/types_tests.rs
+++ b/src/types_tests.rs
@@ -101,6 +101,9 @@ fn test_types() {
     assert_roundtrip::<Type>(&ctx, "time?");
     assert_roundtrip::<Type>(&ctx, "interval_year");
     assert_roundtrip::<Type>(&ctx, "interval_year?");
+    assert_roundtrip::<Type>(&ctx, "interval_day<9>");
+    assert_roundtrip::<Type>(&ctx, "interval_day?<6>");
+    assert_roundtrip::<Type>(&ctx, "interval_day?<0>");
     assert_roundtrip::<Type>(&ctx, "uuid");
     assert_roundtrip::<Type>(&ctx, "uuid?");
 
@@ -161,6 +164,14 @@ fn test_expression() {
     assert_roundtrip::<Literal>(&ctx, "'2023-01-01T12:00:00':precisiontimestamptz<0>");
     assert_roundtrip::<Literal>(&ctx, "'14:30:45':precisiontime<0>");
 
+    assert_roundtrip::<Literal>(&ctx, "'5d':interval_day<0>");
+    assert_roundtrip::<Literal>(&ctx, "'5d':interval_day<9>");
+    assert_roundtrip::<Literal>(&ctx, "'4d 5s':interval_day<6>");
+    assert_roundtrip::<Literal>(&ctx, "'123456789ns':interval_day<9>");
+    assert_roundtrip::<Literal>(&ctx, "'5d 3s 100ms':interval_day<3>");
+    assert_roundtrip::<Literal>(&ctx, "'-5d 3s':interval_day<0>");
+    assert_roundtrip::<Literal>(&ctx, "'0s':interval_day<0>");
+    assert_roundtrip::<Literal>(&ctx, "'5d':interval_day?<6>");
     roundtrip_parse::<FieldReference>(&ctx, "$1");
     assert_roundtrip::<ScalarFunction>(&ctx, "foo():i64");
     assert_roundtrip::<Expression>(&ctx, "bar(12):i64");

--- a/tests/literal_roundtrip.rs
+++ b/tests/literal_roundtrip.rs
@@ -83,6 +83,17 @@ Root[result]
 }
 
 #[test]
+fn test_interval_day_literal_roundtrip() {
+    let plan = r#"
+=== Plan
+Root[result]
+  Project['-5d 3s':interval_day<0>, '5d 3s 100ns':interval_day<9>]
+    Read[data => a:i64]
+"#;
+    roundtrip_plan(plan);
+}
+
+#[test]
 fn test_nullable_integer_literal_roundtrip() {
     let plan = r#"
 === Plan


### PR DESCRIPTION
## Description

Adds Substrait's IntervalDayToSecond type and literal to the text format, on both the parse and textify sides.

- Type: interval_day (bare, unset precision → treated as 6/microseconds) and interval_day<precision> (explicit precision 0–12), matching Type.IntervalDay in the spec.
- Literal: '<terms>':interval_day, e.g. '5d 3s':interval_day, '123456789ns':interval_day. A literal is 1–3 whitespace-separated terms (d, s, and one of ms/us/ns/ps), each term optionally signed and appearing at most once; the subsecond unit determines the stored precision. Literal type ascription is always bare :interval_day — precision is derived from the string, not a type parameter — to avoid two ways of expressing precision disagreeing with each other.
- Enforces the spec's ±3,650,000-day bound (both individually and combined with seconds), i32 bounds on seconds, and per-precision bounds on subseconds.
- Updates GRAMMAR.md with the interval_day_literal grammar and precision semantics.

## Type of Change
- [x] New feature


## Testing
- [x] Added tests for new functionality
- [x] All existing tests pass

## Related Issues

Closes #177
