### PR TITLE
refactor(textify): extract shared textify components

### DIFF
--- a/src/textify/expressions.rs
+++ b/src/textify/expressions.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self};
+use std::fmt;
 
 use chrono::{DateTime, NaiveDate};
 use expr::RexType;
@@ -402,32 +402,45 @@ impl Textify for FieldReference {
     }
 }
 
+/// Write the `name(args, options)` prefix shared by `ScalarFunction`,
+/// `AggregateFunction`, and `WindowFunction` textification.
+fn textify_function_call_prefix<S: Scope, W: fmt::Write>(
+    function_reference: u32,
+    arguments: &[FunctionArgument],
+    options: &[FunctionOption],
+    ctx: &S,
+    w: &mut W,
+) -> fmt::Result {
+    let name_and_anchor = NamedAnchor::lookup(ctx, ExtensionKind::Function, function_reference);
+    let name_and_anchor = ctx.display(&name_and_anchor);
+
+    let between = if arguments.is_empty() || options.is_empty() {
+        ""
+    } else {
+        ", "
+    };
+    let args = ctx.separated(arguments, ", ");
+    let options = ctx.separated(options, ", ");
+
+    write!(w, "{name_and_anchor}({args}{between}{options})")
+}
+
 impl Textify for ScalarFunction {
     fn name() -> &'static str {
         "ScalarFunction"
     }
 
     fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
-        let name_and_anchor =
-            NamedAnchor::lookup(ctx, ExtensionKind::Function, self.function_reference);
-        let name_and_anchor = ctx.display(&name_and_anchor);
-
-        let args = ctx.separated(&self.arguments, ", ");
-        let options = ctx.separated(&self.options, ", ");
-        let between = if self.arguments.is_empty() || self.options.is_empty() {
-            ""
-        } else {
-            ", "
-        };
+        textify_function_call_prefix(
+            self.function_reference,
+            &self.arguments,
+            &self.options,
+            ctx,
+            w,
+        )?;
 
         let output = OutputType(self.output_type.as_ref());
-        let output_type = ctx.display(&output);
-
-        write!(
-            w,
-            "{name_and_anchor}({args}{between}{options}){output_type}"
-        )?;
-        Ok(())
+        write!(w, "{}", ctx.display(&output))
     }
 }
 
@@ -532,7 +545,7 @@ impl Textify for RexType {
             RexType::Literal(literal) => literal.textify(ctx, w),
             RexType::Selection(f) => f.textify(ctx, w),
             RexType::ScalarFunction(s) => s.textify(ctx, w),
-            RexType::WindowFunction(_w) => write!(
+            RexType::WindowFunction(_f) => write!(
                 w,
                 "{}",
                 ctx.failure(PlanError::unimplemented(
@@ -645,26 +658,16 @@ impl Textify for AggregateFunction {
     }
 
     fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
-        // Similar to ScalarFunction textification
-        let name_and_anchor =
-            NamedAnchor::lookup(ctx, ExtensionKind::Function, self.function_reference);
-        let name_and_anchor = ctx.display(&name_and_anchor);
-
-        let args = ctx.separated(&self.arguments, ", ");
-        let options = ctx.separated(&self.options, ", ");
-        let between = if self.arguments.is_empty() || self.options.is_empty() {
-            ""
-        } else {
-            ", "
-        };
+        textify_function_call_prefix(
+            self.function_reference,
+            &self.arguments,
+            &self.options,
+            ctx,
+            w,
+        )?;
 
         let output = OutputType(self.output_type.as_ref());
-        let output_type = ctx.display(&output);
-
-        write!(
-            w,
-            "{name_and_anchor}({args}{between}{options}){output_type}"
-        )
+        write!(w, "{}", ctx.display(&output))
     }
 }
 

--- a/src/textify/expressions.rs
+++ b/src/textify/expressions.rs
@@ -402,27 +402,60 @@ impl Textify for FieldReference {
     }
 }
 
-/// Write the `name(args, options)` prefix shared by `ScalarFunction`,
-/// `AggregateFunction`, and `WindowFunction` textification.
-fn textify_function_call_prefix<S: Scope, W: fmt::Write>(
-    function_reference: u32,
-    arguments: &[FunctionArgument],
-    options: &[FunctionOption],
-    ctx: &S,
-    w: &mut W,
-) -> fmt::Result {
-    let name_and_anchor = NamedAnchor::lookup(ctx, ExtensionKind::Function, function_reference);
-    let name_and_anchor = ctx.display(&name_and_anchor);
+/// The fields shared by every Substrait function call - `ScalarFunction`,
+/// `AggregateFunction`, and `WindowFunction` - that render as
+/// `name#anchor(args, options)`.
+///
+/// The remaining fields of each function message (the output type, and the
+/// aggregate/window-specific parts) are textified alongside this by the
+/// respective `Textify` implementations.
+#[derive(Debug, Clone, Copy)]
+pub struct FunctionInvocation<'a> {
+    pub function_reference: u32,
+    pub arguments: &'a [FunctionArgument],
+    pub options: &'a [FunctionOption],
+}
 
-    let between = if arguments.is_empty() || options.is_empty() {
-        ""
-    } else {
-        ", "
-    };
-    let args = ctx.separated(arguments, ", ");
-    let options = ctx.separated(options, ", ");
+impl<'a> From<&'a ScalarFunction> for FunctionInvocation<'a> {
+    fn from(f: &'a ScalarFunction) -> Self {
+        FunctionInvocation {
+            function_reference: f.function_reference,
+            arguments: &f.arguments,
+            options: &f.options,
+        }
+    }
+}
 
-    write!(w, "{name_and_anchor}({args}{between}{options})")
+impl<'a> From<&'a AggregateFunction> for FunctionInvocation<'a> {
+    fn from(f: &'a AggregateFunction) -> Self {
+        FunctionInvocation {
+            function_reference: f.function_reference,
+            arguments: &f.arguments,
+            options: &f.options,
+        }
+    }
+}
+
+impl Textify for FunctionInvocation<'_> {
+    fn name() -> &'static str {
+        "FunctionInvocation"
+    }
+
+    fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
+        let name_and_anchor =
+            NamedAnchor::lookup(ctx, ExtensionKind::Function, self.function_reference);
+        let name_and_anchor = ctx.display(&name_and_anchor);
+
+        let args = ctx.separated(self.arguments, ", ");
+        let options = ctx.separated(self.options, ", ");
+        let between = if self.arguments.is_empty() || self.options.is_empty() {
+            ""
+        } else {
+            ", "
+        };
+
+        write!(w, "{name_and_anchor}({args}{between}{options})")
+    }
 }
 
 impl Textify for ScalarFunction {
@@ -431,16 +464,13 @@ impl Textify for ScalarFunction {
     }
 
     fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
-        textify_function_call_prefix(
-            self.function_reference,
-            &self.arguments,
-            &self.options,
-            ctx,
-            w,
-        )?;
+        let invocation = FunctionInvocation::from(self);
+        let output_type = OutputType(self.output_type.as_ref());
 
-        let output = OutputType(self.output_type.as_ref());
-        write!(w, "{}", ctx.display(&output))
+        let invocation = ctx.display(&invocation);
+        let output_type = ctx.display(&output_type);
+
+        write!(w, "{invocation}{output_type}")
     }
 }
 
@@ -658,16 +688,13 @@ impl Textify for AggregateFunction {
     }
 
     fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
-        textify_function_call_prefix(
-            self.function_reference,
-            &self.arguments,
-            &self.options,
-            ctx,
-            w,
-        )?;
+        let invocation = FunctionInvocation::from(self);
+        let output_type = OutputType(self.output_type.as_ref());
 
-        let output = OutputType(self.output_type.as_ref());
-        write!(w, "{}", ctx.display(&output))
+        let invocation = ctx.display(&invocation);
+        let output_type = ctx.display(&output_type);
+
+        write!(w, "{invocation}{output_type}")
     }
 }
 

--- a/src/textify/mod.rs
+++ b/src/textify/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod foundation;
 pub(crate) mod plan;
 pub(crate) mod rels;
 pub(crate) mod types;
+pub(crate) mod values;
 
 #[cfg(test)]
 pub(crate) use foundation::ErrorQueue;

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -17,7 +17,7 @@ use substrait::proto::{
 
 use super::addenda::AddendumLines;
 use super::types::Name;
-use super::values::{ArgsLayout, Arguments, NamedArg, Value, ValueEnum, decode_enum_field};
+use super::values::{Arguments, NamedArg, Value, ValueEnum, decode_enum_field};
 use super::{PlanError, Scope, Textify};
 use crate::FormatError;
 use crate::extensions::any::AnyRef;
@@ -215,17 +215,42 @@ impl<'a> Textify for Emitted<'a> {
     }
 }
 
+/// The argument section of a relation header.
+#[derive(Debug, Clone)]
+pub enum RelationArgs<'a> {
+    /// `arg, arg, name=arg` inline inside the header's `[...]`.
+    Inline(Arguments<'a>),
+    /// One `- row` per line, used by `Read:Virtual` once it has enough rows to
+    /// be worth spreading out. Named arguments have no row form yet.
+    Rows(Vec<Value<'a>>),
+}
+
+impl<'a> RelationArgs<'a> {
+    /// An inline argument list, the layout used by every relation but a
+    /// multi-row `Read:Virtual`.
+    pub fn inline(positional: Vec<Value<'a>>, named: Vec<NamedArg<'a>>) -> Self {
+        RelationArgs::Inline(Arguments::new(positional, named))
+    }
+
+    /// A row-per-line argument list.
+    pub fn rows(positional: Vec<Value<'a>>) -> Self {
+        RelationArgs::Rows(positional)
+    }
+}
+
 pub struct Relation<'a> {
     pub name: Cow<'a, str>,
     /// Arguments to the relation, if any.
     ///
     /// - `None` means this relation does not take arguments, and the argument
     ///   section is omitted entirely.
-    /// - `Some(args)` with both vectors empty means the relation takes
-    ///   arguments, but none are provided; this will print as `_ => ...`.
-    /// - `Some(args)` with non-empty vectors will print as usual, with
-    ///   positional arguments first, then named arguments, separated by commas.
-    pub arguments: Option<Arguments<'a>>,
+    /// - `Some(RelationArgs::Inline(args))` with both vectors empty means the
+    ///   relation takes arguments, but none are provided; this will print as
+    ///   `_ => ...`.
+    /// - `Some(RelationArgs::Inline(args))` with non-empty vectors will print
+    ///   with positional arguments first, then named arguments, separated by commas.
+    /// - `Some(RelationArgs::Rows(rows))` prints one row per line.
+    pub arguments: Option<RelationArgs<'a>>,
     /// The columns emitted by this relation, pre-emit - the 'direct' column
     /// output.
     pub columns: Vec<Value<'a>>,
@@ -260,7 +285,7 @@ impl Textify for Relation<'_> {
 impl Relation<'_> {
     /// Write the header for this relation, e.g. `Filter[$0 => $0]`.
     ///
-    /// Usually a single line, but an argument list with [`ArgsLayout::Rows`]
+    /// Usually a single line, but an argument list of [`RelationArgs::Rows`]
     /// (used by `Read:Virtual` with many rows) spans several lines:
     ///
     /// ```text
@@ -281,14 +306,14 @@ impl Relation<'_> {
                 let cols = ctx.display(&cols);
                 write!(w, "{indent}{name}[{cols}]")
             }
-            Some(args) if args.layout() == ArgsLayout::Rows => {
+            Some(RelationArgs::Rows(rows)) => {
                 // One `- row` per line, one indent level deeper, with a trailing
                 // comma on every row but the last, then `- <output> cols]`.
                 let child = ctx.push_indent();
                 let child_indent = child.indent();
                 writeln!(w, "{indent}{name}[")?;
-                let last = args.positional.len().saturating_sub(1);
-                for (i, row) in args.positional.iter().enumerate() {
+                let last = rows.len().saturating_sub(1);
+                for (i, row) in rows.iter().enumerate() {
                     let row = ctx.display(row);
                     let comma = if i == last { "" } else { "," };
                     writeln!(w, "{child_indent}- {row}{comma}")?;
@@ -297,7 +322,7 @@ impl Relation<'_> {
                 let output = ctx.display(&output);
                 write!(w, "{child_indent}- {output}]")
             }
-            Some(args) => {
+            Some(RelationArgs::Inline(args)) => {
                 let args = ctx.display(args);
                 let output = Emitted::output_clause(&self.columns, self.emit, self.output_syntax);
                 let output = ctx.display(&output);
@@ -349,7 +374,7 @@ impl<'a> Relation<'a> {
                 };
                 Relation {
                     name: Cow::Borrowed("Read"),
-                    arguments: Some(Arguments::inline(vec![table_name], vec![])),
+                    arguments: Some(RelationArgs::inline(vec![table_name], vec![])),
                     columns,
                     emit,
                     output_syntax,
@@ -374,9 +399,9 @@ impl<'a> Relation<'a> {
                 let multiline = !positional.is_empty()
                     && positional.len() >= ctx.options().virtual_table_multiline_threshold;
                 let arguments = if multiline {
-                    Arguments::rows(positional)
+                    RelationArgs::rows(positional)
                 } else {
-                    Arguments::inline(positional, vec![])
+                    RelationArgs::inline(positional, vec![])
                 };
 
                 Relation {
@@ -420,7 +445,7 @@ impl<'a> Relation<'a> {
                 );
                 Relation {
                     name: Cow::Borrowed("Read"),
-                    arguments: Some(Arguments::inline(vec![Value::Missing(err)], vec![])),
+                    arguments: Some(RelationArgs::inline(vec![Value::Missing(err)], vec![])),
                     columns,
                     emit,
                     output_syntax: OutputSyntax::Implicit,
@@ -486,7 +511,7 @@ impl<'a> Relation<'a> {
             PlanError::unimplemented("FilterRel", Some("condition"), "Condition is None")
         });
         let positional = vec![condition];
-        let arguments = Some(Arguments::inline(positional, vec![]));
+        let arguments = Some(RelationArgs::inline(positional, vec![]));
         let emit = get_emit(rel.common.as_ref());
         let (children, columns) = Relation::convert_children(vec![rel.input.as_deref()], ctx);
         let columns = (0..columns).map(|i| Value::Reference(i as i32)).collect();
@@ -614,7 +639,7 @@ impl<'a> Relation<'a> {
                 }
                 Relation {
                     name: Cow::Owned(format!("{}:{}", ext_type, name)),
-                    arguments: Some(Arguments::inline(positional, named)),
+                    arguments: Some(RelationArgs::inline(positional, named)),
                     columns,
                     emit: None,
                     output_syntax: OutputSyntax::Implicit,
@@ -710,7 +735,7 @@ impl<'a> Relation<'a> {
         }
 
         // adding the grouping_sets as a list of Arguments to Aggregate Rel
-        let arguments = Some(Arguments::inline(positional, vec![]));
+        let arguments = Some(RelationArgs::inline(positional, vec![]));
 
         // The columns are the direct outputs of this relation (before emit)
         let mut all_outputs: Vec<Value> = expression_list;
@@ -819,7 +844,7 @@ impl<'a> Relation<'a> {
         for sort_field in &rel.sorts {
             positional.push(Value::from(sort_field));
         }
-        let arguments = Some(Arguments::inline(positional, vec![]));
+        let arguments = Some(RelationArgs::inline(positional, vec![]));
         // The columns are the direct outputs of this relation (before emit)
         let mut col_values = vec![];
         for i in 0..input_columns {
@@ -881,7 +906,7 @@ impl<'a> Relation<'a> {
             .collect();
         Relation {
             name: Cow::Borrowed("Fetch"),
-            arguments: Some(Arguments::inline(vec![], named_args)),
+            arguments: Some(RelationArgs::inline(vec![], named_args)),
             columns,
             emit,
             output_syntax: OutputSyntax::Implicit,
@@ -983,7 +1008,7 @@ impl<'a> Relation<'a> {
         // Currently post_join_filter is not supported in the text format
         // grammar
         let positional = vec![join_type_value, condition];
-        let arguments = Some(Arguments::inline(positional, vec![]));
+        let arguments = Some(RelationArgs::inline(positional, vec![]));
 
         let emit = get_emit(rel.common.as_ref());
         let columns = join_output_columns(join_type, left_columns, right_columns);
@@ -1015,7 +1040,7 @@ impl<'a> Relation<'a> {
 
         let op_value = decode_enum_field::<set_rel::SetOp>(rel.op, "SetRel", "op");
 
-        let arguments = Some(Arguments::inline(vec![op_value], vec![]));
+        let arguments = Some(RelationArgs::inline(vec![op_value], vec![]));
         let emit = get_emit(rel.common.as_ref());
         let columns = (0..width).map(|i| Value::Reference(i as i32)).collect();
 
@@ -1500,36 +1525,6 @@ Filter[gt($0, 10:i32):boolean => $0, $1]
     }
 
     #[test]
-    fn test_arguments_textify_positional_only() {
-        let ctx = TestContext::new();
-        let args = Arguments::inline(vec![Value::Integer(42), Value::Integer(7)], vec![]);
-        let (result, errors) = ctx.textify(&args);
-        assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
-        assert_eq!(result, "42, 7");
-    }
-
-    #[test]
-    fn test_arguments_textify_named_only() {
-        let ctx = TestContext::new();
-        let args = Arguments::inline(
-            vec![],
-            vec![
-                NamedArg {
-                    name: Cow::Borrowed("limit"),
-                    value: Value::Integer(10),
-                },
-                NamedArg {
-                    name: Cow::Borrowed("offset"),
-                    value: Value::Integer(5),
-                },
-            ],
-        );
-        let (result, errors) = ctx.textify(&args);
-        assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
-        assert_eq!(result, "limit=10, offset=5");
-    }
-
-    #[test]
     fn test_join_relation_unknown_type() {
         let ctx = TestContext::new();
 
@@ -1672,48 +1667,6 @@ Cross[$0, $3]
   Read[right_tbl => category:string?, amount:fp64?, value:i32?]"#
             .trim_start();
         assert_eq!(result, expected);
-    }
-
-    #[test]
-    fn test_arguments_textify_both() {
-        let ctx = TestContext::new();
-        let args = Arguments::inline(
-            vec![Value::Integer(1)],
-            vec![NamedArg {
-                name: "foo".into(),
-                value: Value::Integer(2),
-            }],
-        );
-        let (result, errors) = ctx.textify(&args);
-        assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
-        assert_eq!(result, "1, foo=2");
-    }
-
-    #[test]
-    fn test_arguments_textify_empty() {
-        let ctx = TestContext::new();
-        let args = Arguments::inline(vec![], vec![]);
-        let (result, errors) = ctx.textify(&args);
-        assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
-        assert_eq!(result, "_");
-    }
-
-    #[test]
-    fn test_named_arg_textify_error_token() {
-        let ctx = TestContext::new();
-        let named_arg = NamedArg {
-            name: "foo".into(),
-            value: Value::Missing(PlanError::invalid(
-                "my_enum",
-                Some(Cow::Borrowed("my_enum")),
-                Cow::Borrowed("my_enum"),
-            )),
-        };
-        let (result, errors) = ctx.textify(&named_arg);
-        // Should show !{my_enum} in the output
-        assert!(result.contains("foo=!{my_enum}"), "Output: {result}");
-        // Should also accumulate an error
-        assert!(!errors.is_empty(), "Expected error for error token");
     }
 
     #[test]

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -2,28 +2,26 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::fmt;
-use std::fmt::Debug;
 
-use prost::{Message, UnknownEnumValue};
+use prost::Message;
 use substrait::proto::fetch_rel::CountMode;
 use substrait::proto::plan_rel::RelType as PlanRelType;
 use substrait::proto::read_rel::ReadType;
 use substrait::proto::rel::RelType;
 use substrait::proto::rel_common::EmitKind;
-use substrait::proto::sort_field::{SortDirection, SortKind};
 use substrait::proto::{
-    AggregateFunction, AggregateRel, CrossRel, Expression, ExtensionLeafRel, ExtensionMultiRel,
-    ExtensionSingleRel, FetchRel, FilterRel, JoinRel, NamedStruct, PlanRel, ProjectRel, ReadRel,
-    Rel, RelCommon, RelRoot, SetRel, SortField, SortRel, Type, join_rel, set_rel,
+    AggregateRel, CrossRel, ExtensionLeafRel, ExtensionMultiRel, ExtensionSingleRel, FetchRel,
+    FilterRel, JoinRel, NamedStruct, PlanRel, ProjectRel, ReadRel, Rel, RelCommon, RelRoot, SetRel,
+    SortRel, join_rel, set_rel,
 };
 
 use super::addenda::AddendumLines;
-use super::expressions::Reference;
 use super::types::Name;
+use super::values::{ArgsLayout, Arguments, NamedArg, Value, ValueEnum, decode_enum_field};
 use super::{PlanError, Scope, Textify};
 use crate::FormatError;
 use crate::extensions::any::AnyRef;
-use crate::extensions::{ExtensionArgs, ExtensionColumn, ExtensionError, ExtensionValue};
+use crate::extensions::{ExtensionArgs, ExtensionError};
 
 pub trait NamedRelation {
     fn name(&self) -> &'static str;
@@ -68,84 +66,6 @@ impl Textify for Rel {
         // delegates to `Relation` which carries `advanced_extension`, so the full
         // header → enhancement → children sequence is handled uniformly there.
         Relation::from_rel(self, ctx).textify(ctx, w)
-    }
-}
-
-/// Trait for enums that can be converted to a string representation for
-/// textification.
-///
-/// Returns Ok(str) for valid enum values, or Err([PlanError]) for invalid or
-/// unknown values.
-pub trait ValueEnum {
-    fn as_enum_str(&self) -> Result<Cow<'static, str>, PlanError>;
-}
-
-#[derive(Debug, Clone)]
-pub struct NamedArg<'a> {
-    pub name: Cow<'a, str>,
-    pub value: Value<'a>,
-}
-
-#[derive(Debug, Clone)]
-pub enum Value<'a> {
-    TableName(Vec<Name<'a>>),
-    Field(Option<Name<'a>>, Option<&'a Type>),
-    Tuple(Vec<Value<'a>>),
-    Reference(i32),
-    Expression(&'a Expression),
-    AggregateFunction(&'a AggregateFunction),
-    /// Represents a missing, invalid, or unspecified value.
-    Missing(PlanError),
-    /// Represents a valid enum value as a string for textification.
-    Enum(Cow<'a, str>),
-    EmptyGroup,
-    Integer(i64),
-    /// A decoded extension argument value.
-    ExtensionArgument(ExtensionValue),
-    /// A decoded extension output column.
-    ExtColumn(ExtensionColumn),
-}
-
-impl<'a> Value<'a> {
-    pub fn expect(maybe_value: Option<Self>, f: impl FnOnce() -> PlanError) -> Self {
-        match maybe_value {
-            Some(s) => s,
-            None => Value::Missing(f()),
-        }
-    }
-}
-
-impl<'a> From<Result<Vec<Name<'a>>, PlanError>> for Value<'a> {
-    fn from(token: Result<Vec<Name<'a>>, PlanError>) -> Self {
-        match token {
-            Ok(value) => Value::TableName(value),
-            Err(err) => Value::Missing(err),
-        }
-    }
-}
-
-impl<'a> Textify for Value<'a> {
-    fn name() -> &'static str {
-        "Value"
-    }
-
-    fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
-        match self {
-            Value::TableName(names) => write!(w, "{}", ctx.separated(names, ".")),
-            Value::Field(name, typ) => {
-                write!(w, "{}:{}", ctx.expect(name.as_ref()), ctx.expect(*typ))
-            }
-            Value::Tuple(values) => write!(w, "({})", ctx.separated(values, ", ")),
-            Value::Reference(i) => write!(w, "{}", Reference(*i)),
-            Value::Expression(e) => write!(w, "{}", ctx.display(*e)),
-            Value::AggregateFunction(agg_fn) => agg_fn.textify(ctx, w),
-            Value::Missing(err) => write!(w, "{}", ctx.failure(err.clone())),
-            Value::Enum(res) => write!(w, "&{res}"),
-            Value::Integer(i) => write!(w, "{i}"),
-            Value::EmptyGroup => write!(w, "_"),
-            Value::ExtensionArgument(ev) => ev.textify(ctx, w),
-            Value::ExtColumn(ec) => ec.textify(ctx, w),
-        }
     }
 }
 
@@ -295,68 +215,6 @@ impl<'a> Textify for Emitted<'a> {
     }
 }
 
-/// How an argument list renders inside a relation's `[...]`.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum ArgsLayout {
-    /// `arg, arg, arg` on a single line.
-    #[default]
-    Inline,
-    /// One `- arg` per line, used for `Read:Virtual` rows. See
-    /// [`Relation::write_header`] for the exact layout.
-    Rows,
-}
-
-#[derive(Debug, Clone)]
-pub struct Arguments<'a> {
-    /// Positional arguments (e.g., a filter condition, group-bys, etc.)
-    pub positional: Vec<Value<'a>>,
-    /// Named arguments (e.g., limit=10, offset=5)
-    pub named: Vec<NamedArg<'a>>,
-    /// How this argument list is laid out. Defaults to [`ArgsLayout::Inline`];
-    /// only `Read:Virtual` opts into [`ArgsLayout::Rows`].
-    layout: ArgsLayout,
-}
-
-impl<'a> Arguments<'a> {
-    /// An inline argument list (`arg, arg, arg`), the default for every
-    /// relation.
-    pub fn inline(positional: Vec<Value<'a>>, named: Vec<NamedArg<'a>>) -> Self {
-        Arguments {
-            positional,
-            named,
-            layout: ArgsLayout::Inline,
-        }
-    }
-
-    /// A row-per-line argument list (`- arg` per line) used for `Read:Virtual`
-    /// with many rows. Currently not enabled for named arguments.
-    /// TODO: enable for named arguments as well.
-    pub fn rows(positional: Vec<Value<'a>>) -> Self {
-        Arguments {
-            positional,
-            named: vec![],
-            layout: ArgsLayout::Rows,
-        }
-    }
-}
-
-impl<'a> Textify for Arguments<'a> {
-    fn name() -> &'static str {
-        "Arguments"
-    }
-    fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
-        if self.positional.is_empty() && self.named.is_empty() {
-            return write!(w, "_");
-        }
-
-        write!(w, "{}", ctx.separated(self.positional.iter(), ", "))?;
-        if !self.positional.is_empty() && !self.named.is_empty() {
-            write!(w, ", ")?;
-        }
-        write!(w, "{}", ctx.separated(self.named.iter(), ", "))
-    }
-}
-
 pub struct Relation<'a> {
     pub name: Cow<'a, str>,
     /// Arguments to the relation, if any.
@@ -423,7 +281,7 @@ impl Relation<'_> {
                 let cols = ctx.display(&cols);
                 write!(w, "{indent}{name}[{cols}]")
             }
-            Some(args) if args.layout == ArgsLayout::Rows => {
+            Some(args) if args.layout() == ArgsLayout::Rows => {
                 // One `- row` per line, one indent level deeper, with a trailing
                 // comma on every row but the last, then `- <output> cols]`.
                 let child = ctx.push_indent();
@@ -1155,17 +1013,7 @@ impl<'a> Relation<'a> {
             total_columns / children.len()
         };
 
-        let op_value = match set_rel::SetOp::try_from(rel.op) {
-            Ok(op) => match op.as_enum_str() {
-                Ok(s) => Value::Enum(s),
-                Err(e) => Value::Missing(e),
-            },
-            Err(_) => Value::Missing(PlanError::invalid(
-                "SetRel",
-                Some("op"),
-                format!("Unknown set op: {}", rel.op),
-            )),
-        };
+        let op_value = decode_enum_field::<set_rel::SetOp>(rel.op, "SetRel", "op");
 
         let arguments = Some(Arguments::inline(vec![op_value], vec![]));
         let emit = get_emit(rel.common.as_ref());
@@ -1204,147 +1052,6 @@ impl<'a> Relation<'a> {
     }
 }
 
-impl<'a> From<&'a SortField> for Value<'a> {
-    fn from(sf: &'a SortField) -> Self {
-        let field = match &sf.expr {
-            Some(expr) => match &expr.rex_type {
-                Some(substrait::proto::expression::RexType::Selection(fref)) => {
-                    if let Some(substrait::proto::expression::field_reference::ReferenceType::DirectReference(seg)) = &fref.reference_type {
-                        if let Some(substrait::proto::expression::reference_segment::ReferenceType::StructField(sf)) = &seg.reference_type {
-                            Value::Reference(sf.field)
-                        } else { Value::Missing(PlanError::unimplemented("SortField", Some("expr"), "Not a struct field")) }
-                    } else { Value::Missing(PlanError::unimplemented("SortField", Some("expr"), "Not a direct reference")) }
-                }
-                _ => Value::Missing(PlanError::unimplemented(
-                    "SortField",
-                    Some("expr"),
-                    "Not a selection",
-                )),
-            },
-            None => Value::Missing(PlanError::unimplemented(
-                "SortField",
-                Some("expr"),
-                "Missing expr",
-            )),
-        };
-        let direction = match &sf.sort_kind {
-            Some(kind) => Value::from(kind),
-            None => Value::Missing(PlanError::invalid(
-                "SortKind",
-                Some(Cow::Borrowed("sort_kind")),
-                "Missing sort_kind",
-            )),
-        };
-        Value::Tuple(vec![field, direction])
-    }
-}
-
-impl<'a, T: ValueEnum + ?Sized> From<&'a T> for Value<'a> {
-    fn from(enum_val: &'a T) -> Self {
-        match enum_val.as_enum_str() {
-            Ok(s) => Value::Enum(s),
-            Err(e) => Value::Missing(e),
-        }
-    }
-}
-
-impl ValueEnum for SortKind {
-    fn as_enum_str(&self) -> Result<Cow<'static, str>, PlanError> {
-        let d = match self {
-            &SortKind::Direction(d) => SortDirection::try_from(d),
-            SortKind::ComparisonFunctionReference(f) => {
-                return Err(PlanError::invalid(
-                    "SortKind",
-                    Some(Cow::Owned(format!("function reference{f}"))),
-                    "SortKind::ComparisonFunctionReference unimplemented",
-                ));
-            }
-        };
-        let s = match d {
-            Err(UnknownEnumValue(d)) => {
-                return Err(PlanError::invalid(
-                    "SortKind",
-                    Some(Cow::Owned(format!("unknown variant: {d:?}"))),
-                    "Unknown SortDirection",
-                ));
-            }
-            Ok(SortDirection::AscNullsFirst) => "AscNullsFirst",
-            Ok(SortDirection::AscNullsLast) => "AscNullsLast",
-            Ok(SortDirection::DescNullsFirst) => "DescNullsFirst",
-            Ok(SortDirection::DescNullsLast) => "DescNullsLast",
-            Ok(SortDirection::Clustered) => "Clustered",
-            Ok(SortDirection::Unspecified) => {
-                return Err(PlanError::invalid(
-                    "SortKind",
-                    Option::<Cow<str>>::None,
-                    "Unspecified SortDirection",
-                ));
-            }
-        };
-        Ok(Cow::Borrowed(s))
-    }
-}
-
-impl ValueEnum for join_rel::JoinType {
-    fn as_enum_str(&self) -> Result<Cow<'static, str>, PlanError> {
-        let s = match self {
-            join_rel::JoinType::Unspecified => {
-                return Err(PlanError::invalid(
-                    "JoinType",
-                    Option::<Cow<str>>::None,
-                    "Unspecified JoinType",
-                ));
-            }
-            join_rel::JoinType::Inner => "Inner",
-            join_rel::JoinType::Outer => "Outer",
-            join_rel::JoinType::Left => "Left",
-            join_rel::JoinType::Right => "Right",
-            join_rel::JoinType::LeftSemi => "LeftSemi",
-            join_rel::JoinType::RightSemi => "RightSemi",
-            join_rel::JoinType::LeftAnti => "LeftAnti",
-            join_rel::JoinType::RightAnti => "RightAnti",
-            join_rel::JoinType::LeftSingle => "LeftSingle",
-            join_rel::JoinType::RightSingle => "RightSingle",
-            join_rel::JoinType::LeftMark => "LeftMark",
-            join_rel::JoinType::RightMark => "RightMark",
-        };
-        Ok(Cow::Borrowed(s))
-    }
-}
-
-impl ValueEnum for set_rel::SetOp {
-    fn as_enum_str(&self) -> Result<Cow<'static, str>, PlanError> {
-        let s = match self {
-            set_rel::SetOp::Unspecified => {
-                return Err(PlanError::invalid(
-                    "SetOp",
-                    Option::<Cow<str>>::None,
-                    "Unspecified SetOp",
-                ));
-            }
-            set_rel::SetOp::MinusPrimary => "MinusPrimary",
-            set_rel::SetOp::MinusPrimaryAll => "MinusPrimaryAll",
-            set_rel::SetOp::MinusMultiset => "MinusMultiset",
-            set_rel::SetOp::IntersectionPrimary => "IntersectionPrimary",
-            set_rel::SetOp::IntersectionMultiset => "IntersectionMultiset",
-            set_rel::SetOp::IntersectionMultisetAll => "IntersectionMultisetAll",
-            set_rel::SetOp::UnionDistinct => "UnionDistinct",
-            set_rel::SetOp::UnionAll => "UnionAll",
-        };
-        Ok(Cow::Borrowed(s))
-    }
-}
-
-impl<'a> Textify for NamedArg<'a> {
-    fn name() -> &'static str {
-        "NamedArg"
-    }
-    fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
-        write!(w, "{}=", self.name)?;
-        self.value.textify(ctx, w)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use substrait::proto::aggregate_rel::Grouping;
@@ -1355,12 +1062,13 @@ mod tests {
     use substrait::proto::rel_common::{Direct, Emit};
     use substrait::proto::r#type::{self as ptype, Boolean, I64, Kind, Nullability, Struct};
     use substrait::proto::{
-        Expression, FunctionArgument, NamedStruct, ReadRel, Type, aggregate_rel,
+        AggregateFunction, Expression, FunctionArgument, NamedStruct, ReadRel, Type, aggregate_rel,
     };
 
     use super::*;
     use crate::fixtures::TestContext;
     use crate::parser::expressions::FieldIndex;
+    use crate::textify::expressions::Reference;
 
     #[test]
     fn test_read_rel() {

--- a/src/textify/values.rs
+++ b/src/textify/values.rs
@@ -92,53 +92,19 @@ impl<'a> Textify for Value<'a> {
     }
 }
 
-/// How an argument list renders inside a relation's `[...]` or an
-/// expression's `(...)`.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum ArgsLayout {
-    /// `arg, arg, arg` on a single line.
-    #[default]
-    Inline,
-    /// One `- arg` per line, used for `Read:Virtual` rows. See
-    /// [`super::rels::Relation::write_header`] for the exact layout.
-    Rows,
-}
-
-#[derive(Debug, Clone)]
+/// A comma-separated argument list: positional arguments first, then named
+/// arguments. Renders as `arg, arg, name=arg`, or `_` when empty.
+#[derive(Debug, Clone, Default)]
 pub struct Arguments<'a> {
     /// Positional arguments (e.g., a filter condition, group-bys, etc.)
     pub positional: Vec<Value<'a>>,
     /// Named arguments (e.g., limit=10, offset=5)
     pub named: Vec<NamedArg<'a>>,
-    /// How this argument list is laid out. Defaults to [`ArgsLayout::Inline`];
-    /// only `Read:Virtual` opts into [`ArgsLayout::Rows`].
-    layout: ArgsLayout,
 }
 
 impl<'a> Arguments<'a> {
-    /// An inline argument list (`arg, arg, arg`), the default for every
-    /// relation.
-    pub fn inline(positional: Vec<Value<'a>>, named: Vec<NamedArg<'a>>) -> Self {
-        Arguments {
-            positional,
-            named,
-            layout: ArgsLayout::Inline,
-        }
-    }
-
-    /// A row-per-line argument list (`- arg` per line) used for `Read:Virtual`
-    /// with many rows. Currently not enabled for named arguments.
-    /// TODO: enable for named arguments as well.
-    pub fn rows(positional: Vec<Value<'a>>) -> Self {
-        Arguments {
-            positional,
-            named: vec![],
-            layout: ArgsLayout::Rows,
-        }
-    }
-
-    pub fn layout(&self) -> ArgsLayout {
-        self.layout
+    pub fn new(positional: Vec<Value<'a>>, named: Vec<NamedArg<'a>>) -> Self {
+        Arguments { positional, named }
     }
 }
 
@@ -208,10 +174,11 @@ pub(crate) fn enum_str_value<'a>(result: Result<Cow<'static, str>, PlanError>) -
 /// rendering: convert to the enum type and then to its `&Variant` string, or
 /// produce a field-specific diagnostic when the raw value matches no variant.
 ///
-/// Shared by the callers that render an enum field straight from its `i32`
-/// (window `phase=`/`invocation=`, `SetRel`'s `op`), so the
-/// decode-or-diagnose shape lives in one place. `message` is the proto message
-/// tag used for the failure token, `field` the offending field name.
+/// Keeps the decode-or-diagnose shape in one place for callers that render an
+/// enum field straight from its `i32` (currently `SetRel`'s `op`). `message` is
+/// the proto message tag used for the failure token, `field` the offending
+/// field name; both are named in the diagnostic so it identifies which field
+/// carried the unknown value.
 pub(crate) fn decode_enum_field<'a, T>(
     raw: i32,
     message: &'static str,
@@ -225,7 +192,7 @@ where
         Err(_) => Value::Missing(PlanError::invalid(
             message,
             Some(field),
-            format!("Unknown {message}: {raw}"),
+            format!("Unknown {message}.{field}: {raw}"),
         )),
     }
 }
@@ -354,5 +321,108 @@ impl<'a> Textify for NamedArg<'a> {
     fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
         write!(w, "{}=", self.name)?;
         self.value.textify(ctx, w)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fixtures::TestContext;
+
+    #[test]
+    fn test_arguments_textify_positional_only() {
+        let ctx = TestContext::new();
+        let args = Arguments::new(vec![Value::Integer(42), Value::Integer(7)], vec![]);
+        let (result, errors) = ctx.textify(&args);
+        assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
+        assert_eq!(result, "42, 7");
+    }
+
+    #[test]
+    fn test_arguments_textify_named_only() {
+        let ctx = TestContext::new();
+        let args = Arguments::new(
+            vec![],
+            vec![
+                NamedArg {
+                    name: Cow::Borrowed("limit"),
+                    value: Value::Integer(10),
+                },
+                NamedArg {
+                    name: Cow::Borrowed("offset"),
+                    value: Value::Integer(5),
+                },
+            ],
+        );
+        let (result, errors) = ctx.textify(&args);
+        assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
+        assert_eq!(result, "limit=10, offset=5");
+    }
+
+    #[test]
+    fn test_arguments_textify_both() {
+        let ctx = TestContext::new();
+        let args = Arguments::new(
+            vec![Value::Integer(1)],
+            vec![NamedArg {
+                name: "foo".into(),
+                value: Value::Integer(2),
+            }],
+        );
+        let (result, errors) = ctx.textify(&args);
+        assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
+        assert_eq!(result, "1, foo=2");
+    }
+
+    #[test]
+    fn test_arguments_textify_empty() {
+        let ctx = TestContext::new();
+        let args = Arguments::new(vec![], vec![]);
+        let (result, errors) = ctx.textify(&args);
+        assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
+        assert_eq!(result, "_");
+    }
+
+    #[test]
+    fn test_named_arg_textify_error_token() {
+        let ctx = TestContext::new();
+        let named_arg = NamedArg {
+            name: "foo".into(),
+            value: Value::Missing(PlanError::invalid(
+                "my_enum",
+                Some(Cow::Borrowed("my_enum")),
+                Cow::Borrowed("my_enum"),
+            )),
+        };
+        let (result, errors) = ctx.textify(&named_arg);
+        // Should show !{my_enum} in the output
+        assert!(result.contains("foo=!{my_enum}"), "Output: {result}");
+        // Should also accumulate an error
+        assert!(!errors.is_empty(), "Expected error for error token");
+    }
+
+    #[test]
+    fn test_decode_enum_field_known_variant() {
+        let value =
+            decode_enum_field::<set_rel::SetOp>(set_rel::SetOp::UnionAll as i32, "SetRel", "op");
+        match value {
+            Value::Enum(s) => assert_eq!(s, "UnionAll"),
+            other => panic!("Expected Value::Enum, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_decode_enum_field_unknown_variant_names_field() {
+        let value = decode_enum_field::<set_rel::SetOp>(99, "SetRel", "op");
+        match value {
+            Value::Missing(err) => {
+                assert_eq!(err.message, "SetRel");
+                assert_eq!(err.lookup.as_deref(), Some("op"));
+                // The description names the offending field, not just the
+                // message, so the diagnostic is actionable on its own.
+                assert_eq!(err.description, "Unknown SetRel.op: 99");
+            }
+            other => panic!("Expected Value::Missing, got {other:?}"),
+        }
     }
 }

--- a/src/textify/values.rs
+++ b/src/textify/values.rs
@@ -1,0 +1,358 @@
+//! Shared value-rendering primitives ([`Value`], [`NamedArg`], [`Arguments`])
+//! used by both relation and expression textification.
+
+use std::borrow::Cow;
+use std::convert::TryFrom;
+use std::fmt;
+
+use prost::UnknownEnumValue;
+use substrait::proto::aggregate_function::AggregationInvocation;
+use substrait::proto::sort_field::{SortDirection, SortKind};
+use substrait::proto::{
+    AggregateFunction, AggregationPhase, Expression, SortField, join_rel, set_rel,
+};
+
+use super::types::Name;
+use super::{PlanError, Scope, Textify};
+use crate::extensions::{ExtensionColumn, ExtensionValue};
+
+/// A trait for enum types that can be rendered as `&VariantName` in the text
+/// format.
+pub trait ValueEnum {
+    fn as_enum_str(&self) -> Result<Cow<'static, str>, PlanError>;
+}
+
+#[derive(Debug, Clone)]
+pub struct NamedArg<'a> {
+    pub name: Cow<'a, str>,
+    pub value: Value<'a>,
+}
+
+#[derive(Debug, Clone)]
+pub enum Value<'a> {
+    TableName(Vec<Name<'a>>),
+    Field(Option<Name<'a>>, Option<&'a substrait::proto::Type>),
+    Tuple(Vec<Value<'a>>),
+    Reference(i32),
+    Expression(&'a Expression),
+    AggregateFunction(&'a AggregateFunction),
+    /// Represents a missing, invalid, or unspecified value.
+    Missing(PlanError),
+    /// Represents a valid enum value as a string for textification.
+    Enum(Cow<'a, str>),
+    EmptyGroup,
+    Integer(i64),
+    /// A decoded extension argument value.
+    ExtensionArgument(ExtensionValue),
+    /// A decoded extension output column.
+    ExtColumn(ExtensionColumn),
+}
+
+impl<'a> Value<'a> {
+    pub fn expect(maybe_value: Option<Self>, f: impl FnOnce() -> PlanError) -> Self {
+        match maybe_value {
+            Some(s) => s,
+            None => Value::Missing(f()),
+        }
+    }
+}
+
+impl<'a> From<Result<Vec<Name<'a>>, PlanError>> for Value<'a> {
+    fn from(token: Result<Vec<Name<'a>>, PlanError>) -> Self {
+        match token {
+            Ok(value) => Value::TableName(value),
+            Err(err) => Value::Missing(err),
+        }
+    }
+}
+
+impl<'a> Textify for Value<'a> {
+    fn name() -> &'static str {
+        "Value"
+    }
+
+    fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
+        match self {
+            Value::TableName(names) => write!(w, "{}", ctx.separated(names, ".")),
+            Value::Field(name, typ) => {
+                write!(w, "{}:{}", ctx.expect(name.as_ref()), ctx.expect(*typ))
+            }
+            Value::Tuple(values) => write!(w, "({})", ctx.separated(values, ", ")),
+            // Field-reference syntax (`$N`); inlined rather than importing `expressions::Reference`.
+            Value::Reference(i) => write!(w, "${i}"),
+            Value::Expression(e) => write!(w, "{}", ctx.display(*e)),
+            Value::AggregateFunction(agg_fn) => agg_fn.textify(ctx, w),
+            Value::Missing(err) => write!(w, "{}", ctx.failure(err.clone())),
+            Value::Enum(res) => write!(w, "&{res}"),
+            Value::Integer(i) => write!(w, "{i}"),
+            Value::EmptyGroup => write!(w, "_"),
+            Value::ExtensionArgument(ev) => ev.textify(ctx, w),
+            Value::ExtColumn(ec) => ec.textify(ctx, w),
+        }
+    }
+}
+
+/// How an argument list renders inside a relation's `[...]` or an
+/// expression's `(...)`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ArgsLayout {
+    /// `arg, arg, arg` on a single line.
+    #[default]
+    Inline,
+    /// One `- arg` per line, used for `Read:Virtual` rows. See
+    /// [`super::rels::Relation::write_header`] for the exact layout.
+    Rows,
+}
+
+#[derive(Debug, Clone)]
+pub struct Arguments<'a> {
+    /// Positional arguments (e.g., a filter condition, group-bys, etc.)
+    pub positional: Vec<Value<'a>>,
+    /// Named arguments (e.g., limit=10, offset=5)
+    pub named: Vec<NamedArg<'a>>,
+    /// How this argument list is laid out. Defaults to [`ArgsLayout::Inline`];
+    /// only `Read:Virtual` opts into [`ArgsLayout::Rows`].
+    layout: ArgsLayout,
+}
+
+impl<'a> Arguments<'a> {
+    /// An inline argument list (`arg, arg, arg`), the default for every
+    /// relation.
+    pub fn inline(positional: Vec<Value<'a>>, named: Vec<NamedArg<'a>>) -> Self {
+        Arguments {
+            positional,
+            named,
+            layout: ArgsLayout::Inline,
+        }
+    }
+
+    /// A row-per-line argument list (`- arg` per line) used for `Read:Virtual`
+    /// with many rows. Currently not enabled for named arguments.
+    /// TODO: enable for named arguments as well.
+    pub fn rows(positional: Vec<Value<'a>>) -> Self {
+        Arguments {
+            positional,
+            named: vec![],
+            layout: ArgsLayout::Rows,
+        }
+    }
+
+    pub fn layout(&self) -> ArgsLayout {
+        self.layout
+    }
+}
+
+impl<'a> Textify for Arguments<'a> {
+    fn name() -> &'static str {
+        "Arguments"
+    }
+    fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
+        if self.positional.is_empty() && self.named.is_empty() {
+            return write!(w, "_");
+        }
+
+        write!(w, "{}", ctx.separated(self.positional.iter(), ", "))?;
+        if !self.positional.is_empty() && !self.named.is_empty() {
+            write!(w, ", ")?;
+        }
+        write!(w, "{}", ctx.separated(self.named.iter(), ", "))
+    }
+}
+
+impl<'a> From<&'a SortField> for Value<'a> {
+    fn from(sf: &'a SortField) -> Self {
+        let field = match &sf.expr {
+            Some(expr) => match &expr.rex_type {
+                Some(substrait::proto::expression::RexType::Selection(fref)) => {
+                    if let Some(substrait::proto::expression::field_reference::ReferenceType::DirectReference(seg)) = &fref.reference_type {
+                        if let Some(substrait::proto::expression::reference_segment::ReferenceType::StructField(sf)) = &seg.reference_type {
+                            Value::Reference(sf.field)
+                        } else { Value::Missing(PlanError::unimplemented("SortField", Some("expr"), "Not a struct field")) }
+                    } else { Value::Missing(PlanError::unimplemented("SortField", Some("expr"), "Not a direct reference")) }
+                }
+                _ => Value::Missing(PlanError::unimplemented(
+                    "SortField",
+                    Some("expr"),
+                    "Not a selection",
+                )),
+            },
+            None => Value::Missing(PlanError::unimplemented(
+                "SortField",
+                Some("expr"),
+                "Missing expr",
+            )),
+        };
+        let direction = match &sf.sort_kind {
+            Some(kind) => Value::from(kind),
+            None => Value::Missing(PlanError::invalid(
+                "SortKind",
+                Some(Cow::Borrowed("sort_kind")),
+                "Missing sort_kind",
+            )),
+        };
+        Value::Tuple(vec![field, direction])
+    }
+}
+
+/// Converts an [`ValueEnum::as_enum_str`] result into a [`Value`]. Shared by
+/// the blanket `From<&T>` impl below and by callers that only have an owned
+/// enum value (and so can't borrow it for the lifetime `Value<'a>` requires).
+pub(crate) fn enum_str_value<'a>(result: Result<Cow<'static, str>, PlanError>) -> Value<'a> {
+    match result {
+        Ok(s) => Value::Enum(s),
+        Err(e) => Value::Missing(e),
+    }
+}
+
+/// Decode a raw protobuf enum field (`i32`) into its shared [`Value`]
+/// rendering: convert to the enum type and then to its `&Variant` string, or
+/// produce a field-specific diagnostic when the raw value matches no variant.
+///
+/// Shared by the callers that render an enum field straight from its `i32`
+/// (window `phase=`/`invocation=`, `SetRel`'s `op`), so the
+/// decode-or-diagnose shape lives in one place. `message` is the proto message
+/// tag used for the failure token, `field` the offending field name.
+pub(crate) fn decode_enum_field<'a, T>(
+    raw: i32,
+    message: &'static str,
+    field: &'static str,
+) -> Value<'a>
+where
+    T: TryFrom<i32> + ValueEnum,
+{
+    match T::try_from(raw) {
+        Ok(v) => enum_str_value(v.as_enum_str()),
+        Err(_) => Value::Missing(PlanError::invalid(
+            message,
+            Some(field),
+            format!("Unknown {message}: {raw}"),
+        )),
+    }
+}
+
+impl<'a, T: ValueEnum + ?Sized> From<&'a T> for Value<'a> {
+    fn from(enum_val: &'a T) -> Self {
+        enum_str_value(enum_val.as_enum_str())
+    }
+}
+
+impl ValueEnum for SortKind {
+    fn as_enum_str(&self) -> Result<Cow<'static, str>, PlanError> {
+        let d = match self {
+            &SortKind::Direction(d) => SortDirection::try_from(d),
+            SortKind::ComparisonFunctionReference(f) => {
+                return Err(PlanError::invalid(
+                    "SortKind",
+                    Some(Cow::Owned(format!("function reference{f}"))),
+                    "SortKind::ComparisonFunctionReference unimplemented",
+                ));
+            }
+        };
+        let s = match d {
+            Err(UnknownEnumValue(d)) => {
+                return Err(PlanError::invalid(
+                    "SortKind",
+                    Some(Cow::Owned(format!("unknown variant: {d:?}"))),
+                    "Unknown SortDirection",
+                ));
+            }
+            Ok(SortDirection::AscNullsFirst) => "AscNullsFirst",
+            Ok(SortDirection::AscNullsLast) => "AscNullsLast",
+            Ok(SortDirection::DescNullsFirst) => "DescNullsFirst",
+            Ok(SortDirection::DescNullsLast) => "DescNullsLast",
+            Ok(SortDirection::Clustered) => "Clustered",
+            Ok(SortDirection::Unspecified) => {
+                return Err(PlanError::invalid(
+                    "SortKind",
+                    Option::<Cow<str>>::None,
+                    "Unspecified SortDirection",
+                ));
+            }
+        };
+        Ok(Cow::Borrowed(s))
+    }
+}
+
+impl ValueEnum for join_rel::JoinType {
+    fn as_enum_str(&self) -> Result<Cow<'static, str>, PlanError> {
+        let s = match self {
+            join_rel::JoinType::Unspecified => {
+                return Err(PlanError::invalid(
+                    "JoinType",
+                    Option::<Cow<str>>::None,
+                    "Unspecified JoinType",
+                ));
+            }
+            join_rel::JoinType::Inner => "Inner",
+            join_rel::JoinType::Outer => "Outer",
+            join_rel::JoinType::Left => "Left",
+            join_rel::JoinType::Right => "Right",
+            join_rel::JoinType::LeftSemi => "LeftSemi",
+            join_rel::JoinType::RightSemi => "RightSemi",
+            join_rel::JoinType::LeftAnti => "LeftAnti",
+            join_rel::JoinType::RightAnti => "RightAnti",
+            join_rel::JoinType::LeftSingle => "LeftSingle",
+            join_rel::JoinType::RightSingle => "RightSingle",
+            join_rel::JoinType::LeftMark => "LeftMark",
+            join_rel::JoinType::RightMark => "RightMark",
+        };
+        Ok(Cow::Borrowed(s))
+    }
+}
+
+impl ValueEnum for set_rel::SetOp {
+    fn as_enum_str(&self) -> Result<Cow<'static, str>, PlanError> {
+        let s = match self {
+            set_rel::SetOp::Unspecified => {
+                return Err(PlanError::invalid(
+                    "SetOp",
+                    Option::<Cow<str>>::None,
+                    "Unspecified SetOp",
+                ));
+            }
+            set_rel::SetOp::MinusPrimary => "MinusPrimary",
+            set_rel::SetOp::MinusPrimaryAll => "MinusPrimaryAll",
+            set_rel::SetOp::MinusMultiset => "MinusMultiset",
+            set_rel::SetOp::IntersectionPrimary => "IntersectionPrimary",
+            set_rel::SetOp::IntersectionMultiset => "IntersectionMultiset",
+            set_rel::SetOp::IntersectionMultisetAll => "IntersectionMultisetAll",
+            set_rel::SetOp::UnionDistinct => "UnionDistinct",
+            set_rel::SetOp::UnionAll => "UnionAll",
+        };
+        Ok(Cow::Borrowed(s))
+    }
+}
+
+impl ValueEnum for AggregationPhase {
+    fn as_enum_str(&self) -> Result<Cow<'static, str>, PlanError> {
+        let s = match self {
+            AggregationPhase::Unspecified => "Unspecified",
+            AggregationPhase::InitialToIntermediate => "InitialToIntermediate",
+            AggregationPhase::IntermediateToIntermediate => "IntermediateToIntermediate",
+            AggregationPhase::InitialToResult => "InitialToResult",
+            AggregationPhase::IntermediateToResult => "IntermediateToResult",
+        };
+        Ok(Cow::Borrowed(s))
+    }
+}
+
+impl ValueEnum for AggregationInvocation {
+    fn as_enum_str(&self) -> Result<Cow<'static, str>, PlanError> {
+        let s = match self {
+            AggregationInvocation::Unspecified => "Unspecified",
+            AggregationInvocation::All => "All",
+            AggregationInvocation::Distinct => "Distinct",
+        };
+        Ok(Cow::Borrowed(s))
+    }
+}
+
+impl<'a> Textify for NamedArg<'a> {
+    fn name() -> &'static str {
+        "NamedArg"
+    }
+    fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
+        write!(w, "{}=", self.name)?;
+        self.value.textify(ctx, w)
+    }
+}

--- a/src/textify/values.rs
+++ b/src/textify/values.rs
@@ -7,6 +7,9 @@ use std::fmt;
 
 use prost::UnknownEnumValue;
 use substrait::proto::aggregate_function::AggregationInvocation;
+use substrait::proto::expression::RexType;
+use substrait::proto::expression::field_reference::ReferenceType as FieldReferenceType;
+use substrait::proto::expression::reference_segment::ReferenceType as SegmentReferenceType;
 use substrait::proto::sort_field::{SortDirection, SortKind};
 use substrait::proto::{
     AggregateFunction, AggregationPhase, Expression, SortField, join_rel, set_rel,
@@ -129,12 +132,24 @@ impl<'a> From<&'a SortField> for Value<'a> {
     fn from(sf: &'a SortField) -> Self {
         let field = match &sf.expr {
             Some(expr) => match &expr.rex_type {
-                Some(substrait::proto::expression::RexType::Selection(fref)) => {
-                    if let Some(substrait::proto::expression::field_reference::ReferenceType::DirectReference(seg)) = &fref.reference_type {
-                        if let Some(substrait::proto::expression::reference_segment::ReferenceType::StructField(sf)) = &seg.reference_type {
+                Some(RexType::Selection(fref)) => {
+                    if let Some(FieldReferenceType::DirectReference(seg)) = &fref.reference_type {
+                        if let Some(SegmentReferenceType::StructField(sf)) = &seg.reference_type {
                             Value::Reference(sf.field)
-                        } else { Value::Missing(PlanError::unimplemented("SortField", Some("expr"), "Not a struct field")) }
-                    } else { Value::Missing(PlanError::unimplemented("SortField", Some("expr"), "Not a direct reference")) }
+                        } else {
+                            Value::Missing(PlanError::unimplemented(
+                                "SortField",
+                                Some("expr"),
+                                "Not a struct field",
+                            ))
+                        }
+                    } else {
+                        Value::Missing(PlanError::unimplemented(
+                            "SortField",
+                            Some("expr"),
+                            "Not a direct reference",
+                        ))
+                    }
                 }
                 _ => Value::Missing(PlanError::unimplemented(
                     "SortField",


### PR DESCRIPTION
## Description

This PR refactors the textify code for expressions into its own module file that will be used by textify/expressions.rs and textify/rels.rs.

### Key Changes
- Move Value, NamedArg, Arguments, ArgsLayout, ValueEnum, enum_str_value, and the SortField->Value conversion out of textify::rels into a new neutral textify::values module
- adds a shared decode_enum_field helper (dedups the raw-i32-enum -> Value decode, applied here to SetRel). This decouples textify::expressions from textify::rels: both now depend downward on textify::values


## Testing
- [x] All existing tests pass
