### PR TITLE
feat: added support for filters on virtual table read rels

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -656,7 +656,7 @@ The `Read:Virtual` relation uses the same `ReadRel` protobuf message with `ReadT
 
 #### Syntax
 
-`"Read:Virtual" "[" virtual_read_rows [ "," "filter" "=" expression ] "=>" named_column_list "]"`
+`"Read:Virtual" "[" virtual_read_rows ("," "filter" "=" expression)? "=>" named_column_list "]"`
 
 Where `virtual_read_rows := virtual_row ("," virtual_row)* / "_"`, and
 `virtual_row := "(" (expression ("," expression)*)? ")"` — a parenthesized

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -656,14 +656,19 @@ The `Read:Virtual` relation uses the same `ReadRel` protobuf message with `ReadT
 
 #### Syntax
 
-`"Read:Virtual" "[" (virtual_row ("," virtual_row)*)? "=>" named_column_list "]"`
+`"Read:Virtual" "[" virtual_read_rows [ "," "filter" "=" expression ] "=>" named_column_list "]"`
 
-Where `virtual_row := "(" (expression ("," expression)*)? ")"` — a parenthesized tuple of expressions forming one row. Rows may be empty (`()`) for zero-column tables. For an empty virtual table, write `_` in place of the entire row list, e.g. `Read:Virtual[_ => id:i64]` for zero rows.
+Where `virtual_read_rows := virtual_row ("," virtual_row)* / "_"`, and
+`virtual_row := "(" (expression ("," expression)*)? ")"` — a parenthesized
+tuple of expressions forming one row. Rows may be empty (`()`) for zero-column
+tables. For an empty virtual table, write `_` in place of the entire row list,
+e.g. `Read:Virtual[_ => id:i64]` for zero rows.
 
 #### Components
 
 - `virtual_row` - parenthesized tuple of expressions, one per row; `()` for zero-column rows
 - `expression` - any expression (literal, field reference, function call)
+- `filter` - optional `ReadRel.filter` expression, with field references over the virtual table output schema
 - `named_column_list` - output column names with type annotations
 
 #### Examples
@@ -698,22 +703,50 @@ Root[id, name]
 # assert_eq!(plan.relations.len(), 1);
 ```
 
-#### Multi-line form
-
-For readability, a `Read:Virtual` with many rows may be written across several
-lines. Each continuation line is indented one level deeper than the relation and
-prefixed with a `- ` marker. Continuations are allowed after the opening `[`,
-after each row separator (`,`), and before `=>`:
+Inline form with a `ReadRel.filter`:
 
 ```rust
 # use substrait_explain::Parser;
 #
 # let plan_text = r#"
+=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml
+Functions:
+  ## 10 @  1: gt
+
+=== Plan
+Root[id, name]
+  Read:Virtual[(1, 'alice'), (2, 'bob'), filter=gt($0, 1:i64):boolean => id:i64, name:string]
+# "#;
+#
+# let plan = Parser::parse(plan_text).unwrap();
+# assert_eq!(plan.relations.len(), 1);
+```
+
+#### Multi-line form
+
+For readability, a `Read:Virtual` with many rows may be written across several
+lines. Each continuation line is indented one level deeper than the relation and
+prefixed with a `- ` marker. Continuations are allowed after the opening `[`,
+after each row or filter separator (`,`), and before `=>`:
+
+```rust
+# use substrait_explain::Parser;
+#
+# let plan_text = r#"
+=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml
+Functions:
+  ## 10 @  1: gt
+
 === Plan
 Root[id, name]
   Read:Virtual[
     - (1, 'alice'),
-    - (2, 'bob')
+    - (2, 'bob'),
+    - filter=gt($0, 1:i64):boolean
     - => id:i64, name:string]
 # "#;
 #

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -280,7 +280,7 @@ relation_open      = _{ "[" ~ relation_line_cont? }
 relation_comma     = _{ sp ~ "," ~ (relation_line_cont | sp) }
 relation_arrow     = _{ (relation_line_cont | sp) ~ "=>" ~ sp }
 
-// VirtualTable read: Read:Virtual[rows => columns] or Read:Virtual[_ => columns]
+// VirtualTable read: Read:Virtual[rows => columns] or Read:Virtual[_, filter=... => columns]
 // Rows are parenthesized tuples; _ means empty (no rows). May also be written
 // across multiple lines using the relation layout rules above:
 //   Read:Virtual[
@@ -291,9 +291,10 @@ relation_arrow     = _{ (relation_line_cont | sp) ~ "=>" ~ sp }
 // multi-line) input, so a stray continuation line after `]` is a parse error
 // rather than silently dropped. It is silent so the `EOI` token does not show
 // up among the relation's child pairs.
-virtual_read_relation = { "Read:Virtual" ~ relation_open ~ virtual_read_args ~ relation_arrow ~ named_column_list ~ "]" ~ relation_end }
+virtual_read_relation = { "Read:Virtual" ~ relation_open ~ virtual_read_rows ~ (relation_comma ~ virtual_read_filter)? ~ relation_arrow ~ named_column_list ~ "]" ~ relation_end }
 relation_end          = _{ sp ~ EOI }
-virtual_read_args     = { virtual_row_list | empty }
+virtual_read_rows     = { virtual_row_list | empty }
+virtual_read_filter   = { "filter" ~ sp ~ "=" ~ sp ~ expression }
 virtual_row_list      = { virtual_row ~ (relation_comma ~ virtual_row)* }
 virtual_row           = { "(" ~ sp ~ expression_list? ~ sp ~ ")" }
 

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -425,11 +425,18 @@ impl RelationParsePair for VirtualReadRel {
         }
 
         let mut iter = RuleIter::from(pair.into_inner());
-        let args_pair = iter.pop(Rule::virtual_read_args);
+        let rows_pair = iter.pop(Rule::virtual_read_rows);
+        let filter = iter
+            .try_pop(Rule::virtual_read_filter)
+            .map(|pair| {
+                let expression_pair = unwrap_single_pair(pair);
+                Expression::parse_pair(extensions, expression_pair).map(Box::new)
+            })
+            .transpose()?;
         let columns_pair = iter.pop(Rule::named_column_list);
         iter.done();
 
-        let rows = parse_virtual_read_args(extensions, args_pair)?;
+        let rows = parse_virtual_read_rows(extensions, rows_pair)?;
         let columns = NamedColumnList::parse_pair(extensions, columns_pair)?.0;
 
         // TODO: Validate that each row has the same number of expressions as
@@ -444,6 +451,7 @@ impl RelationParsePair for VirtualReadRel {
                     expressions: rows,
                     ..Default::default()
                 })),
+                filter,
                 ..Default::default()
             }),
             output_count,
@@ -528,12 +536,12 @@ pub(crate) fn build_named_struct(columns: Vec<Column>) -> NamedStruct {
     }
 }
 
-/// `Read:Virtual` positional args: either `empty` or a list of row tuples.
-fn parse_virtual_read_args(
+/// `Read:Virtual` rows: either `empty` or a list of row tuples.
+fn parse_virtual_read_rows(
     extensions: &SimpleExtensions,
     pair: Pair<Rule>,
 ) -> Result<Vec<nested::Struct>, MessageParseError> {
-    assert_eq!(pair.as_rule(), Rule::virtual_read_args);
+    assert_eq!(pair.as_rule(), Rule::virtual_read_rows);
     let inner = unwrap_single_pair(pair);
     match inner.as_rule() {
         Rule::empty => Ok(vec![]),
@@ -542,7 +550,7 @@ fn parse_virtual_read_args(
             .map(|row| parse_virtual_row(extensions, row))
             .collect(),
         _ => unreachable!(
-            "Unexpected rule in virtual_read_args: {:?}",
+            "Unexpected rule in virtual_read_rows: {:?}",
             inner.as_rule()
         ),
     }
@@ -1528,6 +1536,35 @@ mod tests {
             matches!(emit_kind, EmitKind::Direct(_)),
             "Expected +> without |> to produce Direct, got {emit_kind:?}"
         );
+    }
+
+    #[test]
+    fn test_parse_virtual_read_relation_filter() {
+        let extensions = TestContext::new()
+            .with_urn(1, "https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml")
+            .with_function(1, 10, "gt")
+            .extensions;
+
+        let read = VirtualReadRel::parse_pair_with_context(
+            &extensions,
+            parse_exact(
+                Rule::virtual_read_relation,
+                "Read:Virtual[(1, 'alice'), filter=gt($0, 0:i64):boolean => id:i64, name:string]",
+            ),
+            vec![],
+            0,
+        )
+        .unwrap()
+        .0
+        .0;
+
+        match read.read_type {
+            Some(read_rel::ReadType::VirtualTable(table)) => {
+                assert_eq!(table.expressions.len(), 1);
+            }
+            other => panic!("Expected VirtualTable, got {other:?}"),
+        }
+        assert!(read.filter.is_some());
     }
 
     #[test]

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -329,12 +329,20 @@ impl<'a> Arguments<'a> {
     }
 
     /// A row-per-line argument list (`- arg` per line) used for `Read:Virtual`
-    /// with many rows. Currently not enabled for named arguments.
-    /// TODO: enable for named arguments as well.
+    /// with many rows.
     pub fn rows(positional: Vec<Value<'a>>) -> Self {
         Arguments {
             positional,
             named: vec![],
+            layout: ArgsLayout::Rows,
+        }
+    }
+
+    /// A row-per-line argument list with named arguments following the rows.
+    pub fn rows_with_named(positional: Vec<Value<'a>>, named: Vec<NamedArg<'a>>) -> Self {
+        Arguments {
+            positional,
+            named,
             layout: ArgsLayout::Rows,
         }
     }
@@ -424,16 +432,27 @@ impl Relation<'_> {
                 write!(w, "{indent}{name}[{cols}]")
             }
             Some(args) if args.layout == ArgsLayout::Rows => {
-                // One `- row` per line, one indent level deeper, with a trailing
-                // comma on every row but the last, then `- <output> cols]`.
+                // One `- row` per line, one indent level deeper, with a
+                // trailing comma when another row or named argument follows,
+                // then `- <output> cols]`.
                 let child = ctx.push_indent();
                 let child_indent = child.indent();
                 writeln!(w, "{indent}{name}[")?;
                 let last = args.positional.len().saturating_sub(1);
                 for (i, row) in args.positional.iter().enumerate() {
                     let row = ctx.display(row);
-                    let comma = if i == last { "" } else { "," };
+                    let comma = if i == last && args.named.is_empty() {
+                        ""
+                    } else {
+                        ","
+                    };
                     writeln!(w, "{child_indent}- {row}{comma}")?;
+                }
+                let last = args.named.len().saturating_sub(1);
+                for (i, named_arg) in args.named.iter().enumerate() {
+                    let named_arg = ctx.display(named_arg);
+                    let comma = if i == last { "" } else { "," };
+                    writeln!(w, "{child_indent}- {named_arg}{comma}")?;
                 }
                 let output = Emitted::output_clause(&self.columns, self.emit, self.output_syntax);
                 let output = ctx.display(&output);
@@ -503,22 +522,37 @@ impl<'a> Relation<'a> {
                 }
             }
             Some(ReadType::VirtualTable(vt)) => {
-                let positional: Vec<Value> = vt
+                let row_count = vt.expressions.len();
+                let mut positional: Vec<Value> = vt
                     .expressions
                     .iter()
                     .map(|row| Value::Tuple(row.fields.iter().map(Value::Expression).collect()))
                     .collect();
+                let mut named = vec![];
+                if let Some(filter) = rel.filter.as_ref() {
+                    named.push(NamedArg {
+                        name: Cow::Borrowed("filter"),
+                        value: Value::Expression(filter.as_ref()),
+                    });
+                }
+                if positional.is_empty() && !named.is_empty() {
+                    positional.push(Value::EmptyGroup);
+                }
 
                 // Emit many rows across multiple lines for readability, based on
                 // a configurable threshold (default = 3). An empty table has no
                 // rows to spread out and is written `_`, so it stays inline
                 // regardless of the threshold — the row layout has no `_` form.
-                let multiline = !positional.is_empty()
-                    && positional.len() >= ctx.options().virtual_table_multiline_threshold;
+                let multiline =
+                    row_count > 0 && row_count >= ctx.options().virtual_table_multiline_threshold;
                 let arguments = if multiline {
-                    Arguments::rows(positional)
+                    if named.is_empty() {
+                        Arguments::rows(positional)
+                    } else {
+                        Arguments::rows_with_named(positional, named)
+                    }
                 } else {
-                    Arguments::inline(positional, vec![])
+                    Arguments::inline(positional, named)
                 };
 
                 Relation {

--- a/tests/multi_line_roundtrip.rs
+++ b/tests/multi_line_roundtrip.rs
@@ -52,6 +52,36 @@ Root[id, name]
 }
 
 #[test]
+fn test_virtual_read_multiline_filter() {
+    let multiline = r#"=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml
+Functions:
+  # 10 @  1: gt
+
+=== Plan
+Root[id, name]
+  Read:Virtual[
+    - (1, 'alice'),
+    - (2, 'bob'),
+    - (3, 'carol'),
+    - filter=gt($0, 1):boolean
+    - => id:i64, name:string]"#;
+
+    let inline = r#"=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml
+Functions:
+  # 10 @  1: gt
+
+=== Plan
+Root[id, name]
+  Read:Virtual[(1, 'alice'), (2, 'bob'), (3, 'carol'), filter=gt($0, 1:i64):boolean => id:i64, name:string]"#;
+
+    assert_roundtrip_canonical(multiline.trim(), inline.trim());
+}
+
+#[test]
 fn test_virtual_read_multiline_typed_null() {
     let inline = r#"
 === Plan

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -842,6 +842,36 @@ Root[id, name]
 }
 
 #[test]
+fn test_virtual_read_filter_roundtrip() {
+    let plan = r#"=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml
+Functions:
+  # 10 @  1: gt
+
+=== Plan
+Root[id, name]
+  Read:Virtual[(1, 'alice'), (2, 'bob'), filter=gt($0, 1):boolean => id:i64, name:string]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
+fn test_virtual_read_empty_filter_roundtrip() {
+    let plan = r#"=== Extensions
+URNs:
+  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml
+Functions:
+  # 10 @  1: gt
+
+=== Plan
+Root[id, name]
+  Read:Virtual[_, filter=gt($0, 1):boolean => id:i64, name:string]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
 fn test_virtual_read_single_column() {
     // Three rows reaches the multi-line threshold, so the canonical output
     // spreads the rows across lines.


### PR DESCRIPTION
## Description
Added support for adding filters directly on read rels. The code works by creating an optional filter variable when parsing VirtualReadRel's arguments. If the filter exists, it is then assigned directly into the Substrait protobuf struct.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Example update
- [ ] Other (please describe)

## Testing

- [x] Added tests for new functionality
- [x] All existing tests pass
- [x] Ran examples to verify behavior

## Checklist

- [x] Code follows Rust conventions
- [x] Documentation updated if needed
- [x] No breaking changes (or breaking changes documented)
- [x] Pre-commit hooks pass