### PR TITLE
feat: support explicit emits for passthrough relations

### DIFF
--- a/API.md
+++ b/API.md
@@ -277,10 +277,11 @@ let default = OutputOptions::default();
 // Verbose - show all details
 let verbose = OutputOptions::verbose();
 
-// Custom - show literal types and use 4-space indentation
+// Custom - show literal types, 4-space indentation, and explicit emits
 let custom = OutputOptions {
     literal_types: Visibility::Always,
     indent: "    ".to_string(),
+    show_emit: true,
     ..OutputOptions::default()
 };
 ```

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -522,7 +522,7 @@ An IfThen expression is a conditional function or logical operator that evaluate
 # let plan_text = r#"
 === Plan
 Root[status]
-  Fetch[limit=10, offset=0 => ]
+  Fetch[limit=10, offset=0 => $0]
     Project[if_then(true -> $0, false -> $1, _ -> $2)]
       Read[events.logs => status:string?]
 #  "#;
@@ -552,8 +552,8 @@ Where:
 - **`arguments`**: Input expressions, field references, function calls, or other parameters (optional)
 - **`named_arguments`**: Named arguments (optional)
 - **`=>`**: Separator between arguments and output columns (optional, only present when both arguments and columns are specified)
-- **`columns`**: Output column names and types, or field references for pass-through (all relations specify outputs, but format varies)
-- **`reference_list := reference ("," reference)*`**: comma-separated list of field references
+- **`columns`**: Output column names and types, or field references for pass-through; relation-specific syntax determines whether an output clause is present
+- **`reference_list := reference ("," reference)* / "_"`**: comma-separated field references, or `_` for an explicitly empty list
 
 #### Example
 
@@ -568,6 +568,85 @@ RelationName[arguments, named_arguments => columns]
 - Some relations may use '...' instead of column names when they pass through all fields
 
 The exact structure varies by relation type, but all follow this basic pattern.
+
+#### Output clauses
+
+This text format follows the [Substrait relation
+model](https://substrait.io/relations/logical_relations/). Each relation has a
+**direct output** in its **direct output order**. The relation returns that
+output directly (`Direct`), or uses an **emit** (`Emit`) to select and order
+fields from it.
+
+The relation-specific syntax defines its base direct output. Pass-through
+relations use this shared output grammar:
+
+```text
+reference_output := implicit_reference_output / explicit_emit
+implicit_reference_output := "=>" reference_list
+explicit_emit := "|>" reference_list
+```
+
+The output clauses describe the remaining parts of the relation model:
+
+- `+> additions` declares fields appended to the base direct output. Together,
+  the base fields and additions form the relation's complete direct output. Use
+  `_` when the additions list is empty.
+- `|> mapping` declares an `Emit`. Its field references are positions in the
+  complete direct output, and its listed fields form the relation's final
+  output. Use `_` when the mapping is empty.
+- `=> output` declares the relation's final output in compact form. For the
+  pass-through relations using `implicit_reference_output`, field references in
+  this form use the relation's input order. Other relations define their output
+  scope in their relation-specific syntax. When this output is the direct output
+  in its existing order, it represents `Direct`; otherwise it represents
+  `Emit`. Use `_` when the output is empty.
+- With no output clause, the relation returns its direct output as `Direct`.
+
+A pass-through relation such as `Filter`, `Fetch`, or `Sort` has its input
+fields as its complete direct output, so it uses `=>` for compact final output
+or `|>` for an explicit mapping. When a `Read` relation is written explicitly,
+its base direct output is empty and its schema follows `+>`; `|>` may then
+select or reorder that schema. A direct Read schema is written compactly after
+`=>`.
+
+#### Field-reference scopes
+
+Substrait declares, for each relation, an **input order** and a **direct output
+order**. Field references are ordinal over one of those orders, and this text
+format follows the definitions in the [Substrait
+specification](https://substrait.io/relations/logical_relations/).
+
+- The input order is the order of the incoming streams. For a relation with one
+  input it is that input's emitted output; for `Join` and `Cross` it is the left
+  input followed by the right input; for `Set` it is the shared field order of
+  the inputs, which Substrait requires to have identical field types.
+- The direct output order is the order the relation itself produces. `Filter`,
+  `Sort`, and `Fetch` produce their input order; `Project` produces the input
+  fields followed by its expressions in declaration order; `Aggregate` produces
+  the grouping expressions followed by the measures.
+- The input order of `Read` is relative to its direct schema; its "input" is what
+  it is reading from. Its references are over the direct schema, written as the
+  read's `named_column_list`, which Substrait interprets before any projection
+  is applied.
+
+`$N` refers to field N of the relation's input order, which is the scope of a
+relation's expressions: a `Filter` condition, `Project` expressions, `Aggregate`
+grouping expressions and measures, `Sort` fields, and a `Join` condition. Where
+Substrait declares a property over the direct output order instead, this
+document states that scope with the property.
+
+For `Filter`, `Sort`, `Fetch`, `Set`, and `Cross`, which use the shared
+`reference_output` grammar, output clauses use these orders as follows:
+
+- Compact output after `=>` lists the values the relation returns, over the
+  input order. The parser derives the direct output and an `Emit` mapping that
+  produce those values, and reports an error for a value the relation's direct
+  output cannot produce.
+- Explicit output after `|>` lists positions in the direct output order. It is
+  always an `Emit` mapping.
+
+Other relations define their output syntax and reference scope in their own
+sections.
 
 ### Arguments
 
@@ -634,10 +713,11 @@ direct_output := "+>" named_column_list ("|>" reference_list)?
 
 - `table_name := name ("." name)*` - table name, optionally qualified with schema/database
 - `named_column := name ":" type` - column name with type annotation
-- `named_column_list := (named_column ("," named_column)*)?` - the list of columns and their types to be read from the table `table_name`.
+- `named_column_list := "_" / (named_column ("," named_column)*)?` - the list of columns and their types to be read from the table `table_name`. `_` denotes an empty schema.
   - `=>` is used to mean implicit column ordering; for `Read`, this translates to `Direct` column ordering.
   - When used with `+>` and no `|>`, the `named_column`s are in the expected order of the table, and `Direct` emit is used.
   - When used with `+> … |>`, the `named_column`s are in the expected order of the table, and the emit order is a Remap specified by `reference_list`.
+  - The parser also accepts a blank `+>` list for compatibility; formatting writes `_`.
 
 #### Example
 
@@ -657,6 +737,7 @@ Root[result2]
 # let plan = Parser::parse(plan_text).unwrap();
 # assert_eq!(plan.relations.len(), 2);
 ```
+
 Use `+>` when the read's base schema records the direct output domain:
 
 ```rust
@@ -868,12 +949,12 @@ Root[id]
 
 #### Syntax
 
-`"Filter" "[" expression "=>" reference_list "]"`
+`filter_relation := "Filter" "[" expression reference_output? "]"`
 
 #### Components
 
 - `expression` - boolean expression for filtering
-- `reference_list` - field references to pass through
+- `reference_output` - optional compact output or explicit emit mapping over the input fields; when omitted, Filter returns its direct output as `Direct`
 
 #### Example
 
@@ -970,8 +1051,8 @@ Sort[($0, &AscNullsFirst), ($1, &DescNullsLast) => $0, $1]
 #### Syntax
 
 ```text
-sort_relation := "Sort" "[" sort_fields "=>" reference_list "]"
-sort_fields := sort_field ("," sort_field)*
+sort_relation := "Sort" "[" sort_fields reference_output? "]"
+sort_fields := sort_field ("," sort_field)* / "_"
 sort_field := "(" reference "," sort_direction ")"
 sort_direction := "&AscNullsFirst" / "&AscNullsLast" / "&DescNullsFirst" / "&DescNullsLast"
 ```
@@ -980,7 +1061,29 @@ sort_direction := "&AscNullsFirst" / "&AscNullsLast" / "&DescNullsFirst" / "&Des
 
 - Each sort field is a tuple: `(reference, sort_direction)`
 - Sort directions follow the general `enum` syntax and specify null handling
-- `reference_list` - comma-separated list of field references to pass through
+- `_` explicitly marks an empty sort-field list
+- `reference_output` optionally selects or reorders the input fields; when omitted, Sort returns its direct output as `Direct`
+
+### Fetch Relation
+
+A Fetch relation limits or offsets rows without changing its direct output.
+
+#### Syntax
+
+```text
+fetch_relation := "Fetch" "[" fetch_args reference_output? "]"
+fetch_args := fetch_arg ("," fetch_arg)* / "_"
+fetch_arg := ("limit" / "offset") "=" expression
+```
+
+#### Components
+
+- `limit` - maximum number of rows to return
+- `offset` - number of rows to skip
+- `_` explicitly marks an empty argument list
+- `reference_output` optionally selects or reorders the input fields; when omitted, Fetch returns its direct output as `Direct`
+
+A negative integer literal is rejected for `limit` or `offset`.
 
 ### Join Relation
 
@@ -1034,15 +1137,15 @@ Root[user_orders]
 
 ### Set Relation
 
-#### Syntax 
+#### Syntax
 
-`"Set" "[" set_op "=>" reference_list "]"`
+`set_relation := "Set" "[" set_op reference_output? "]"`
 
 #### Components
 
 - `set_op` - Set operation enum with `&` prefix, using Substrait's protobuf `SetOp`
   variant names directly
-- `reference_list` - Comma-separated list of field references for output columns
+- `reference_output` - optional compact output or explicit emit mapping over the common input schema; when omitted, Set returns that schema as `Direct`
 
 A `Set` relation combines two or more inputs (written as indented children,
 like any other multi-input relation), which must all share the same output
@@ -1071,16 +1174,17 @@ Root[id, name]
 
 #### Syntax
 
-`"Cross" "[" reference_list "]"`
+`cross_relation := "Cross" "[" "_" reference_output? "]"`
 
 #### Components
 
-- `reference_list` - Comma-separated list of field references for output columns
+- `_` - required empty parameter list
+- `reference_output` - optional compact output or explicit emit mapping over the concatenated left and right inputs; when omitted, Cross returns its direct output as `Direct`
 
 A `Cross` relation is the Cartesian product of its two inputs (written as
-indented children). It takes no arguments, so the bracket body is just the
-output columns. The output concatenates the left and right inputs, so field
-references map to the combined schema:
+indented children). Its parameter list is empty, so it is written as `_`.
+The output concatenates the left and right inputs, so field references map to
+the combined schema:
 
 - `$0`, `$1`, ... refer to left input fields
 - `$n`, `$n+1`, ... refer to right input fields (where n = number of left fields)
@@ -1093,7 +1197,7 @@ references map to the combined schema:
 # let plan_text = r#"
 === Plan
 Root[id, name, order_id, amount]
-  Cross[$0, $1, $2, $3]
+  Cross[_]
     Read[users => id:i64, name:string]
     Read[orders => order_id:i64, amount:i32]
 # "#;

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -65,11 +65,11 @@ parameter = { type | integer | name }
 
 // An arbitrary parameter list for use with type expressions or function calls.
 // Example: <T, V>
-// 
+//
 // Note that if a type can have no parameters, there should be no parameter list.
 // A type that can take parameters but has an empty parameter list should be
 // written with the empty parameter list.
-// 
+//
 // As examples: 'i64' and 'struct<>' are valid, but 'i64<>' and 'struct' are not.
 parameters = { "<" ~ (parameter ~ ("," ~ sp ~ parameter)*)? ~ ">" }
 
@@ -105,7 +105,7 @@ simple_type_name = {
 simple_type = { simple_type_name ~ nullability }
 
 // -- Compound Types --
-// 
+//
 // Note that the names here are case-insensitive. In the docs, they are shown as
 // upper-case, but I prefer them lowercase...
 
@@ -207,32 +207,32 @@ simple_extension_name = @{ "u!"? ~ identifier ~ (":" ~ argument_signature?)? }
 simple_extension = { anchor ~ sp ~ urn_anchor ~ sp ~ ":" ~ sp ~ simple_extension_name }
 
 // == Relations ==
-// These rules are for parsing relations - well, for parsing one relation on one line.
-// A relation is in the form:
-// NAME[parameters => columns]
-// 
-// Parameters are optional, and are a comma-separated list of expressions.
-// Columns are required, and are a comma-separated list of named columns.
-// 
-// Example:
-// 
-// name "[" (arguments "=>")? columns "]"
-// where:
-// - arguments are a comma-separated list of table names or expressions
 
+// -- Common relation components --
+// Relations define their own parameters and direct-output shapes below.
+reference_list = { empty | (reference ~ (sp ~ "," ~ sp ~ reference)*) }
+
+// Pass-through relations use references for both compact final output and
+// explicit emit mappings. An omitted clause means Direct, `=>` describes
+// compact final output, and `|>` preserves Emit.
+reference_output          = { implicit_reference_output | explicit_emit }
+implicit_reference_output = { "=>" ~ sp ~ reference_list }
+explicit_emit             = { "|>" ~ sp ~ reference_list }
+
+// -- Read relation components --
 table_name = { (name ~ ("." ~ name)*) }
 
 named_column      = { name ~ ":" ~ type }
-named_column_list = { (named_column ~ ("," ~ sp ~ named_column)*)? }
+named_column_list = { empty | (named_column ~ ("," ~ sp ~ named_column)*)? }
 
-// -- Output clauses --
-// `=>` declares the final visible output columns without preserving a RelCommon.emit distinction.
-// `+>` declares the direct output domain. Without `|>`, it is an explicit
-// `|>` the trailing reference list is preserved as an explicit Emit over that direct output domain.
-output          = { implicit_output | direct_output }
-implicit_output = { "=>" ~ sp ~ named_column_list }
-direct_output   = { "+>" ~ sp ~ named_column_list ~ emit_suffix }
-emit_suffix     = { (sp ~ "|>" ~ sp ~ reference_list)? }
+// -- Read output clauses --
+// `=>` declares the final visible schema in compact Read syntax. `+>` declares
+// the complete direct schema; an optional `|>` preserves an explicit Emit over
+// that schema.
+read_output          = { implicit_read_output | direct_read_output }
+implicit_read_output = { "=>" ~ sp ~ named_column_list }
+direct_read_output   = { "+>" ~ sp ~ named_column_list ~ read_emit_suffix }
+read_emit_suffix     = { (sp ~ "|>" ~ sp ~ reference_list)? }
 
 planNode = {
     // Specialized read relations must precede read_relation: all start with
@@ -262,7 +262,7 @@ top_level_relation = {
 root_relation  = { "Root" ~ "[" ~ root_name_list ~ "]" }
 root_name_list = { (name ~ (sp ~ "," ~ sp ~ name)*)? }
 
-read_relation = { "Read" ~ "[" ~ table_name ~ sp ~ output ~ "]" }
+read_relation = { "Read" ~ "[" ~ table_name ~ sp ~ read_output ~ "]" }
 
 // ExtensionTable read: Read:Extension[columns], with detail in a required + Ext addendum.
 extension_read_relation = { "Read:Extension" ~ "[" ~ named_column_list ~ "]" }
@@ -298,8 +298,7 @@ virtual_read_filter   = { "filter" ~ sp ~ "=" ~ sp ~ expression }
 virtual_row_list      = { virtual_row ~ (relation_comma ~ virtual_row)* }
 virtual_row           = { "(" ~ sp ~ expression_list? ~ sp ~ ")" }
 
-filter_relation = { "Filter" ~ "[" ~ expression ~ sp ~ "=>" ~ sp ~ reference_list ~ "]" }
-reference_list  = { (reference ~ (sp ~ "," ~ sp ~ reference)*)? }
+filter_relation = { "Filter" ~ "[" ~ expression ~ (sp ~ reference_output)? ~ "]" }
 
 project_relation      = { "Project" ~ "[" ~ project_argument_list ~ "]" }
 project_argument_list = { (project_argument ~ (sp ~ "," ~ sp ~ project_argument)*)? }
@@ -326,18 +325,18 @@ aggregate_output      = { (expression ~ (sp ~ "," ~ sp ~ expression)*)? }
 empty = { "_" }
 
 // SortRel: Sort[($0, &AscNullsFirst), ($2, &DescNullsLast) => ...]
-sort_relation   = { "Sort" ~ "[" ~ sort_field_list ~ sp ~ "=>" ~ sp ~ reference_list ~ "]" }
-sort_field_list = { (sort_field ~ (sp ~ "," ~ sp ~ sort_field)*)? }
+sort_relation   = { "Sort" ~ "[" ~ sort_field_list ~ (sp ~ reference_output)? ~ "]" }
+sort_field_list = { empty | (sort_field ~ (sp ~ "," ~ sp ~ sort_field)*) }
 sort_field      = { "(" ~ sp ~ reference ~ sp ~ "," ~ sp ~ sort_direction ~ sp ~ ")" }
 sort_direction  = { "&AscNullsFirst" | "&AscNullsLast" | "&DescNullsFirst" | "&DescNullsLast" }
 
 // FetchRel: Fetch[limit=..., offset=... => ...] (named arguments only, any order, or _ for empty)
 fetch_arg_name       =  { "limit" | "offset" }
-fetch_value          =  { integer | expression }
+fetch_value          =  { expression }
 fetch_named_arg      =  { fetch_arg_name ~ sp ~ "=" ~ sp ~ fetch_value }
 fetch_named_arg_list =  { fetch_named_arg ~ (sp ~ "," ~ sp ~ fetch_named_arg)* }
 fetch_args           = _{ fetch_named_arg_list | empty }
-fetch_relation       =  { "Fetch" ~ "[" ~ fetch_args ~ sp ~ "=>" ~ sp ~ reference_list ~ "]" }
+fetch_relation       =  { "Fetch" ~ "[" ~ fetch_args ~ (sp ~ reference_output)? ~ "]" }
 
 // JoinRel: Join[&Inner, eq($0, $2), post_filter=gt($3, 0) => $0, $1, $2, $3]
 // Note: Longer prefixes must come before shorter ones (e.g., "&LeftSemi" before "&Left")
@@ -350,10 +349,10 @@ join_relation         = { "Join" ~ "[" ~ join_type ~ sp ~ "," ~ sp ~ expression 
 // Note: Longer prefixes must come before shorter ones (e.g., "&IntersectionMultisetAll"
 // before "&IntersectionMultiset") so that the parser doesn't stop at the shorter match.
 set_op        = { "&IntersectionMultisetAll" | "&IntersectionMultiset" | "&IntersectionPrimary" | "&MinusPrimaryAll" | "&MinusPrimary" | "&MinusMultiset" | "&UnionAll" | "&UnionDistinct" }
-set_relation  = { "Set" ~ "[" ~ set_op ~ sp ~ "=>" ~ sp ~ reference_list ~ "]" }
+set_relation  = { "Set" ~ "[" ~ set_op ~ (sp ~ reference_output)? ~ "]" }
 
-// CrossRel: Cross[$0, $1, $2, $3]  (Cartesian product of left and right; no args)
-cross_relation = { "Cross" ~ "[" ~ reference_list ~ "]" }
+// CrossRel has no parameters, so its required parameter list is `_`.
+cross_relation = { "Cross" ~ "[" ~ empty ~ (sp ~ reference_output)? ~ "]" }
 
 // Extension relations for custom operators not covered by standard Substrait
 // Format: ExtensionType:ExtensionName[arguments, named_arguments => columns]

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -4,7 +4,7 @@ use pest::iterators::Pair;
 use prost::Message;
 use substrait::proto::aggregate_rel::Grouping;
 use substrait::proto::expression::literal::LiteralType;
-use substrait::proto::expression::{Literal, RexType, nested};
+use substrait::proto::expression::{RexType, nested};
 use substrait::proto::extensions::AdvancedExtension;
 use substrait::proto::fetch_rel::{CountMode, OffsetMode};
 use substrait::proto::rel::RelType;
@@ -171,7 +171,10 @@ impl ScopedParsePair for NamedColumnList {
     ) -> Result<Self, MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
         let mut columns = Vec::new();
-        for col in pair.into_inner() {
+        for col in pair
+            .into_inner()
+            .filter(|pair| pair.as_rule() == Rule::named_column)
+        {
             columns.push(Column::parse_pair(extensions, col)?);
         }
         Ok(Self(columns))
@@ -202,78 +205,184 @@ pub(crate) fn expect_one_child(
     }
 }
 
-/// Parse a reference list Pair and return an EmitKind::Emit.
-/// Parse a reference list into field indices for emit mapping.
-fn parse_output_mapping(pair: Pair<Rule>) -> Vec<i32> {
-    assert_eq!(pair.as_rule(), Rule::reference_list);
-    pair.into_inner()
-        .map(|p| FieldIndex::parse_pair(p).0)
-        .collect()
-}
+/// A list of field indices addressing a relation's direct output, as written
+/// in a `=>` or `|>` output clause.
+#[derive(Debug)]
+struct OutputMapping(Vec<i32>);
 
-/// Build an emit: `Direct` if the mapping is the identity `[0, 1, ..., N-1]`
-/// (where N = `direct_output_count`), otherwise `Emit` with the explicit mapping.
-fn make_emit(output_mapping: Vec<i32>, direct_output_count: usize) -> EmitKind {
-    let is_identity = output_mapping.len() == direct_output_count
-        && output_mapping
-            .iter()
-            .enumerate()
-            .all(|(i, &v)| v == i as i32);
-    if is_identity {
-        EmitKind::Direct(Direct {})
-    } else {
-        EmitKind::Emit(Emit { output_mapping })
+impl ParsePair for OutputMapping {
+    fn rule() -> Rule {
+        Rule::reference_list
+    }
+
+    fn message() -> &'static str {
+        "OutputMapping"
+    }
+
+    fn parse_pair(pair: Pair<Rule>) -> Self {
+        assert_eq!(pair.as_rule(), Self::rule());
+        Self(
+            pair.into_inner()
+                .filter(|pair| pair.as_rule() == Rule::reference)
+                .map(|pair| FieldIndex::parse_pair(pair).0)
+                .collect(),
+        )
     }
 }
 
-/// Parse a reference list into an emit and output field count.
-fn parse_emit(reference_list: Pair<Rule>, direct_output_count: usize) -> (EmitKind, usize) {
-    let output_mapping = parse_output_mapping(reference_list);
-    let output_count = output_mapping.len();
-    let emit = make_emit(output_mapping, direct_output_count);
-    (emit, output_count)
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "Field reference ${field} is out of bounds for direct output with {direct_output_count} fields"
+)]
+struct OutputReferenceOutOfBounds {
+    field: i32,
+    direct_output_count: usize,
 }
 
-fn parse_output(
+impl OutputReferenceOutOfBounds {
+    fn into_parse_error(self, message: &'static str, span: pest::Span<'_>) -> MessageParseError {
+        MessageParseError::invalid(message, span, self)
+    }
+}
+
+impl OutputMapping {
+    fn validate(&self, direct_output_count: usize) -> Result<(), OutputReferenceOutOfBounds> {
+        if let Some(&field) = self
+            .0
+            .iter()
+            .find(|&&field| field < 0 || field as usize >= direct_output_count)
+        {
+            return Err(OutputReferenceOutOfBounds {
+                field,
+                direct_output_count,
+            });
+        }
+        Ok(())
+    }
+
+    /// Build a compact emit: `Direct` if the mapping is the identity
+    /// `[0, 1, ..., N-1]` (where N = `direct_output_count`), otherwise `Emit`
+    /// with the explicit mapping.
+    fn into_compact_emit(self, direct_output_count: usize) -> (EmitKind, usize) {
+        let output_count = self.0.len();
+        let is_identity = output_count == direct_output_count
+            && self
+                .0
+                .iter()
+                .enumerate()
+                .all(|(index, &field)| field == index as i32);
+        let emit = if is_identity {
+            EmitKind::Direct(Direct {})
+        } else {
+            EmitKind::Emit(Emit {
+                output_mapping: self.0,
+            })
+        };
+        (emit, output_count)
+    }
+
+    /// Build an explicit emit, which is always `Emit`, even for an identity
+    /// mapping.
+    fn into_explicit_emit(self) -> (EmitKind, usize) {
+        let output_count = self.0.len();
+        (
+            EmitKind::Emit(Emit {
+                output_mapping: self.0,
+            }),
+            output_count,
+        )
+    }
+}
+
+/// Output syntax for a relation with no added direct-output columns - either `=> <reference_list>` or `|> reference_list`
+#[derive(Debug)]
+enum PassthroughOutput {
+    /// No output clause: expose the inherited direct output.
+    Direct,
+    /// Compact `=>` syntax, which describes the final output.
+    Compact(OutputMapping),
+    /// Explicit `|>` syntax, which preserves an Emit even for an identity map.
+    Explicit(OutputMapping),
+}
+
+impl ParsePair for PassthroughOutput {
+    fn rule() -> Rule {
+        Rule::reference_output
+    }
+
+    fn message() -> &'static str {
+        "PassthroughOutput"
+    }
+
+    fn parse_pair(pair: Pair<Rule>) -> Self {
+        assert_eq!(pair.as_rule(), Self::rule());
+        let output = unwrap_single_pair(pair);
+        match output.as_rule() {
+            Rule::implicit_reference_output => {
+                Self::Compact(OutputMapping::parse_pair(unwrap_single_pair(output)))
+            }
+            Rule::explicit_emit => {
+                Self::Explicit(OutputMapping::parse_pair(unwrap_single_pair(output)))
+            }
+            other => unreachable!("Unexpected reference output: {other:?}"),
+        }
+    }
+}
+
+impl PassthroughOutput {
+    fn resolve(
+        self,
+        direct_output_count: usize,
+    ) -> Result<(EmitKind, usize), OutputReferenceOutOfBounds> {
+        match self {
+            Self::Direct => Ok((EmitKind::Direct(Direct {}), direct_output_count)),
+            Self::Compact(mapping) => {
+                mapping.validate(direct_output_count)?;
+                Ok(mapping.into_compact_emit(direct_output_count))
+            }
+            Self::Explicit(mapping) => {
+                mapping.validate(direct_output_count)?;
+                Ok(mapping.into_explicit_emit())
+            }
+        }
+    }
+}
+
+fn parse_read_output(
     extensions: &SimpleExtensions,
     output: Pair<Rule>,
 ) -> Result<(Vec<Column>, Option<RelCommon>, usize), MessageParseError> {
-    assert_eq!(output.as_rule(), Rule::output);
+    assert_eq!(output.as_rule(), Rule::read_output);
     let output = unwrap_single_pair(output);
     match output.as_rule() {
-        Rule::implicit_output => {
+        Rule::implicit_read_output => {
             let mut iter = RuleIter::from(output.into_inner());
             let columns = iter.parse_next_scoped::<NamedColumnList>(extensions)?.0;
             iter.done();
             let output_count = columns.len();
             Ok((columns, None, output_count))
         }
-        Rule::direct_output => {
+        Rule::direct_read_output => {
             let mut iter = RuleIter::from(output.into_inner());
             let columns = iter.parse_next_scoped::<NamedColumnList>(extensions)?.0;
-            let emit_suffix = iter.pop(Rule::emit_suffix);
+            let emit = iter
+                .pop(Rule::read_emit_suffix)
+                .into_inner()
+                .next()
+                .map(|mapping| OutputMapping::parse_pair(mapping).into_explicit_emit());
             iter.done();
 
             let direct_output_count = columns.len();
-            let (emit, output_count) = parse_emit_suffix(emit_suffix)
-                .unwrap_or((EmitKind::Direct(Direct {}), direct_output_count));
+            let (emit, output_count) =
+                emit.unwrap_or((EmitKind::Direct(Direct {}), direct_output_count));
             let common = Some(RelCommon {
                 emit_kind: Some(emit),
                 ..Default::default()
             });
             Ok((columns, common, output_count))
         }
-        other => unreachable!("Unexpected rule in output: {other:?}"),
+        other => unreachable!("Unexpected rule in Read output: {other:?}"),
     }
-}
-
-fn parse_emit_suffix(suffix: Pair<Rule>) -> Option<(EmitKind, usize)> {
-    assert_eq!(suffix.as_rule(), Rule::emit_suffix);
-    let reference_list = suffix.into_inner().next()?;
-    assert_eq!(reference_list.as_rule(), Rule::reference_list);
-    let output_mapping = parse_output_mapping(reference_list);
-    let output_count = output_mapping.len();
-    Some((EmitKind::Emit(Emit { output_mapping }), output_count))
 }
 
 /// Extracts named arguments from pest pairs with duplicate detection and completeness checking.
@@ -368,10 +477,10 @@ impl RelationParsePair for ReadRel {
 
         let mut iter = RuleIter::from(pair.into_inner());
         let table = iter.parse_next::<TableName>().0;
-        let output_pair = iter.pop(Rule::output);
+        let output_pair = iter.pop(Rule::read_output);
         iter.done();
 
-        let (columns, common, output_count) = parse_output(extensions, output_pair)?;
+        let (columns, common, output_count) = parse_read_output(extensions, output_pair)?;
 
         Ok((
             ReadRel {
@@ -597,12 +706,17 @@ impl RelationParsePair for FilterRel {
     ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
         let input = expect_one_child(Self::message(), &pair, input_children)?;
+        let span = pair.as_span();
         let mut iter = RuleIter::from(pair.into_inner());
         let condition = iter.parse_next_scoped::<Expression>(extensions)?;
-        let references_pair = iter.pop(Rule::reference_list);
+        let output = iter
+            .parse_if_next::<PassthroughOutput>()
+            .unwrap_or(PassthroughOutput::Direct);
         iter.done();
 
-        let (emit, output_count) = parse_emit(references_pair, input_field_count);
+        let (emit, output_count) = output
+            .resolve(input_field_count)
+            .map_err(|error| error.into_parse_error(Self::message(), span))?;
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
@@ -667,9 +781,8 @@ impl RelationParsePair for ProjectRel {
             }
         }
 
-        let output_count = output_mapping.len();
         let direct_count = input_field_count + expressions.len();
-        let emit = make_emit(output_mapping, direct_count);
+        let (emit, output_count) = OutputMapping(output_mapping).into_compact_emit(direct_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
@@ -729,9 +842,8 @@ impl RelationParsePair for AggregateRel {
         let (measures, output_mapping) =
             parse_aggregate_output(extensions, output_pair, &grouping_expressions)?;
 
-        let output_count = output_mapping.len();
         let direct_count = grouping_expressions.len() + measures.len();
-        let emit = make_emit(output_mapping, direct_count);
+        let (emit, output_count) = OutputMapping(output_mapping).into_compact_emit(direct_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
@@ -988,20 +1100,27 @@ impl RelationParsePair for SortRel {
     ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
         let input = expect_one_child(Self::message(), &pair, input_children)?;
+        let span = pair.as_span();
         let mut iter = RuleIter::from(pair.into_inner());
         let sort_field_list_pair = iter.pop(Rule::sort_field_list);
-        let references_pair = iter.pop(Rule::reference_list);
+        let output = iter
+            .parse_if_next::<PassthroughOutput>()
+            .unwrap_or(PassthroughOutput::Direct);
         let mut sorts = Vec::new();
         for sort_field_pair in sort_field_list_pair.into_inner() {
-            let sort_field = SortField::parse_pair(extensions, sort_field_pair)?;
-            sorts.push(sort_field);
+            if sort_field_pair.as_rule() == Rule::sort_field {
+                let sort_field = SortField::parse_pair(extensions, sort_field_pair)?;
+                sorts.push(sort_field);
+            }
         }
-        let (emit, output_count) = parse_emit(references_pair, input_field_count);
+        iter.done();
+        let (emit, output_count) = output
+            .resolve(input_field_count)
+            .map_err(|error| error.into_parse_error(Self::message(), span))?;
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
         };
-        iter.done();
         Ok((
             SortRel {
                 input: Some(input),
@@ -1026,51 +1145,25 @@ impl ScopedParsePair for CountMode {
         pair: Pair<Rule>,
     ) -> Result<Self, MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
+        let span = pair.as_span();
         let mut arg_inner = RuleIter::from(pair.into_inner());
-        let value_pair = if let Some(int_pair) = arg_inner.try_pop(Rule::integer) {
-            int_pair
-        } else {
-            arg_inner.pop(Rule::expression)
-        };
-        match value_pair.as_rule() {
-            Rule::integer => {
-                let value = value_pair.as_str().parse::<i64>().map_err(|e| {
-                    MessageParseError::invalid(
-                        Self::message(),
-                        value_pair.as_span(),
-                        format!("Invalid integer: {e}"),
-                    )
-                })?;
-                if value < 0 {
-                    return Err(MessageParseError::invalid(
-                        Self::message(),
-                        value_pair.as_span(),
-                        format!("Fetch limit must be non-negative, got: {value}"),
-                    ));
-                }
-                Ok(CountMode::CountExpr(i64_literal_expr(value)))
-            }
-            Rule::expression => {
-                let expr = Expression::parse_pair(extensions, value_pair)?;
-                Ok(CountMode::CountExpr(Box::new(expr)))
-            }
-            _ => Err(MessageParseError::invalid(
-                Self::message(),
-                value_pair.as_span(),
-                format!("Unexpected rule for CountMode: {:?}", value_pair.as_rule()),
-            )),
-        }
-    }
-}
+        let expression = arg_inner.parse_next_scoped::<Expression>(extensions)?;
+        arg_inner.done();
 
-fn i64_literal_expr(value: i64) -> Box<Expression> {
-    Box::new(Expression {
-        rex_type: Some(RexType::Literal(Literal {
-            nullable: false,
-            type_variation_reference: 0,
-            literal_type: Some(LiteralType::I64(value)),
-        })),
-    })
+        // TODO: Typecheck Fetch limits as i64 expressions.
+        if let Some(RexType::Literal(literal)) = &expression.rex_type
+            && let Some(LiteralType::I64(value)) = literal.literal_type.as_ref()
+            && *value < 0
+        {
+            return Err(MessageParseError::invalid(
+                Self::message(),
+                span,
+                format!("Fetch limit must be non-negative, got: {value}"),
+            ));
+        }
+
+        Ok(CountMode::CountExpr(Box::new(expression)))
+    }
 }
 
 impl ScopedParsePair for OffsetMode {
@@ -1085,40 +1178,24 @@ impl ScopedParsePair for OffsetMode {
         pair: Pair<Rule>,
     ) -> Result<Self, MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
+        let span = pair.as_span();
         let mut arg_inner = RuleIter::from(pair.into_inner());
-        let value_pair = if let Some(int_pair) = arg_inner.try_pop(Rule::integer) {
-            int_pair
-        } else {
-            arg_inner.pop(Rule::expression)
-        };
-        match value_pair.as_rule() {
-            Rule::integer => {
-                let value = value_pair.as_str().parse::<i64>().map_err(|e| {
-                    MessageParseError::invalid(
-                        Self::message(),
-                        value_pair.as_span(),
-                        format!("Invalid integer: {e}"),
-                    )
-                })?;
-                if value < 0 {
-                    return Err(MessageParseError::invalid(
-                        Self::message(),
-                        value_pair.as_span(),
-                        format!("Fetch offset must be non-negative, got: {value}"),
-                    ));
-                }
-                Ok(OffsetMode::OffsetExpr(i64_literal_expr(value)))
-            }
-            Rule::expression => {
-                let expr = Expression::parse_pair(extensions, value_pair)?;
-                Ok(OffsetMode::OffsetExpr(Box::new(expr)))
-            }
-            _ => Err(MessageParseError::invalid(
+        let expression = arg_inner.parse_next_scoped::<Expression>(extensions)?;
+        arg_inner.done();
+
+        // TODO: Typecheck Fetch offsets as i64 expressions.
+        if let Some(RexType::Literal(literal)) = &expression.rex_type
+            && let Some(LiteralType::I64(value)) = literal.literal_type.as_ref()
+            && *value < 0
+        {
+            return Err(MessageParseError::invalid(
                 Self::message(),
-                value_pair.as_span(),
-                format!("Unexpected rule for OffsetMode: {:?}", value_pair.as_rule()),
-            )),
+                span,
+                format!("Fetch offset must be non-negative, got: {value}"),
+            ));
         }
+
+        Ok(OffsetMode::OffsetExpr(Box::new(expression)))
     }
 }
 
@@ -1146,6 +1223,7 @@ impl RelationParsePair for FetchRel {
     ) -> Result<(Self, usize), MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
         let input = expect_one_child(Self::message(), &pair, input_children)?;
+        let span = pair.as_span();
         let mut iter = RuleIter::from(pair.into_inner());
 
         // Extract all pairs before any validation: RuleIter's Drop panics on
@@ -1166,13 +1244,18 @@ impl RelationParsePair for FetchRel {
             }
         };
 
-        let references_pair = iter.pop(Rule::reference_list);
-        let (emit, output_count) = parse_emit(references_pair, input_field_count);
+        let output = iter
+            .parse_if_next::<PassthroughOutput>()
+            .unwrap_or(PassthroughOutput::Direct);
+        iter.done();
+
+        let (emit, output_count) = output
+            .resolve(input_field_count)
+            .map_err(|error| error.into_parse_error(Self::message(), span))?;
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
         };
-        iter.done();
 
         let count_mode = limit_pair
             .map(|pair| CountMode::parse_pair(extensions, pair))
@@ -1278,7 +1361,8 @@ impl RelationParsePair for JoinRel {
         // TODO: For semi/anti joins, the direct output width differs from
         // left+right — `input_field_count` would misclassify the emit as Direct.
         // Revisit when those join types are supported.
-        let (emit, output_count) = parse_emit(references_pair, input_field_count);
+        let (emit, output_count) =
+            OutputMapping::parse_pair(references_pair).into_compact_emit(input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
@@ -1338,11 +1422,17 @@ impl RelationParsePair for CrossRel {
         let left = Box::new(children_iter.next().unwrap());
         let right = Box::new(children_iter.next().unwrap());
 
+        let span = pair.as_span();
         let mut iter = RuleIter::from(pair.into_inner());
-        let reference_list_pair = iter.pop(Rule::reference_list);
+        iter.pop(Rule::empty);
+        let output = iter
+            .parse_if_next::<PassthroughOutput>()
+            .unwrap_or(PassthroughOutput::Direct);
         iter.done();
 
-        let (emit, output_count) = parse_emit(reference_list_pair, input_field_count);
+        let (emit, output_count) = output
+            .resolve(input_field_count)
+            .map_err(|error| error.into_parse_error(Self::message(), span))?;
         let common = RelCommon {
             emit_kind: Some(emit),
             ..Default::default()
@@ -1420,12 +1510,17 @@ pub(crate) fn parse_set_relation_pair(
         ));
     }
 
+    let span = pair.as_span();
     let mut iter = RuleIter::from(pair.into_inner());
     let op = iter.parse_next::<set_rel::SetOp>();
-    let reference_list_pair = iter.pop(Rule::reference_list);
+    let output = iter
+        .parse_if_next::<PassthroughOutput>()
+        .unwrap_or(PassthroughOutput::Direct);
     iter.done();
 
-    let (emit, output_count) = parse_emit(reference_list_pair, child_width);
+    let (emit, output_count) = output
+        .resolve(child_width)
+        .map_err(|error| error.into_parse_error("SetRel", span))?;
     let common = RelCommon {
         emit_kind: Some(emit),
         ..Default::default()
@@ -1447,10 +1542,22 @@ pub(crate) fn parse_set_relation_pair(
 #[cfg(test)]
 mod tests {
     use pest::Parser;
+    use substrait::proto::expression::Literal;
 
     use super::*;
     use crate::fixtures::TestContext;
     use crate::parser::{ExpressionParser, Rule};
+
+    #[cfg(test)]
+    fn i64_literal_expr(value: i64) -> Box<Expression> {
+        Box::new(Expression {
+            rex_type: Some(RexType::Literal(Literal {
+                nullable: false,
+                type_variation_reference: 0,
+                literal_type: Some(LiteralType::I64(value)),
+            })),
+        })
+    }
 
     #[test]
     fn test_parse_relation() {
@@ -1622,6 +1729,57 @@ mod tests {
             matches!(emit_kind, EmitKind::Direct(_)),
             "Expected Direct for identity emit, got {emit_kind:?}"
         );
+    }
+
+    #[test]
+    fn test_parse_filter_relation_explicit_identity_emit_not_collapsed() {
+        let extensions = SimpleExtensions::default();
+        let filter = FilterRel::parse_pair_with_context(
+            &extensions,
+            parse_exact(Rule::filter_relation, "Filter[$1 |> $0, $1, $2]"),
+            vec![example_read_relation().into_rel(None)],
+            3,
+        )
+        .unwrap()
+        .0;
+
+        let emit_kind = filter.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
+        assert!(
+            matches!(emit_kind, EmitKind::Emit(emit) if emit.output_mapping == [0, 1, 2]),
+            "Expected an explicit identity mapping to remain Emit, got {emit_kind:?}"
+        );
+    }
+
+    #[test]
+    fn test_passthrough_output_rejects_out_of_bounds_references() {
+        for (input, field) in [("=> $3", 3), ("|> $3", 3), ("=> $-1", -1), ("|> $-1", -1)] {
+            let error = PassthroughOutput::parse_str(input)
+                .unwrap()
+                .resolve(3)
+                .unwrap_err();
+            assert!(matches!(
+                error,
+                OutputReferenceOutOfBounds {
+                    field: actual_field,
+                    direct_output_count: 3,
+                } if actual_field == field
+            ));
+        }
+    }
+
+    #[test]
+    fn test_sort_requires_empty_parameter_marker() {
+        assert!(ExpressionParser::parse(Rule::sort_relation, "Sort[]").is_err());
+    }
+
+    #[test]
+    fn test_cross_rejects_blank_empty_lists() {
+        for input in ["Cross[]", "Cross[_ =>]", "Cross[_ |>]"] {
+            assert!(
+                ExpressionParser::parse(Rule::cross_relation, input).is_err(),
+                "accepted {input}"
+            );
+        }
     }
 
     #[test]

--- a/src/textify/foundation.rs
+++ b/src/textify/foundation.rs
@@ -36,7 +36,15 @@ pub struct OutputOptions {
     ///
     /// If `Required`, the anchor is shown for all simple extensions.
     pub show_simple_extension_anchors: Visibility,
-    /// Instead of showing the emitted columns inline, show the emits directly.
+    /// Preserve relation direct output and explicit emit mappings.
+    ///
+    /// When false, supported relations use compact `=>` output describing the
+    /// final visible fields. When true, they use `+>` for direct additions and
+    /// `|>` for an explicit `RelCommon::Emit` mapping. This preserves an
+    /// explicit identity mapping that compact output may normalize to Direct.
+    ///
+    /// Relation kinds that do not support explicit output continue to use
+    /// their compact spelling.
     pub show_emit: bool,
 
     /// Show the types for columns in a read
@@ -83,8 +91,7 @@ impl OutputOptions {
             show_simple_extensions: true,
             show_simple_extension_anchors: Visibility::Always,
             literal_types: Visibility::Always,
-            // Emits are not required for a complete plan - just not a precise one.
-            show_emit: false,
+            show_emit: true,
             read_types: true,
             nullability: true,
             indent: "  ".to_string(),

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -95,122 +95,214 @@ fn schema_to_values<'a>(schema: &'a NamedStruct) -> Vec<Value<'a>> {
     values
 }
 
-/// How a relation header renders its output.
+/// How a relation header renders an output clause.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 enum OutputSyntax {
-    /// Output columns are rendered as final visible output: `=> output_columns`.
+    /// Final visible output: `=> output`.
     #[default]
-    Implicit,
-    /// Output columns are rendered as the direct output domain: `+> columns`,
-    /// with `|> order` appended when an explicit emit mapping is present.
+    Compact,
+    /// Explicit direct output: `+> output`, optionally followed by `|> mapping`.
+    /// Relations without direct-output additions use `|> mapping` directly.
     Explicit,
 }
 
+impl OutputSyntax {
+    fn from_show_emit(show_emit: bool) -> Self {
+        if show_emit {
+            Self::Explicit
+        } else {
+            Self::Compact
+        }
+    }
+}
+
+/// Whether a relation grammar requires an output clause when its output is Direct.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum OutputClausePresence {
+    /// The relation's header states its output domain even when it returns that
+    /// domain directly. This is used when the header declares a schema,
+    /// generated fields, or another relation-specific direct output.
+    #[default]
+    Required,
+    /// The relation derives its direct output entirely from its input, so
+    /// `Direct` needs no output clause. An explicit `Emit` writes an output
+    /// clause using the selected [`OutputSyntax`].
+    WhenNeeded,
+}
+
+/// Fields appended to a relation's base direct output by `+>`.
+struct OutputAdditions<'a>(&'a [Value<'a>]);
+
+impl Textify for OutputAdditions<'_> {
+    fn name() -> &'static str {
+        "OutputAdditions"
+    }
+
+    fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
+        if self.0.is_empty() {
+            return write!(w, "_");
+        }
+        write!(w, "{}", ctx.separated(self.0.iter(), ", "))
+    }
+}
+
+/// A mapping over positions in a relation's complete direct output.
+#[derive(Clone, Copy)]
+struct OutputMapping<'a>(&'a [i32]);
+
+impl Textify for OutputMapping<'_> {
+    fn name() -> &'static str {
+        "OutputMapping"
+    }
+
+    fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
+        if self.0.is_empty() {
+            return write!(w, "_");
+        }
+
+        for (position, &index) in self.0.iter().enumerate() {
+            if position > 0 {
+                write!(w, ", ")?;
+            }
+            write!(w, "{}", ctx.display(&Value::Reference(index)))?;
+        }
+        Ok(())
+    }
+}
+
+/// The final output produced from a relation's complete direct output.
 struct Emitted<'a> {
-    values: &'a [Value<'a>],
+    direct_output: &'a [Value<'a>],
     emit: Option<&'a EmitKind>,
-    output_syntax: Option<OutputSyntax>,
 }
 
 impl<'a> Emitted<'a> {
-    pub fn columns(values: &'a [Value<'a>], emit: Option<&'a EmitKind>) -> Self {
+    fn new(direct_output: &'a [Value<'a>], emit: Option<&'a EmitKind>) -> Self {
         Self {
-            values,
+            direct_output,
             emit,
-            output_syntax: None,
         }
-    }
-
-    pub fn output_clause(
-        values: &'a [Value<'a>],
-        emit: Option<&'a EmitKind>,
-        output_syntax: OutputSyntax,
-    ) -> Self {
-        Self {
-            values,
-            emit,
-            output_syntax: Some(output_syntax),
-        }
-    }
-
-    fn write_output_clause<S: Scope, W: fmt::Write>(
-        &self,
-        ctx: &S,
-        w: &mut W,
-        output_syntax: OutputSyntax,
-    ) -> fmt::Result {
-        match output_syntax {
-            OutputSyntax::Implicit => {
-                write!(w, "=> ")?;
-                self.write_implicit_columns(ctx, w)
-            }
-            OutputSyntax::Explicit => {
-                write!(w, "+> ")?;
-                self.write_direct_columns(ctx, w)?;
-                self.write_emit_suffix(ctx, w)
-            }
-        }
-    }
-
-    fn write_direct_columns<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
-        write!(w, "{}", ctx.separated(self.values.iter(), ", "))
-    }
-
-    fn write_implicit_columns<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
-        if ctx.options().show_emit {
-            return self.write_direct_columns(ctx, w);
-        }
-
-        let indices = match &self.emit {
-            Some(EmitKind::Emit(e)) => &e.output_mapping,
-            Some(EmitKind::Direct(_)) => return self.write_direct_columns(ctx, w),
-            None => return self.write_direct_columns(ctx, w),
-        };
-
-        for (i, &index) in indices.iter().enumerate() {
-            if i > 0 {
-                write!(w, ", ")?;
-            }
-
-            match self.values.get(index as usize) {
-                Some(value) => write!(w, "{}", ctx.display(value))?,
-                None => write!(w, "{}", ctx.failure(PlanError::invalid(
-                    "Emitted",
-                    Some("output_mapping"),
-                    format!(
-                        "Output mapping index {} is out of bounds for values collection of size {}",
-                        index, self.values.len()
-                    )
-                )))?,
-            }
-        }
-
-        Ok(())
-    }
-
-    fn write_emit_suffix<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
-        let Some(EmitKind::Emit(emit)) = self.emit else {
-            return Ok(());
-        };
-        let mapping = emit
-            .output_mapping
-            .iter()
-            .copied()
-            .map(Value::Reference)
-            .collect::<Vec<_>>();
-        write!(w, " |> {}", ctx.separated(mapping.iter(), ", "))
     }
 }
 
-impl<'a> Textify for Emitted<'a> {
+impl Textify for Emitted<'_> {
     fn name() -> &'static str {
         "Emitted"
     }
 
     fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
-        match self.output_syntax {
-            Some(output_syntax) => self.write_output_clause(ctx, w, output_syntax),
-            None => self.write_implicit_columns(ctx, w),
+        let Some(EmitKind::Emit(emit)) = self.emit else {
+            return write!(w, "{}", ctx.separated(self.direct_output.iter(), ", "));
+        };
+
+        if emit.output_mapping.is_empty() {
+            return write!(w, "_");
+        }
+
+        for (position, &index) in emit.output_mapping.iter().enumerate() {
+            if position > 0 {
+                write!(w, ", ")?;
+            }
+            match self.direct_output.get(index as usize) {
+                Some(value) => write!(w, "{}", ctx.display(value))?,
+                None => write!(w, "{}", ctx.failure(PlanError::invalid(
+                    "Emitted",
+                    Some("output_mapping"),
+                    format!(
+                        "Output mapping index {index} is out of bounds for direct output of size {}",
+                        self.direct_output.len()
+                    )
+                )))?,
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Explicit output syntax: additions with an optional mapping, or a mapping
+/// over an implicit direct output.
+enum ExplicitOutput<'a> {
+    Additions {
+        additions: OutputAdditions<'a>,
+        mapping: Option<OutputMapping<'a>>,
+    },
+    Mapping(OutputMapping<'a>),
+}
+
+impl Textify for ExplicitOutput<'_> {
+    fn name() -> &'static str {
+        "ExplicitOutput"
+    }
+
+    fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
+        match self {
+            Self::Additions {
+                additions,
+                mapping: Some(mapping),
+            } => write!(
+                w,
+                "+> {} |> {}",
+                ctx.display(additions),
+                ctx.display(mapping)
+            ),
+            Self::Additions {
+                additions,
+                mapping: None,
+            } => write!(w, "+> {}", ctx.display(additions)),
+            Self::Mapping(mapping) => write!(w, "|> {}", ctx.display(mapping)),
+        }
+    }
+}
+
+/// A complete output clause, when a relation needs one.
+enum OutputClause<'a> {
+    Compact(Emitted<'a>),
+    Explicit(ExplicitOutput<'a>),
+}
+
+impl<'a> OutputClause<'a> {
+    fn new(
+        direct_output: &'a [Value<'a>],
+        emit: Option<&'a EmitKind>,
+        syntax: OutputSyntax,
+        presence: OutputClausePresence,
+    ) -> Option<Self> {
+        let mapping = match emit {
+            Some(EmitKind::Emit(emit)) => Some(OutputMapping(&emit.output_mapping)),
+            Some(EmitKind::Direct(_)) | None => None,
+        };
+
+        match (syntax, presence, mapping) {
+            (OutputSyntax::Compact, OutputClausePresence::Required, _) => {
+                Some(Self::Compact(Emitted::new(direct_output, emit)))
+            }
+            (OutputSyntax::Compact, OutputClausePresence::WhenNeeded, Some(_)) => {
+                Some(Self::Compact(Emitted::new(direct_output, emit)))
+            }
+            (OutputSyntax::Compact, OutputClausePresence::WhenNeeded, None) => None,
+            (OutputSyntax::Explicit, OutputClausePresence::Required, mapping) => {
+                Some(Self::Explicit(ExplicitOutput::Additions {
+                    additions: OutputAdditions(direct_output),
+                    mapping,
+                }))
+            }
+            (OutputSyntax::Explicit, OutputClausePresence::WhenNeeded, Some(mapping)) => {
+                Some(Self::Explicit(ExplicitOutput::Mapping(mapping)))
+            }
+            (OutputSyntax::Explicit, OutputClausePresence::WhenNeeded, None) => None,
+        }
+    }
+}
+
+impl Textify for OutputClause<'_> {
+    fn name() -> &'static str {
+        "OutputClause"
+    }
+
+    fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
+        match self {
+            Self::Compact(emitted) => write!(w, "=> {}", ctx.display(emitted)),
+            Self::Explicit(output) => write!(w, "{}", ctx.display(output)),
         }
     }
 }
@@ -262,9 +354,11 @@ pub struct Relation<'a> {
     pub columns: Vec<Value<'a>>,
     /// The emit kind, if any. If none, use the columns directly.
     pub emit: Option<&'a EmitKind>,
-    /// Whether output columns are rendered as visible output or as a direct
-    /// output domain plus optional explicit emit mapping.
+    /// How an output clause is rendered when one is present.
     output_syntax: OutputSyntax,
+    /// Whether the current relation grammar requires an output clause even
+    /// without an explicit emit mapping.
+    output_clause_presence: OutputClausePresence,
     /// `+`-prefixed addendum lines to emit between this relation's header and
     /// children.  This owns the canonical ordering for `+ Ext`, `+ Enh`, and
     /// `+ Opt` lines rather than making the generic relation shape grow one
@@ -308,7 +402,7 @@ impl Relation<'_> {
         let name = &self.name;
         match &self.arguments {
             None => {
-                let cols = Emitted::columns(&self.columns, self.emit);
+                let cols = Emitted::new(&self.columns, self.emit);
                 let cols = ctx.display(&cols);
                 write!(w, "{indent}{name}[{cols}]")
             }
@@ -335,15 +429,33 @@ impl Relation<'_> {
                     let comma = if i == last { "" } else { "," };
                     writeln!(w, "{child_indent}- {named_arg}{comma}")?;
                 }
-                let output = Emitted::output_clause(&self.columns, self.emit, self.output_syntax);
+                let output = OutputClause::new(
+                    &self.columns,
+                    self.emit,
+                    self.output_syntax,
+                    self.output_clause_presence,
+                )
+                .unwrap_or(OutputClause::Compact(Emitted::new(
+                    &self.columns,
+                    self.emit,
+                )));
                 let output = ctx.display(&output);
                 write!(w, "{child_indent}- {output}]")
             }
             Some(RelationArgs::Inline(args)) => {
                 let args = ctx.display(args);
-                let output = Emitted::output_clause(&self.columns, self.emit, self.output_syntax);
-                let output = ctx.display(&output);
-                write!(w, "{indent}{name}[{args} {output}]")
+                match OutputClause::new(
+                    &self.columns,
+                    self.emit,
+                    self.output_syntax,
+                    self.output_clause_presence,
+                ) {
+                    Some(output_clause) => {
+                        let output = ctx.display(&output_clause);
+                        write!(w, "{indent}{name}[{args} {output}]")
+                    }
+                    None => write!(w, "{indent}{name}[{args}]"),
+                }
             }
         }
     }
@@ -378,16 +490,15 @@ impl<'a> Relation<'a> {
         match &rel.read_type {
             Some(ReadType::NamedTable(table)) => {
                 let table_name = Value::TableName(table.names.iter().map(|n| Name(n)).collect());
-                // XXX: For `ReadRel`s, we use `=>` if emit is None, `+>` if
-                // `emit` is `Some(Direct)`, and `+> … |>` if emit is
-                // `Some(Remap(…))`. However, we ignore the
-                // `OutputOptions::show_emit` option, and we haven't yet
-                // supported other operators; at some point, we should figure
-                // out our policy here and clean this up.
+                // Named Reads preserve their existing schema spelling: an
+                // absent common output form uses compact `=> schema`, while a
+                // present Direct or Emit form writes the schema after `+>`.
+                // The Read compact-output slice canonicalizes Direct to the
+                // compact spelling.
                 let output_syntax = if emit.is_some() {
                     OutputSyntax::Explicit
                 } else {
-                    OutputSyntax::Implicit
+                    OutputSyntax::Compact
                 };
                 Relation {
                     name: Cow::Borrowed("Read"),
@@ -395,6 +506,7 @@ impl<'a> Relation<'a> {
                     columns,
                     emit,
                     output_syntax,
+                    output_clause_presence: OutputClausePresence::Required,
                     addenda: AddendumLines::from_advanced_extension(
                         ctx,
                         rel.advanced_extension.as_ref(),
@@ -437,7 +549,8 @@ impl<'a> Relation<'a> {
                     arguments: Some(arguments),
                     columns,
                     emit,
-                    output_syntax: OutputSyntax::Implicit,
+                    output_syntax: OutputSyntax::Compact,
+                    output_clause_presence: OutputClausePresence::Required,
                     addenda: AddendumLines::from_advanced_extension(
                         ctx,
                         rel.advanced_extension.as_ref(),
@@ -456,7 +569,8 @@ impl<'a> Relation<'a> {
                     arguments: None,
                     columns,
                     emit,
-                    output_syntax: OutputSyntax::Implicit,
+                    output_syntax: OutputSyntax::Compact,
+                    output_clause_presence: OutputClausePresence::Required,
                     addenda: AddendumLines::extension_table(
                         ctx,
                         decoded,
@@ -476,7 +590,8 @@ impl<'a> Relation<'a> {
                     arguments: Some(RelationArgs::inline(vec![Value::Missing(err)], vec![])),
                     columns,
                     emit,
-                    output_syntax: OutputSyntax::Implicit,
+                    output_syntax: OutputSyntax::Compact,
+                    output_clause_presence: OutputClausePresence::Required,
                     addenda: AddendumLines::from_advanced_extension(
                         ctx,
                         rel.advanced_extension.as_ref(),
@@ -549,7 +664,8 @@ impl<'a> Relation<'a> {
             arguments,
             columns,
             emit,
-            output_syntax: OutputSyntax::Implicit,
+            output_syntax: OutputSyntax::from_show_emit(ctx.options().show_emit),
+            output_clause_presence: OutputClausePresence::WhenNeeded,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -570,7 +686,8 @@ impl<'a> Relation<'a> {
             arguments: None,
             columns,
             emit: get_emit(rel.common.as_ref()),
-            output_syntax: OutputSyntax::Implicit,
+            output_syntax: OutputSyntax::Compact,
+            output_clause_presence: OutputClausePresence::Required,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -602,7 +719,8 @@ impl<'a> Relation<'a> {
                     arguments: None,
                     columns: vec![],
                     emit: None,
-                    output_syntax: OutputSyntax::Implicit,
+                    output_syntax: OutputSyntax::Compact,
+                    output_clause_presence: OutputClausePresence::Required,
                     addenda: AddendumLines::none(),
                     children: vec![],
                 }
@@ -670,7 +788,8 @@ impl<'a> Relation<'a> {
                     arguments: Some(RelationArgs::inline(positional, named)),
                     columns,
                     emit: None,
-                    output_syntax: OutputSyntax::Implicit,
+                    output_syntax: OutputSyntax::Compact,
+                    output_clause_presence: OutputClausePresence::Required,
                     // Extension relations use `detail` rather than
                     // `advanced_extension`; the field does not exist on these
                     // proto types.
@@ -689,7 +808,8 @@ impl<'a> Relation<'a> {
                         error.to_string(),
                     ))],
                     emit: None,
-                    output_syntax: OutputSyntax::Implicit,
+                    output_syntax: OutputSyntax::Compact,
+                    output_clause_presence: OutputClausePresence::Required,
                     addenda: AddendumLines::none(),
                     children,
                 }
@@ -783,7 +903,8 @@ impl<'a> Relation<'a> {
             arguments,
             columns: all_outputs,
             emit,
-            output_syntax: OutputSyntax::Implicit,
+            output_syntax: OutputSyntax::Compact,
+            output_clause_presence: OutputClausePresence::Required,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -884,7 +1005,8 @@ impl<'a> Relation<'a> {
             arguments,
             columns: col_values,
             emit,
-            output_syntax: OutputSyntax::Implicit,
+            output_syntax: OutputSyntax::from_show_emit(ctx.options().show_emit),
+            output_clause_presence: OutputClausePresence::WhenNeeded,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -937,7 +1059,8 @@ impl<'a> Relation<'a> {
             arguments: Some(RelationArgs::inline(vec![], named_args)),
             columns,
             emit,
-            output_syntax: OutputSyntax::Implicit,
+            output_syntax: OutputSyntax::from_show_emit(ctx.options().show_emit),
+            output_clause_presence: OutputClausePresence::WhenNeeded,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -1050,7 +1173,8 @@ impl<'a> Relation<'a> {
             arguments,
             columns,
             emit,
-            output_syntax: OutputSyntax::Implicit,
+            output_syntax: OutputSyntax::Compact,
+            output_clause_presence: OutputClausePresence::Required,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -1081,7 +1205,8 @@ impl<'a> Relation<'a> {
             arguments,
             columns,
             emit,
-            output_syntax: OutputSyntax::Implicit,
+            output_syntax: OutputSyntax::from_show_emit(ctx.options().show_emit),
+            output_clause_presence: OutputClausePresence::WhenNeeded,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -1099,10 +1224,11 @@ impl<'a> Relation<'a> {
 
         Relation {
             name: Cow::Borrowed("Cross"),
-            arguments: None,
+            arguments: Some(RelationArgs::inline(vec![], vec![])),
             columns,
             emit: get_emit(rel.common.as_ref()),
-            output_syntax: OutputSyntax::Implicit,
+            output_syntax: OutputSyntax::from_show_emit(ctx.options().show_emit),
+            output_clause_presence: OutputClausePresence::WhenNeeded,
             addenda: AddendumLines::from_advanced_extension(ctx, rel.advanced_extension.as_ref()),
             children,
         }
@@ -1262,7 +1388,7 @@ mod tests {
         let (result, errors) = ctx.textify(&rel);
         assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
         let expected = r#"
-Filter[gt($0, 10:i32):boolean => $0, $1]
+Filter[gt($0, 10:i32):boolean]
   Read[test_table => col1:i32?, col2:i32?]"#
             .trim_start();
         assert_eq!(result, expected);
@@ -1664,7 +1790,7 @@ Filter[gt($0, 10:i32):boolean => $0, $1]
         let (result, errors) = ctx.textify(&rel);
         assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
         let expected = r#"
-Cross[$0, $1, $2, $3, $4, $5]
+Cross[_]
   Read[left_tbl => category:string?, amount:fp64?, value:i32?]
   Read[right_tbl => category:string?, amount:fp64?, value:i32?]"#
             .trim_start();
@@ -1694,7 +1820,7 @@ Cross[$0, $1, $2, $3, $4, $5]
         let (result, errors) = ctx.textify(&rel);
         assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
         let expected = r#"
-Cross[$0, $3]
+Cross[_ => $0, $3]
   Read[left_tbl => category:string?, amount:fp64?, value:i32?]
   Read[right_tbl => category:string?, amount:fp64?, value:i32?]"#
             .trim_start();

--- a/tests/adv_extension_roundtrip.rs
+++ b/tests/adv_extension_roundtrip.rs
@@ -104,7 +104,7 @@ fn test_enhancement_with_child_relation() {
     // so the annotation visually attaches to Filter and not to Read.
     let plan_text = r#"=== Plan
 Root[result]
-  Filter[$0 => $0]
+  Filter[$0]
     + Enh:PartitionHint[&BROADCAST]
     Read[my.table => col:i64]"#;
 
@@ -379,7 +379,7 @@ fn test_enhancement_on_filter_roundtrip() {
 
     let plan_text = r#"=== Plan
 Root[result]
-  Filter[$0 => $0]
+  Filter[$0]
     + Enh:PartitionHint[&HASH, count=4]
     Read[my.table => col:i64]"#;
 
@@ -398,7 +398,7 @@ fn test_enhancement_on_sort_roundtrip() {
 
     let plan_text = r#"=== Plan
 Root[result]
-  Sort[($0, &AscNullsFirst) => $0]
+  Sort[($0, &AscNullsFirst)]
     + Enh:PartitionHint[&RANGE]
     Read[my.table => col:i64]"#;
 
@@ -650,7 +650,7 @@ fn test_enhancement_on_fetch_roundtrip() {
     let registry = make_registry();
     let plan_text = r#"=== Plan
 Root[col]
-  Fetch[limit=5 => $0]
+  Fetch[limit=5]
     + Enh:PartitionHint[&HASH]
     Read[my.table => col:i64]"#;
     let parser = Parser::new().with_extension_registry(registry.clone());
@@ -713,7 +713,7 @@ fn test_optimization_on_nested_read_roundtrip() {
 
     let plan_text = r#"=== Plan
 Root[result]
-  Filter[$0 => $0]
+  Filter[$0]
     Read[my.table => col:i64]
       + Opt:PlanHint[hint='index']"#;
 
@@ -738,7 +738,7 @@ fn test_multiple_optimizations_on_nested_read_roundtrip() {
 
     let plan_text = r#"=== Plan
 Root[result]
-  Filter[$0 => $0]
+  Filter[$0]
     Read[my.table => col:i64]
       + Opt:PlanHint[hint='use_index']
       + Opt:PlanHint[hint='parallel']"#;
@@ -760,7 +760,7 @@ fn test_enhancement_and_optimization_on_nested_relation_roundtrip() {
 
     let plan_text = r#"=== Plan
 Root[result]
-  Filter[$0 => $0]
+  Filter[$0]
     Read[my.table => col:i64]
       + Enh:PartitionHint[&HASH]
       + Opt:PlanHint[hint='index']"#;
@@ -779,7 +779,7 @@ fn test_enhancement_on_nested_read_roundtrip() {
 
     let plan_text = r#"=== Plan
 Root[result]
-  Filter[$0 => $0]
+  Filter[$0]
     Read[my.table => col:i64]
       + Enh:PartitionHint[&HASH]"#;
 
@@ -798,8 +798,8 @@ fn test_enhancement_on_nested_filter_roundtrip() {
 
     let plan_text = r#"=== Plan
 Root[result]
-  Sort[($0, &AscNullsFirst) => $0]
-    Filter[$0 => $0]
+  Sort[($0, &AscNullsFirst)]
+    Filter[$0]
       + Enh:PartitionHint[&RANGE]
       Read[my.table => col:i64]"#;
 
@@ -817,8 +817,8 @@ fn test_enhancement_depth_three_nesting_roundtrip() {
     let registry = make_registry();
     let plan_text = r#"=== Plan
 Root[result]
-  Sort[($0, &AscNullsFirst) => $0]
-    Filter[$0 => $0]
+  Sort[($0, &AscNullsFirst)]
+    Filter[$0]
       Read[my.table => col:i64]
         + Enh:PartitionHint[&RANGE]"#;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,7 +2,7 @@
 
 use substrait::proto;
 use substrait::proto::{plan_rel, rel};
-use substrait_explain::{Parser, format, parse};
+use substrait_explain::{OutputOptions, Parser, format, format_with_options, parse};
 
 /// Roundtrip a plan and verify that the output is the same as the input, after
 /// being parsed to a Substrait plan and then back to text.
@@ -60,6 +60,51 @@ pub fn assert_roundtrip_canonical(canonical: &str, equivalent: &str) {
         canonical.trim(),
         "Equivalent did not roundtrip to canonical"
     );
+}
+
+/// Assert that compact and verbose equivalents roundtrip to the expected
+/// syntax under both output styles.
+pub fn assert_roundtrip_verbose(compact: &str, verbose: &str) {
+    for (input, options, expected, description) in [
+        (
+            compact,
+            OutputOptions::default(),
+            compact,
+            "compact input with default options",
+        ),
+        (
+            verbose,
+            OutputOptions::default(),
+            compact,
+            "verbose input with default options",
+        ),
+        (
+            compact,
+            OutputOptions::verbose(),
+            verbose,
+            "compact input with verbose options",
+        ),
+        (
+            verbose,
+            OutputOptions::verbose(),
+            verbose,
+            "verbose input with verbose options",
+        ),
+    ] {
+        let plan = Parser::parse(input).unwrap_or_else(|error| {
+            panic!("Failed to parse {description}: {error}");
+        });
+        let (actual, errors) = format_with_options(&plan, &options);
+        assert!(
+            errors.is_empty(),
+            "Formatting errors for {description}: {errors:?}"
+        );
+        assert_eq!(
+            actual.trim(),
+            expected.trim(),
+            "Unexpected output for {description}"
+        );
+    }
 }
 
 /// Parse a built-in type string (e.g. `"i64"`, `"string?"`) into a

--- a/tests/literal_roundtrip.rs
+++ b/tests/literal_roundtrip.rs
@@ -149,7 +149,7 @@ fn test_if_then_expression_roundtrip() {
     let plan = r#"
 === Plan
 Root[statusq]
-  Fetch[limit=10, offset=0 => ]
+  Fetch[limit=10, offset=0 => _]
     Project[if_then(true -> $0, false -> $1, _ -> $2)]
       Read[events.logs => status:string?]
 "#;

--- a/tests/multi_line_roundtrip.rs
+++ b/tests/multi_line_roundtrip.rs
@@ -111,7 +111,7 @@ Functions:
 
 === Plan
 Root[name]
-  Filter[gt($0, 1):boolean => $0, $1]
+  Filter[gt($0, 1):boolean]
     Read:Virtual[(1, 'alice'), (2, 'bob') => id:i64, name:string]"#;
 
     let multiline = r#"
@@ -123,7 +123,7 @@ Functions:
 
 === Plan
 Root[name]
-  Filter[gt($0, 1):boolean => $0, $1]
+  Filter[gt($0, 1):boolean]
     Read:Virtual[
       - (1, 'alice'),
       - (2, 'bob')

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -14,7 +14,7 @@ use substrait_explain::{ParseError, Parser};
 fn test_simple_plan_roundtrip() {
     let plan = r#"=== Plan
 Root[c, d]
-  Filter[$0 => $0, $1]
+  Filter[$0]
     Project[$1, 42]
       Read[my.table => a:i32, b:string?, c:boolean]"#;
 
@@ -28,6 +28,18 @@ Root[a, b]
   Read[my.table +> a:i32, b:string?]"#;
 
     roundtrip_plan(plan);
+}
+
+#[test]
+fn test_read_explicit_empty_additions_roundtrip() {
+    let canonical = r#"=== Plan
+Root[]
+  Read[my.table +> _]"#;
+    let legacy = r#"=== Plan
+Root[]
+  Read[my.table +> ]"#;
+
+    assert_roundtrip_canonical(canonical, legacy);
 }
 
 #[test]
@@ -110,7 +122,7 @@ Root[name, num, id]
     Read[t1 => name:string?, num:fp64, id:i64]
 
 Root[name, num, id]
-  Filter[$0 => $0, $1, $2]
+  Filter[$0]
     Read[schema.table => name:string?, num:fp64?, id:i64]"#;
 
     roundtrip_plan(plan);
@@ -188,10 +200,20 @@ Root[sum, count]
 }
 
 #[test]
+fn test_sort_empty_parameter_list() {
+    let plan = r#"=== Plan
+Root[]
+  Sort[_]
+    Read[table => a:i32]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
 fn test_sort_relation_roundtrip() {
     let plan = r#"=== Plan
 Root[a, b]
-  Sort[($0, &AscNullsFirst), ($1, &DescNullsLast) => $0, $1]
+  Sort[($0, &AscNullsFirst), ($1, &DescNullsLast)]
     Read[table => a:i32, b:string]"#;
     roundtrip_plan(plan);
 }
@@ -200,31 +222,31 @@ Root[a, b]
 fn test_fetch_relation_roundtrip() {
     let plan_both = r#"=== Plan
 Root[a, b]
-  Fetch[limit=10, offset=5 => $0, $1]
+  Fetch[limit=10, offset=5]
     Read[table => a:i32, b:string]"#;
 
     let plan_offset_first = r#"=== Plan
 Root[a, b]
-  Fetch[offset=5, limit=10 => $0, $1]
+  Fetch[offset=5, limit=10]
     Read[table => a:i32, b:string]"#;
 
     assert_roundtrip_canonical(plan_both, plan_offset_first);
 
     let plan_limit_only = r#"=== Plan
 Root[a, b]
-  Fetch[limit=10 => $0, $1]
+  Fetch[limit=10]
     Read[table => a:i32, b:string]"#;
     roundtrip_plan(plan_limit_only);
 
     let plan_offset_only = r#"=== Plan
 Root[a, b]
-  Fetch[offset=5 => $0, $1]
+  Fetch[offset=5]
     Read[table => a:i32, b:string]"#;
     roundtrip_plan(plan_offset_only);
 
     let plan_empty = r#"=== Plan
 Root[a, b]
-  Fetch[_ => $0, $1]
+  Fetch[_]
     Read[table => a:i32, b:string]"#;
     roundtrip_plan(plan_empty);
 }
@@ -505,7 +527,7 @@ Root[d, mark]
 fn test_set_relation_union_all_roundtrip() {
     let plan = r#"=== Plan
 Root[a, b]
-  Set[&UnionAll => $0, $1]
+  Set[&UnionAll]
     Read[table1 => a:i64, b:string]
     Read[table2 => c:i64, d:string]"#;
 
@@ -516,7 +538,7 @@ Root[a, b]
 fn test_set_relation_union_distinct_multi_input_roundtrip() {
     let plan = r#"=== Plan
 Root[a, b]
-  Set[&UnionDistinct => $0, $1]
+  Set[&UnionDistinct]
     Read[table1 => a:i64, b:string]
     Read[table2 => c:i64, d:string]
     Read[table3 => e:i64, f:string]"#;
@@ -528,7 +550,7 @@ Root[a, b]
 fn test_set_relation_minus_primary_roundtrip() {
     let plan = r#"=== Plan
 Root[a, b]
-  Set[&MinusPrimary => $0, $1]
+  Set[&MinusPrimary]
     Read[table1 => a:i64, b:string]
     Read[table2 => c:i64, d:string]"#;
 
@@ -579,10 +601,21 @@ Root[a, b]
 }
 
 #[test]
+fn test_empty_cross_parameters_roundtrip() {
+    let plan = r#"=== Plan
+Root[]
+  Cross[_]
+    Read[left => left:i32]
+    Read[right => right:string]"#;
+
+    roundtrip_plan(plan);
+}
+
+#[test]
 fn test_cross_relation_roundtrip() {
     let plan = r#"=== Plan
 Root[a, b, c, d]
-  Cross[$0, $1, $2, $3]
+  Cross[_]
     Read[table1 => a:i64, b:string]
     Read[table2 => c:i64, d:string]"#;
 
@@ -594,7 +627,7 @@ Root[a, b, c, d]
 fn test_cross_relation_uneven_widths_roundtrip() {
     let plan = r#"=== Plan
 Root[a, b, c]
-  Cross[$0, $1, $2]
+  Cross[_]
     Read[table1 => a:i64]
     Read[table2 => c:i64, d:string]"#;
 
@@ -605,7 +638,7 @@ Root[a, b, c]
 fn test_cross_relation_non_identity_emit_roundtrip() {
     let plan = r#"=== Plan
 Root[a, c]
-  Cross[$0, $2]
+  Cross[_ => $0, $2]
     Read[table1 => a:i64, b:string]
     Read[table2 => c:i64, d:string]"#;
 
@@ -616,7 +649,7 @@ Root[a, c]
 fn test_cross_relation_requires_two_children() {
     let one_child = r#"=== Plan
 Root[a, b]
-  Cross[$0, $1]
+  Cross[_]
     Read[table1 => a:i64, b:string]"#;
 
     let err = Parser::parse(one_child).expect_err("CrossRel with one child should fail");
@@ -921,7 +954,7 @@ Functions:
 
 === Plan
 Root[name]
-  Filter[gt($0, 1):boolean => $0, $1]
+  Filter[gt($0, 1):boolean]
     Read:Virtual[
       - (1, 'alice'),
       - (2, 'bob'),
@@ -1017,7 +1050,7 @@ Functions:
 === Plan
 Root[sum]
   Project[add($0, $1):i64]
-    Sort[($0, &AscNullsFirst) => $0, $1]
+    Sort[($0, &AscNullsFirst)]
       Read[t => a:i64, b:i64]"#;
 
     roundtrip_plan(plan);
@@ -1036,7 +1069,7 @@ Functions:
 === Plan
 Root[sum]
   Project[add($0, $1):i64]
-    Fetch[limit=10, offset=0 => $0, $1]
+    Fetch[limit=10, offset=0]
       Read[t => a:i64, b:i64]"#;
 
     roundtrip_plan(plan);

--- a/tests/verbose_roundtrip.rs
+++ b/tests/verbose_roundtrip.rs
@@ -1,0 +1,81 @@
+//! Round-trip tests for compact and verbose relation output styles.
+
+mod common;
+
+use common::assert_roundtrip_verbose;
+
+#[test]
+fn test_filter_empty_output_styles() {
+    let compact = r#"=== Plan
+Root[]
+  Filter[$2 => _]
+    Read[table => a:i32, b:string, c:boolean]"#;
+    let verbose = r#"=== Plan
+Root[]
+  Filter[$2 |> _]
+    Read[table => a:i32, b:string, c:boolean]"#;
+
+    assert_roundtrip_verbose(compact, verbose);
+}
+
+#[test]
+fn test_sort_partial_reordered_output_styles() {
+    let compact = r#"=== Plan
+Root[c, a]
+  Sort[($1, &DescNullsLast), ($0, &AscNullsFirst) => $2, $0]
+    Read[table => a:i32, b:string, c:boolean]"#;
+    let verbose = r#"=== Plan
+Root[c, a]
+  Sort[($1, &DescNullsLast), ($0, &AscNullsFirst) |> $2, $0]
+    Read[table => a:i32, b:string, c:boolean]"#;
+
+    assert_roundtrip_verbose(compact, verbose);
+}
+
+#[test]
+fn test_fetch_single_high_index_output_styles() {
+    let compact = r#"=== Plan
+Root[d]
+  Fetch[limit=10, offset=2 => $3]
+    Read[table => a:i32, b:string, c:boolean, d:i64]"#;
+    let verbose = r#"=== Plan
+Root[d]
+  Fetch[limit=10:i64, offset=2:i64 |> $3]
+    Read[table => a:i32, b:string, c:boolean, d:i64]"#;
+
+    assert_roundtrip_verbose(compact, verbose);
+}
+
+#[test]
+fn test_set_three_input_output_styles() {
+    let compact = r#"=== Plan
+Root[c, a, b]
+  Set[&UnionAll => $2, $0, $1]
+    Read[left => a:i32, b:string, c:boolean]
+    Read[middle => a:i32, b:string, c:boolean]
+    Read[right => a:i32, b:string, c:boolean]"#;
+    let verbose = r#"=== Plan
+Root[c, a, b]
+  Set[&UnionAll |> $2, $0, $1]
+    Read[left => a:i32, b:string, c:boolean]
+    Read[middle => a:i32, b:string, c:boolean]
+    Read[right => a:i32, b:string, c:boolean]"#;
+
+    assert_roundtrip_verbose(compact, verbose);
+}
+
+#[test]
+fn test_cross_uneven_input_output_styles() {
+    let compact = r#"=== Plan
+Root[right_c, left, right_b]
+  Cross[_ => $3, $0, $2]
+    Read[left => left:i32]
+    Read[right => right_a:string, right_b:i64, right_c:boolean]"#;
+    let verbose = r#"=== Plan
+Root[right_c, left, right_b]
+  Cross[_ |> $3, $0, $2]
+    Read[left => left:i32]
+    Read[right => right_a:string, right_b:i64, right_c:boolean]"#;
+
+    assert_roundtrip_verbose(compact, verbose);
+}


### PR DESCRIPTION
This PR adds compact and explicit output syntax for pass-through relations:

`Filter`, `Sort`, `Fetch`, `Set`, and `Cross`.

For example, a Filter with an explicit output mapping can be written as:

```text
Filter[gt($0, 0):boolean |> $1, $0]
```

Compact formatting remains the default. `OutputOptions::show_emit` and `OutputOptions::verbose()` select explicit formatting, preserving an explicit identity `Emit` mapping rather than normalizing it to `Direct`.

Part of #34.

## Changes

- Add `=>` compact output and `|>` explicit output parsing for pass-through relations, including empty mappings written as `_`.
- Format pass-through relations without an output clause for `Direct`, with compact `=>` output by default and explicit `|>` output when requested.
- Add `OutputOptions::show_emit` as the public formatting option for explicit relation output.
- Model output formatting around the text syntax: `OutputAdditions` for `+>`, `OutputMapping` for `|>`, `Emitted` for compact final output, and `OutputClause` for their composition.
- Document Substrait's direct-output and emit model, including input-order and direct-output-order field-reference scopes.
- Accept and canonically format empty named-Read additions as `Read[table +> _]`; retain the previous blank spelling as accepted input for now.

## API Impact

- `OutputOptions` now exposes `show_emit: bool`.
- `OutputOptions::verbose()` sets `show_emit` to `true`.

## Validation

- `just test`
- `just check`
