### PR TITLE
fix: undo incorrect left anti/semi join tests and re-do the original join TODO comment in relations.rs

### DIFF
--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -1260,6 +1260,11 @@ impl RelationParsePair for JoinRel {
         let references_pair = iter.pop(Rule::reference_list);
         iter.done();
 
+        // TODO: For semi/anti/single/mark joins, the direct output width differs
+        // from left+right. Using `input_field_count` here misclassifies identity
+        // emits and accepts mappings such as `RightSemi => $3, $4`, even though
+        // emit references are relative to the join's direct output domain.
+        // Revisit when `parse_pair_with_context` can see per-child field counts.
         let (emit, output_count) = parse_emit(references_pair, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
@@ -2147,7 +2152,8 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_join_relation_right_semi() {
+    #[ignore = "Join emit parsing currently uses left+right input_field_count instead of the join-type-specific direct output width"]
+    fn test_parse_join_relation_right_semi_identity_emit_is_direct() {
         let extensions = TestContext::new()
             .with_urn(1, "https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml")
             .with_function(1, 10, "eq")
@@ -2160,7 +2166,7 @@ mod tests {
             &extensions,
             parse_exact(
                 Rule::join_relation,
-                "Join[&RightSemi, eq($0, $3):boolean => $3, $4]",
+                "Join[&RightSemi, eq($0, $3):boolean => $0, $1, $2]",
             ),
             vec![left_rel, right_rel],
             6,
@@ -2172,12 +2178,37 @@ mod tests {
         assert_eq!(join.r#type, join_rel::JoinType::RightSemi as i32);
 
         let emit_kind = &join.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
-        let emit = match emit_kind {
-            EmitKind::Emit(emit) => &emit.output_mapping,
-            _ => panic!("Expected EmitKind::Emit, got {emit_kind:?}"),
-        };
-        // Output mapping should be [3, 4] (only right columns for semi join)
-        assert_eq!(emit, &[3, 4]);
+        assert!(
+            matches!(emit_kind, EmitKind::Direct(_)),
+            "Expected RightSemi identity emit over direct output fields $0..$2 to be Direct, got {emit_kind:?}"
+        );
+    }
+
+    #[test]
+    #[ignore = "Join emit parsing currently accepts references outside the join-type-specific direct output domain"]
+    fn test_parse_join_relation_right_semi_rejects_input_scope_emit() {
+        let extensions = TestContext::new()
+            .with_urn(1, "https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml")
+            .with_function(1, 10, "eq")
+            .extensions;
+
+        let left_rel = example_read_relation().into_rel(None);
+        let right_rel = example_read_relation().into_rel(None);
+
+        let result = JoinRel::parse_pair_with_context(
+            &extensions,
+            parse_exact(
+                Rule::join_relation,
+                "Join[&RightSemi, eq($0, $3):boolean => $3, $4]",
+            ),
+            vec![left_rel, right_rel],
+            6,
+        );
+
+        assert!(
+            result.is_err(),
+            "RightSemi emit references are relative to the join direct output, so $3 and $4 are out of bounds for a 3-column right-side output"
+        );
     }
 
     #[test]

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -1260,12 +1260,9 @@ impl RelationParsePair for JoinRel {
         let references_pair = iter.pop(Rule::reference_list);
         iter.done();
 
-        // TODO: For semi/anti/single/mark joins, the direct output width differs
-        // from left+right. The text `=>` list is written in join input-reference
-        // space, but `RelCommon.emit.output_mapping` is over the direct output
-        // domain. Using `input_field_count` here misclassifies identity emits
-        // and fails to translate right-side-only joins into 0-based emit mappings.
-        // Revisit when `parse_pair_with_context` can see per-child field counts.
+        // TODO: For semi/anti joins, the direct output width differs from
+        // left+right — `input_field_count` would misclassify the emit as Direct.
+        // Revisit when those join types are supported.
         let (emit, output_count) = parse_emit(references_pair, input_field_count);
         let common = RelCommon {
             emit_kind: Some(emit),
@@ -2150,75 +2147,6 @@ mod tests {
         };
         // Output mapping should be [0, 1] (only left columns for semi join)
         assert_eq!(emit, &[0, 1]);
-    }
-
-    #[test]
-    #[ignore = "Join emit parsing currently uses left+right input_field_count instead of the join-type-specific direct output width"]
-    fn test_parse_join_relation_semi_anti_identity_emit_is_direct() {
-        let extensions = TestContext::new()
-            .with_urn(1, "https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml")
-            .with_function(1, 10, "eq")
-            .extensions;
-
-        for (join_type_name, join_type, output_refs) in [
-            ("LeftSemi", join_rel::JoinType::LeftSemi, "$0, $1, $2"),
-            ("RightSemi", join_rel::JoinType::RightSemi, "$3, $4, $5"),
-            ("LeftAnti", join_rel::JoinType::LeftAnti, "$0, $1, $2"),
-            ("RightAnti", join_rel::JoinType::RightAnti, "$3, $4, $5"),
-        ] {
-            let left_rel = example_read_relation().into_rel(None);
-            let right_rel = example_read_relation().into_rel(None);
-            let text = format!("Join[&{join_type_name}, eq($0, $3):boolean => {output_refs}]");
-
-            let join = JoinRel::parse_pair_with_context(
-                &extensions,
-                parse_exact(Rule::join_relation, &text),
-                vec![left_rel, right_rel],
-                6,
-            )
-            .unwrap()
-            .0;
-
-            assert_eq!(join.r#type, join_type as i32);
-
-            let emit_kind = &join.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
-            assert!(
-                matches!(emit_kind, EmitKind::Direct(_)),
-                "Expected {join_type_name} identity emit over {output_refs} to be normalized to Direct, got {emit_kind:?}"
-            );
-        }
-    }
-
-    #[test]
-    #[ignore = "Join emit parsing currently accepts references from the side omitted by semi/anti direct output"]
-    fn test_parse_join_relation_semi_anti_rejects_omitted_side_emit() {
-        let extensions = TestContext::new()
-            .with_urn(1, "https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml")
-            .with_function(1, 10, "eq")
-            .extensions;
-
-        for (join_type_name, omitted_refs) in [
-            ("LeftSemi", "$3, $4"),
-            ("RightSemi", "$0, $1"),
-            ("LeftAnti", "$3, $4"),
-            ("RightAnti", "$0, $1"),
-        ] {
-            let left_rel = example_read_relation().into_rel(None);
-            let right_rel = example_read_relation().into_rel(None);
-            let text = format!("Join[&{join_type_name}, eq($0, $3):boolean => {omitted_refs}]");
-
-            let result = JoinRel::parse_pair_with_context(
-                &extensions,
-                parse_exact(Rule::join_relation, &text),
-                vec![left_rel, right_rel],
-                6,
-            );
-
-            assert!(
-                result.is_err(),
-                "{join_type_name} output should not be able to emit omitted-side refs {omitted_refs}"
-            );
-        }
     }
 
     #[test]

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -1261,9 +1261,10 @@ impl RelationParsePair for JoinRel {
         iter.done();
 
         // TODO: For semi/anti/single/mark joins, the direct output width differs
-        // from left+right. Using `input_field_count` here misclassifies identity
-        // emits and accepts mappings such as `RightSemi => $3, $4`, even though
-        // emit references are relative to the join's direct output domain.
+        // from left+right. The text `=>` list is written in join input-reference
+        // space, but `RelCommon.emit.output_mapping` is over the direct output
+        // domain. Using `input_field_count` here misclassifies identity emits
+        // and fails to translate right-side-only joins into 0-based emit mappings.
         // Revisit when `parse_pair_with_context` can see per-child field counts.
         let (emit, output_count) = parse_emit(references_pair, input_field_count);
         let common = RelCommon {
@@ -2159,15 +2160,15 @@ mod tests {
             .with_function(1, 10, "eq")
             .extensions;
 
-        for (join_type_name, join_type) in [
-            ("LeftSemi", join_rel::JoinType::LeftSemi),
-            ("RightSemi", join_rel::JoinType::RightSemi),
-            ("LeftAnti", join_rel::JoinType::LeftAnti),
-            ("RightAnti", join_rel::JoinType::RightAnti),
+        for (join_type_name, join_type, output_refs) in [
+            ("LeftSemi", join_rel::JoinType::LeftSemi, "$0, $1, $2"),
+            ("RightSemi", join_rel::JoinType::RightSemi, "$3, $4, $5"),
+            ("LeftAnti", join_rel::JoinType::LeftAnti, "$0, $1, $2"),
+            ("RightAnti", join_rel::JoinType::RightAnti, "$3, $4, $5"),
         ] {
             let left_rel = example_read_relation().into_rel(None);
             let right_rel = example_read_relation().into_rel(None);
-            let text = format!("Join[&{join_type_name}, eq($0, $3):boolean => $0, $1, $2]");
+            let text = format!("Join[&{join_type_name}, eq($0, $3):boolean => {output_refs}]");
 
             let join = JoinRel::parse_pair_with_context(
                 &extensions,
@@ -2183,23 +2184,28 @@ mod tests {
             let emit_kind = &join.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
             assert!(
                 matches!(emit_kind, EmitKind::Direct(_)),
-                "Expected {join_type_name} identity emit over direct output fields $0..$2 to be Direct, got {emit_kind:?}"
+                "Expected {join_type_name} identity emit over {output_refs} to be normalized to Direct, got {emit_kind:?}"
             );
         }
     }
 
     #[test]
-    #[ignore = "Join emit parsing currently accepts references outside the join-type-specific direct output domain"]
-    fn test_parse_join_relation_semi_anti_rejects_input_scope_emit() {
+    #[ignore = "Join emit parsing currently accepts references from the side omitted by semi/anti direct output"]
+    fn test_parse_join_relation_semi_anti_rejects_omitted_side_emit() {
         let extensions = TestContext::new()
             .with_urn(1, "https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml")
             .with_function(1, 10, "eq")
             .extensions;
 
-        for join_type_name in ["LeftSemi", "RightSemi", "LeftAnti", "RightAnti"] {
+        for (join_type_name, omitted_refs) in [
+            ("LeftSemi", "$3, $4"),
+            ("RightSemi", "$0, $1"),
+            ("LeftAnti", "$3, $4"),
+            ("RightAnti", "$0, $1"),
+        ] {
             let left_rel = example_read_relation().into_rel(None);
             let right_rel = example_read_relation().into_rel(None);
-            let text = format!("Join[&{join_type_name}, eq($0, $3):boolean => $3, $4]");
+            let text = format!("Join[&{join_type_name}, eq($0, $3):boolean => {omitted_refs}]");
 
             let result = JoinRel::parse_pair_with_context(
                 &extensions,
@@ -2210,7 +2216,7 @@ mod tests {
 
             assert!(
                 result.is_err(),
-                "{join_type_name} emit references are relative to the join direct output, so $3 and $4 are out of bounds for a 3-column semi/anti output"
+                "{join_type_name} output should not be able to emit omitted-side refs {omitted_refs}"
             );
         }
     }

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -2153,62 +2153,66 @@ mod tests {
 
     #[test]
     #[ignore = "Join emit parsing currently uses left+right input_field_count instead of the join-type-specific direct output width"]
-    fn test_parse_join_relation_right_semi_identity_emit_is_direct() {
+    fn test_parse_join_relation_semi_anti_identity_emit_is_direct() {
         let extensions = TestContext::new()
             .with_urn(1, "https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml")
             .with_function(1, 10, "eq")
             .extensions;
 
-        let left_rel = example_read_relation().into_rel(None);
-        let right_rel = example_read_relation().into_rel(None);
+        for (join_type_name, join_type) in [
+            ("LeftSemi", join_rel::JoinType::LeftSemi),
+            ("RightSemi", join_rel::JoinType::RightSemi),
+            ("LeftAnti", join_rel::JoinType::LeftAnti),
+            ("RightAnti", join_rel::JoinType::RightAnti),
+        ] {
+            let left_rel = example_read_relation().into_rel(None);
+            let right_rel = example_read_relation().into_rel(None);
+            let text = format!("Join[&{join_type_name}, eq($0, $3):boolean => $0, $1, $2]");
 
-        let join = JoinRel::parse_pair_with_context(
-            &extensions,
-            parse_exact(
-                Rule::join_relation,
-                "Join[&RightSemi, eq($0, $3):boolean => $0, $1, $2]",
-            ),
-            vec![left_rel, right_rel],
-            6,
-        )
-        .unwrap()
-        .0;
+            let join = JoinRel::parse_pair_with_context(
+                &extensions,
+                parse_exact(Rule::join_relation, &text),
+                vec![left_rel, right_rel],
+                6,
+            )
+            .unwrap()
+            .0;
 
-        // Should be a RightSemi join
-        assert_eq!(join.r#type, join_rel::JoinType::RightSemi as i32);
+            assert_eq!(join.r#type, join_type as i32);
 
-        let emit_kind = &join.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
-        assert!(
-            matches!(emit_kind, EmitKind::Direct(_)),
-            "Expected RightSemi identity emit over direct output fields $0..$2 to be Direct, got {emit_kind:?}"
-        );
+            let emit_kind = &join.common.as_ref().unwrap().emit_kind.as_ref().unwrap();
+            assert!(
+                matches!(emit_kind, EmitKind::Direct(_)),
+                "Expected {join_type_name} identity emit over direct output fields $0..$2 to be Direct, got {emit_kind:?}"
+            );
+        }
     }
 
     #[test]
     #[ignore = "Join emit parsing currently accepts references outside the join-type-specific direct output domain"]
-    fn test_parse_join_relation_right_semi_rejects_input_scope_emit() {
+    fn test_parse_join_relation_semi_anti_rejects_input_scope_emit() {
         let extensions = TestContext::new()
             .with_urn(1, "https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml")
             .with_function(1, 10, "eq")
             .extensions;
 
-        let left_rel = example_read_relation().into_rel(None);
-        let right_rel = example_read_relation().into_rel(None);
+        for join_type_name in ["LeftSemi", "RightSemi", "LeftAnti", "RightAnti"] {
+            let left_rel = example_read_relation().into_rel(None);
+            let right_rel = example_read_relation().into_rel(None);
+            let text = format!("Join[&{join_type_name}, eq($0, $3):boolean => $3, $4]");
 
-        let result = JoinRel::parse_pair_with_context(
-            &extensions,
-            parse_exact(
-                Rule::join_relation,
-                "Join[&RightSemi, eq($0, $3):boolean => $3, $4]",
-            ),
-            vec![left_rel, right_rel],
-            6,
-        );
+            let result = JoinRel::parse_pair_with_context(
+                &extensions,
+                parse_exact(Rule::join_relation, &text),
+                vec![left_rel, right_rel],
+                6,
+            );
 
-        assert!(
-            result.is_err(),
-            "RightSemi emit references are relative to the join direct output, so $3 and $4 are out of bounds for a 3-column right-side output"
-        );
+            assert!(
+                result.is_err(),
+                "{join_type_name} emit references are relative to the join direct output, so $3 and $4 are out of bounds for a 3-column semi/anti output"
+            );
+        }
     }
 
     #[test]

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -430,7 +430,7 @@ Root[id, name, amount]
 }
 
 #[test]
-fn test_join_relation_semi_types_roundtrip() {
+fn test_join_relation_left_semi_roundtrip() {
     // Test LeftSemi join - should output only left columns
     let plan_semi = r#"=== Extensions
 URNs:
@@ -444,8 +444,11 @@ Root[a, b]
     Read[left_table => a:i32, b:string]
     Read[right_table => c:i32, d:string]"#;
     roundtrip_plan(plan_semi);
+}
 
-    // Test RightSemi join - should output only right columns
+#[test]
+#[ignore = "RightSemi output refs should use right-input field numbers in text, but parser/textifier currently do not translate them to direct-output emit mappings"]
+fn test_join_relation_right_semi_roundtrip() {
     let plan_right_semi = r#"=== Extensions
 URNs:
   @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml
@@ -454,7 +457,7 @@ Functions:
 
 === Plan
 Root[c, d]
-  Join[&RightSemi, eq($0, $2):boolean => $0, $1]
+  Join[&RightSemi, eq($0, $2):boolean => $2, $3]
     Read[left_table => a:i32, b:string]
     Read[right_table => c:i32, d:string]"#;
     roundtrip_plan(plan_right_semi);

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -430,7 +430,7 @@ Root[id, name, amount]
 }
 
 #[test]
-fn test_join_relation_left_semi_roundtrip() {
+fn test_join_relation_semi_types_roundtrip() {
     // Test LeftSemi join - should output only left columns
     let plan_semi = r#"=== Extensions
 URNs:
@@ -444,23 +444,6 @@ Root[a, b]
     Read[left_table => a:i32, b:string]
     Read[right_table => c:i32, d:string]"#;
     roundtrip_plan(plan_semi);
-}
-
-#[test]
-#[ignore = "RightSemi output refs should use right-input field numbers in text, but parser/textifier currently do not translate them to direct-output emit mappings"]
-fn test_join_relation_right_semi_roundtrip() {
-    let plan_right_semi = r#"=== Extensions
-URNs:
-  @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml
-Functions:
-  # 10 @  1: eq
-
-=== Plan
-Root[c, d]
-  Join[&RightSemi, eq($0, $2):boolean => $2, $3]
-    Read[left_table => a:i32, b:string]
-    Read[right_table => c:i32, d:string]"#;
-    roundtrip_plan(plan_right_semi);
 }
 
 #[test]


### PR DESCRIPTION
## Description
This PR undoes the tests added and changes made in these two PRs:
https://github.com/DataDog/substrait-explain/pull/189
https://github.com/DataDog/substrait-explain/pull/190

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Example update
- [ ] Other (please describe)

## Testing

- [ ] Added tests for new functionality
- [x] All existing tests pass
- [ ] Ran examples to verify behavior

## Checklist

- [x] Code follows Rust conventions
- [x] Documentation updated if needed
- [x] No breaking changes (or breaking changes documented)
- [x] Pre-commit hooks pass

