### PR TITLE
feat!: normalize empty lists and direct Read output

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -625,9 +625,8 @@ specification](https://substrait.io/relations/logical_relations/).
   fields followed by its expressions in declaration order; `Aggregate` produces
   the grouping expressions followed by the measures.
 - The input order of `Read` is relative to its direct schema; its "input" is what
-  it is reading from. Its references are over the direct schema, written as the
-  read's `named_column_list`, which Substrait interprets before any projection
-  is applied.
+  it is reading from. Its references are over that schema, which Substrait
+  interprets before any projection is applied.
 
 `$N` refers to field N of the relation's input order, which is the scope of a
 relation's expressions: a `Filter` condition, `Project` expressions, `Aggregate`
@@ -700,23 +699,41 @@ Root[c, d]           // root with output columns c and d
 
 ### Read Relation
 
+A named-table Read represents Substrait's [Read
+operator](https://substrait.io/relations/logical_relations/#read-operator). A
+Read has no relational input. Its named-table definition identifies the data to
+read. Its [direct
+schema](https://substrait.io/relations/logical_relations/#read-properties)
+defines the fields read and their types. The fields appear in the Read direct
+output order.
+
 #### Syntax
 
 ```text
-read_relation := "Read" "[" table_name output "]"
-output := implicit_output / direct_output
-implicit_output := "=>" named_column_list
-direct_output := "+>" named_column_list ("|>" reference_list)?
+read_relation := "Read" "[" table_name ("=>" named_column_list / "+>" named_column_list ("|>" reference_list)?) "]"
 ```
 
 #### Components
 
-- `table_name := name ("." name)*` - table name, optionally qualified with schema/database
-- `named_column := name ":" type` - column name with type annotation
-- `named_column_list := "_" / named_column ("," named_column)*` - the list of columns and their types to be read from the table `table_name`. `_` denotes an empty schema.
-  - `=>` is used to mean implicit column ordering; for `Read`, this translates to `Direct` column ordering.
-  - When used with `+>` and no `|>`, the `named_column`s are in the expected order of the table, and `Direct` emit is used.
-  - When used with `+> … |>`, the `named_column`s are in the expected order of the table, and the emit order is a Remap specified by `reference_list`.
+- `table_name := name ("." name)*`: the namespaced strings in Substrait's
+  named-table definition. The names together identify the table. The text
+  format separates them with `.`.
+- `named_column_list := named_column ("," named_column)* / "_"`: a
+  comma-separated list containing at least one named column. Use `_` for an
+  empty list.
+- `named_column := name ":" type`: a column name followed by its
+  [type](#types).
+- `"=>" named_column_list`: declares the Read direct schema in direct output
+  order and returns it as the final output using `Direct`.
+- `"+>" named_column_list ("|>" reference_list)?`: declares the Read direct
+  schema in direct output order. Without `|>`, the Read uses `Direct`, and
+  formatting uses `=>` as the canonical form.
+  - With `|>`, the shared [`reference_list`](#general-relation-grammar) is
+    Substrait's [emit output
+    mapping](https://substrait.io/relations/common_fields/#emit). Its references
+    are positions in the Read direct output order, so the mapping can select,
+    omit, or reorder fields. An explicit mapping remains `Emit`, including an
+    identity mapping.
 
 #### Example
 
@@ -725,19 +742,16 @@ direct_output := "+>" named_column_list ("|>" reference_list)?
 #
 # let plan_text = r#"
 === Plan
-Root[result]
-  Project[$0, $1]
-    Read[schema.table => a:i64, b:string?]
-Root[result2]
-  Project[$0, $1]
-    Read[orders => quantity:i32?, price:i64]
+Root[a, b]
+  Read[schema.table => a:i64, b:string?]
 # "#;
 #
 # let plan = Parser::parse(plan_text).unwrap();
-# assert_eq!(plan.relations.len(), 2);
+# assert_eq!(plan.relations.len(), 1);
 ```
 
-Use `+>` when the read's base schema records the direct output domain:
+The parser also accepts an explicit `Direct` schema. Formatting rewrites this
+form with `=>`:
 
 ```rust
 # use substrait_explain::Parser;
@@ -752,8 +766,8 @@ Root[a, b]
 # assert_eq!(plan.relations.len(), 1);
 ```
 
-Use `+> ... |>` to specify an Emit / output ordering different from the table's base schema:
-only some fields should flow downstream:
+Use `+> ... |>` to declare the complete direct schema and then apply an
+`Emit` mapping. This example selects 2 fields and reverses their order:
 
 ```rust
 # use substrait_explain::Parser;

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -680,7 +680,7 @@ form a 1-element tuple: `(x,)`. For 2+ elements the trailing comma is optional: 
 
 #### Syntax
 
-`"Root" "[" (name ("," name)*)? "]"`
+`"Root" "[" (name ("," name)* / "_") "]"`
 
 #### Example
 
@@ -713,11 +713,10 @@ direct_output := "+>" named_column_list ("|>" reference_list)?
 
 - `table_name := name ("." name)*` - table name, optionally qualified with schema/database
 - `named_column := name ":" type` - column name with type annotation
-- `named_column_list := "_" / (named_column ("," named_column)*)?` - the list of columns and their types to be read from the table `table_name`. `_` denotes an empty schema.
+- `named_column_list := "_" / named_column ("," named_column)*` - the list of columns and their types to be read from the table `table_name`. `_` denotes an empty schema.
   - `=>` is used to mean implicit column ordering; for `Read`, this translates to `Direct` column ordering.
   - When used with `+>` and no `|>`, the `named_column`s are in the expected order of the table, and `Direct` emit is used.
   - When used with `+> … |>`, the `named_column`s are in the expected order of the table, and the emit order is a Remap specified by `reference_list`.
-  - The parser also accepts a blank `+>` list for compatibility; formatting writes `_`.
 
 #### Example
 
@@ -886,10 +885,10 @@ An `ExtensionTable` read uses `ReadRel` with `ReadType::ExtensionTable`. The rel
 
 ```text
 extension_table_read_relation := "Read:Extension" "[" named_column_list "]"
-extension_table_detail        := "+" "Ext" ":" name "[" (empty / extension_args)? "]"
+extension_table_detail        := "+" "Ext" ":" name "[" (empty / extension_args) "]"
 ```
 
-The `+ Ext:` line is indented one level deeper than the `Read:Extension` line. It is required, and addendum lines must appear before any child relations. Canonical formatting writes `+ Ext:` first, followed by `+ Enh:` and `+ Opt:` lines when present.
+The `+ Ext:` line is indented one level deeper than the `Read:Extension` line. It is required, and addendum lines must appear before any child relations. Its argument list is also required: use `_` when it is empty. Canonical formatting writes `+ Ext:` first, followed by `+ Enh:` and `+ Opt:` lines when present.
 
 #### Components
 
@@ -1015,8 +1014,8 @@ Root[result]
 
 - `grouping_sets := grouping_set_list / expression_list` - can be a list of grouping sets (each parenthesized), or a single unparenthesized list for the common, single-set case
 - `grouping_set_list := grouping_set ("," grouping_set)*`
-- `grouping_set := "(" expression_list ")" / "_"` - a grouping set can be (1) a list of expressions, or (2) `_`, the standard we use for empty lists
-- `aggregate_output := expression ("," expression)*` - comma-separated list of output items
+- `grouping_set := "(" expression_list ")" / "_"` - a grouping set is a list of expressions, or `_` for the empty grouping set
+- `aggregate_output := expression ("," expression)* / "_"` - comma-separated list of output items, or `_` for an explicitly empty output
 - Each output item is either an aggregate function call (which becomes a new measure), or an expression that must match one of the `grouping_sets` expressions by value - since an Aggregate relation's output schema is always exactly `grouping_expressions + measures`. See [Aggregate Measures section](#aggregate-measures)
 
 #### Example
@@ -1221,14 +1220,14 @@ There are three extension relation types, based on their input cardinality:
 #### Syntax
 
 ```text
-extension_relation := extension_type ":" name "[" (empty / extension_args)? ("=>" extension_columns)? "]"
+extension_relation := extension_type ":" name "[" (empty / extension_args) ("=>" extension_columns)? "]"
 extension_type := "ExtensionLeaf" / "ExtensionSingle" / "ExtensionMulti"
 extension_args := (positional_args ("," named_args)?) / named_args
 positional_args := extension_arg ("," extension_arg)*
 extension_arg := enum / reference / literal / expression / tuple
 named_args := named_arg ("," named_arg)*
 named_arg := name "=" extension_arg
-extension_columns := (extension_column ("," extension_column)*)?
+extension_columns := extension_column ("," extension_column)* / "_"
 extension_column := named_column / reference / expression
 ```
 
@@ -1238,9 +1237,9 @@ Note: the parser also accepts the `=>` section being omitted entirely (e.g. `Ext
 
 - **`extension_type`** - One of `ExtensionLeaf`, `ExtensionSingle`, or `ExtensionMulti`
 - **`name`** - The extension name (registered with `ExtensionRegistry`)
-- **`empty`** (`_`) - Explicitly marks an extension with no arguments
-- **`extension_args`** - Positional arguments (enums, references, literals, expressions, or tuples) and/or named arguments (`key=value` pairs); both are optional
-- **`extension_columns`** - Output column definitions: named columns (`name:type`), field references (`$0`), or expressions
+- **`empty`** (`_`) - Required when an extension has no arguments
+- **`extension_args`** - Positional arguments (enums, references, literals, expressions, or tuples) and/or named arguments (`key=value` pairs)
+- **`extension_columns`** - Output column definitions: named columns (`name:type`), field references (`$0`), or expressions; use `_` for an explicitly empty list
 
 Untyped scalar extension arguments such as `2`, `2.4`, `true`, and `'path'`
 are treated as extension scalar values and render without expression type
@@ -1262,13 +1261,13 @@ Root[result]
 Extension with positional arguments and no output columns:
 
 ```text
-ExtensionSingle:VectorNormalize[$0, $1, method='l2' => ]
+ExtensionSingle:VectorNormalize[$0, $1, method='l2' => _]
 ```
 
 Extension with no arguments:
 
 ```text
-ExtensionLeaf:EmptySource[_ => ]
+ExtensionLeaf:EmptySource[_ => _]
 ```
 
 #### Custom Extension Types
@@ -1289,7 +1288,7 @@ Each relation can carry:
 ### Syntax
 
 ```text
-addendum      := "+" addendum_type ":" name "[" (empty | extension_args)? "]"
+addendum      := "+" addendum_type ":" name "[" (empty / extension_args) "]"
 addendum_type := "Enh" | "Opt" | "Ext"
 ```
 

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -367,7 +367,7 @@ extension_relation = { extension_name ~ "[" ~ sp ~ arguments ~ (sp ~ "=>" ~ sp ~
 extension_name = { extension_type ~ ":" ~ name }
 extension_type = { "ExtensionLeaf" | "ExtensionSingle" | "ExtensionMulti" }
 
-arguments = { (empty | (extension_arguments ~ (sp ~ "," ~ sp ~ extension_named_arguments)?) | extension_named_arguments)? }
+arguments = { empty | (extension_arguments ~ (sp ~ "," ~ sp ~ extension_named_arguments)?) | extension_named_arguments }
 // Positional arguments (expressions, literals, references, enums, tuples)
 extension_arguments = { extension_argument ~ (sp ~ "," ~ sp ~ extension_argument)* }
 
@@ -396,7 +396,7 @@ extension_named_arguments = { extension_named_argument ~ (sp ~ "," ~ sp ~ extens
 extension_named_argument  = { name ~ sp ~ "=" ~ sp ~ extension_argument }
 
 // Output columns - can mix named columns, references, and expressions
-extension_columns = { (extension_column ~ (sp ~ "," ~ sp ~ extension_column)*)? }
+extension_columns = { empty | (extension_column ~ (sp ~ "," ~ sp ~ extension_column)*) }
 extension_column  = { named_column | reference | expression }
 
 // Relation addenda: metadata/detail lines attached to a relation.

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -223,7 +223,7 @@ explicit_emit             = { "|>" ~ sp ~ reference_list }
 table_name = { (name ~ ("." ~ name)*) }
 
 named_column      = { name ~ ":" ~ type }
-named_column_list = { empty | (named_column ~ ("," ~ sp ~ named_column)*)? }
+named_column_list = { empty | (named_column ~ ("," ~ sp ~ named_column)*) }
 
 // -- Read output clauses --
 // `=>` declares the final visible schema in compact Read syntax. `+>` declares
@@ -260,7 +260,7 @@ top_level_relation = {
 }
 
 root_relation  = { "Root" ~ "[" ~ root_name_list ~ "]" }
-root_name_list = { (name ~ (sp ~ "," ~ sp ~ name)*)? }
+root_name_list = { empty | (name ~ (sp ~ "," ~ sp ~ name)*) }
 
 read_relation = { "Read" ~ "[" ~ table_name ~ sp ~ read_output ~ "]" }
 
@@ -319,7 +319,7 @@ grouping_set       = { ("(" ~ sp ~ expression_list ~ sp ~ ")") | empty }
 expression_list    = { expression ~ sp ~ ("," ~ sp ~ expression)* }
 
 // TODO: Add support for filter invocation, etc.
-aggregate_output      = { (expression ~ (sp ~ "," ~ sp ~ expression)*)? }
+aggregate_output = { empty | expression_list }
 
 // Empty grouping symbol
 empty = { "_" }

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -923,6 +923,28 @@ Functions:
     }
 
     #[test]
+    fn test_empty_addendum_uses_underscore() {
+        let extensions = SimpleExtensions::default();
+        for (kind, addendum) in [
+            (AddendumKind::Enhancement, "+ Enh:Foo[_]"),
+            (AddendumKind::Optimization, "+ Opt:Foo[_]"),
+            (AddendumKind::ExtensionTable, "+ Ext:Foo[_]"),
+        ] {
+            let invocation = AddendumInvocation::parse(&extensions, addendum).unwrap();
+            assert_eq!(invocation.kind, kind);
+            assert!(invocation.args.positional.is_empty());
+            assert!(invocation.args.named.is_empty());
+        }
+
+        for addendum in ["+ Enh:Foo[]", "+ Opt:Foo[]", "+ Ext:Foo[]"] {
+            assert!(
+                AddendumInvocation::parse(&extensions, addendum).is_err(),
+                "accepted {addendum}"
+            );
+        }
+    }
+
+    #[test]
     fn extension_relation_kind_parses_text_prefixes() {
         assert_eq!(
             ExtensionRelationKind::from_str("ExtensionLeaf").unwrap(),

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -898,6 +898,12 @@ fn parse_aggregate_output(
         .map(|(index, expression)| (expression_key(expression), index))
         .collect();
 
+    let output_pair = unwrap_single_pair(output_pair);
+    if output_pair.as_rule() == Rule::empty {
+        return Ok((Vec::new(), Vec::new()));
+    }
+    assert_eq!(output_pair.as_rule(), Rule::expression_list);
+
     let mut measures = Vec::new();
     let mut output_mapping = Vec::new();
 
@@ -2464,6 +2470,20 @@ mod tests {
             9,
         );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_and_aggregate_empty_lists_require_underscore() {
+        for (rule, input) in [
+            (Rule::read_relation, "Read[my.table +> ]"),
+            (Rule::virtual_read_relation, "Read:Virtual[() => ]"),
+            (Rule::aggregate_relation, "Aggregate[_ => ]"),
+        ] {
+            assert!(
+                ExpressionParser::parse(rule, input).is_err(),
+                "accepted {input}"
+            );
+        }
     }
 
     fn parse_exact(rule: Rule, input: &'_ str) -> pest::iterators::Pair<'_, Rule> {

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -360,7 +360,11 @@ fn parse_read_output(
             let columns = iter.parse_next_scoped::<NamedColumnList>(extensions)?.0;
             iter.done();
             let output_count = columns.len();
-            Ok((columns, None, output_count))
+            let common = Some(RelCommon {
+                emit_kind: Some(EmitKind::Direct(Direct {})),
+                ..Default::default()
+            });
+            Ok((columns, common, output_count))
         }
         Rule::direct_read_output => {
             let mut iter = RuleIter::from(output.into_inner());
@@ -1595,7 +1599,12 @@ mod tests {
             .unwrap()
             .types;
         assert_eq!(columns.len(), 2);
-        assert!(read.common.is_none());
+        assert!(matches!(
+            read.common
+                .as_ref()
+                .and_then(|common| common.emit_kind.as_ref()),
+            Some(EmitKind::Direct(_)),
+        ));
     }
 
     #[test]

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -732,10 +732,8 @@ impl<'a> RelationParser<'a> {
 
         let names: Vec<String> = column_names_pair
             .into_inner()
-            .map(|name_pair| {
-                assert_eq!(name_pair.as_rule(), Rule::name);
-                Name::parse_pair(name_pair).0
-            })
+            .filter(|pair| pair.as_rule() == Rule::name)
+            .map(|name_pair| Name::parse_pair(name_pair).0)
             .collect();
 
         let mut children = node.children;
@@ -1454,7 +1452,7 @@ Root[result]
     fn test_parse_root_relation_no_names() {
         // Test a plan with a Root relation with no names
         let plan = r#"=== Plan
-Root[]
+Root[_]
   Project[$0, $1]
     Read[my.table => a:i32, b:string?]
 "#;
@@ -1473,6 +1471,11 @@ Root[]
 
         // Check that the root has no names
         assert_eq!(rel_root.names, Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_root_requires_empty_list_marker() {
+        assert!(Parser::parse("=== Plan\nRoot[]\n  Read[t => a:i32]").is_err());
     }
 
     #[test]

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -493,15 +493,13 @@ impl<'a> Relation<'a> {
         match &rel.read_type {
             Some(ReadType::NamedTable(table)) => {
                 let table_name = Value::TableName(table.names.iter().map(|n| Name(n)).collect());
-                // Named Reads preserve their existing schema spelling: an
-                // absent common output form uses compact `=> schema`, while a
-                // present Direct or Emit form writes the schema after `+>`.
-                // The Read compact-output slice canonicalizes Direct to the
-                // compact spelling.
-                let output_syntax = if emit.is_some() {
-                    OutputSyntax::Explicit
-                } else {
-                    OutputSyntax::Compact
+                // A compact Read schema determines only the final output, so
+                // it cannot preserve a non-identity emit mapping. Otherwise,
+                // direct schemas use the compact spelling regardless of whether
+                // Direct is explicitly present in the protobuf.
+                let output_syntax = match emit {
+                    Some(EmitKind::Emit(_)) => OutputSyntax::Explicit,
+                    Some(EmitKind::Direct(_)) | None => OutputSyntax::Compact,
                 };
                 Relation {
                     name: Cow::Borrowed("Read"),

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -948,12 +948,13 @@ impl Textify for RelRoot {
     fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
         let names = self.names.iter().map(|n| Name(n)).collect::<Vec<_>>();
 
-        write!(
-            w,
-            "{}Root[{}]",
-            ctx.indent(),
-            ctx.separated(names.iter(), ", ")
-        )?;
+        write!(w, "{}Root[", ctx.indent())?;
+        if names.is_empty() {
+            write!(w, "_")?;
+        } else {
+            write!(w, "{}", ctx.separated(names.iter(), ", "))?;
+        }
+        write!(w, "]")?;
         let child_scope = ctx.push_indent();
         for child in self.input.iter() {
             writeln!(w)?;

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -192,6 +192,9 @@ impl Textify for Emitted<'_> {
 
     fn textify<S: Scope, W: fmt::Write>(&self, ctx: &S, w: &mut W) -> fmt::Result {
         let Some(EmitKind::Emit(emit)) = self.emit else {
+            if self.direct_output.is_empty() {
+                return write!(w, "_");
+            }
             return write!(w, "{}", ctx.separated(self.direct_output.iter(), ", "));
         };
 

--- a/tests/extension_roundtrip.rs
+++ b/tests/extension_roundtrip.rs
@@ -362,11 +362,11 @@ fn test_extension_empty_args_roundtrip() {
     let mut registry = ExtensionRegistry::new();
     registry.register_relation::<EmptySource>().unwrap();
 
-    // No args, no output columns — textifies as [_]
+    // No args and an explicitly empty output list.
     let plan_text = r#"
 === Plan
 Root[result]
-  ExtensionLeaf:EmptySource[_ => ]
+  ExtensionLeaf:EmptySource[_ => _]
 "#;
 
     let parser = Parser::new().with_extension_registry(registry.clone());

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -22,17 +22,25 @@ Root[c, d]
 }
 
 #[test]
-fn test_read_explicit_direct_roundtrip() {
-    let plan = r#"=== Plan
+fn test_read_direct_output_is_canonicalized() {
+    let canonical = r#"=== Plan
+Root[a, b]
+  Read[my.table => a:i32, b:string?]"#;
+    let explicit = r#"=== Plan
 Root[a, b]
   Read[my.table +> a:i32, b:string?]"#;
 
-    roundtrip_plan(plan);
+    assert_roundtrip_canonical(canonical, explicit);
 }
 
 #[test]
-fn test_read_explicit_empty_additions_roundtrip() {
-    roundtrip_plan(
+fn test_empty_read_direct_output_is_canonicalized() {
+    let canonical = r#"=== Plan
+Root[_]
+  Read[my.table => _]"#;
+
+    assert_roundtrip_canonical(
+        canonical,
         r#"=== Plan
 Root[_]
   Read[my.table +> _]"#,

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -32,14 +32,21 @@ Root[a, b]
 
 #[test]
 fn test_read_explicit_empty_additions_roundtrip() {
-    let canonical = r#"=== Plan
-Root[]
-  Read[my.table +> _]"#;
-    let legacy = r#"=== Plan
-Root[]
-  Read[my.table +> ]"#;
+    roundtrip_plan(
+        r#"=== Plan
+Root[_]
+  Read[my.table +> _]"#,
+    );
+}
 
-    assert_roundtrip_canonical(canonical, legacy);
+#[test]
+fn test_empty_aggregate_output_roundtrip() {
+    roundtrip_plan(
+        r#"=== Plan
+Root[_]
+  Aggregate[_ => _]
+    Read[my.table => value:i32]"#,
+    );
 }
 
 #[test]
@@ -202,7 +209,7 @@ Root[sum, count]
 #[test]
 fn test_sort_empty_parameter_list() {
     let plan = r#"=== Plan
-Root[]
+Root[_]
   Sort[_]
     Read[table => a:i32]"#;
 
@@ -603,7 +610,7 @@ Root[a, b]
 #[test]
 fn test_empty_cross_parameters_roundtrip() {
     let plan = r#"=== Plan
-Root[]
+Root[_]
   Cross[_]
     Read[left => left:i32]
     Read[right => right:string]"#;
@@ -969,8 +976,8 @@ fn test_virtual_read_no_columns() {
     // Degenerate table with zero columns and empty rows.
     let plan = r#"
 === Plan
-Root[]
-  Read:Virtual[(), () => ]"#;
+Root[_]
+  Read:Virtual[(), () => _]"#;
 
     roundtrip_plan(plan);
 }

--- a/tests/verbose_roundtrip.rs
+++ b/tests/verbose_roundtrip.rs
@@ -7,11 +7,11 @@ use common::assert_roundtrip_verbose;
 #[test]
 fn test_filter_empty_output_styles() {
     let compact = r#"=== Plan
-Root[]
+Root[_]
   Filter[$2 => _]
     Read[table => a:i32, b:string, c:boolean]"#;
     let verbose = r#"=== Plan
-Root[]
+Root[_]
   Filter[$2 |> _]
     Read[table => a:i32, b:string, c:boolean]"#;
 

--- a/tests/verbose_roundtrip.rs
+++ b/tests/verbose_roundtrip.rs
@@ -5,6 +5,15 @@ mod common;
 use common::assert_roundtrip_verbose;
 
 #[test]
+fn test_direct_read_stays_compact_in_verbose_output() {
+    let read = r#"=== Plan
+Root[a, b]
+  Read[table => a:i32, b:string]"#;
+
+    assert_roundtrip_verbose(read, read);
+}
+
+#[test]
 fn test_filter_empty_output_styles() {
     let compact = r#"=== Plan
 Root[_]


### PR DESCRIPTION
## Description

This PR makes empty lists explicit across the text format and uses compact `=>` as the canonical spelling for a named Read with `Direct` output.

For example, both of these inputs describe an empty named Read schema:

```text
Read[my.table => _]
Read[my.table +> _]
```

Formatting writes the first form. A Read with an explicit `Emit` remains explicit:

```text
Read[my.table +> a:i32, b:string |> $1, $0]
```

Part of #34.

## Changes

- (Breaking!) Requires `_` for empty extension and addendum arguments, extension output
  columns, named and virtual Read schemas, and Aggregate output.
	- Reject blank required lists such as `Read[my.table +> ]`, `Read:Virtual[() => ]`, and `Aggregate[_ => ]`.
- Canonicalize named Read `Direct` output as `=> schema`, including verbose
  formatting and protobuf input that explicitly contains `Direct`.
- Continue accepting `Read[table +> schema]` as `Direct` input, but format it
  with `=>`.
	- The explicit `Read[table +> schema |> mapping]` would be preserved.
