### PR TITLE
chore: enable Clippy path and item-placement lints

### DIFF
--- a/API.md
+++ b/API.md
@@ -138,7 +138,8 @@ syntax around those arguments:
 
 - `name()` - The extension name used in text (e.g., `"ParquetScan"`)
 - `from_args(args)` - Parse text arguments into your type
-- `to_args(&self)` - Convert your type to text arguments
+- `to_args(&self, context)` - Convert your type to text arguments, optionally
+  using information about relation inputs.
 
 The extension API works across three representations:
 
@@ -157,6 +158,11 @@ represented as expression values.
 `ExtensionProtoConvert` converts between extension arguments and Substrait
 protobuf values in either direction, such as output columns and relation
 `NamedStruct`s.
+
+The `to_args` method receives an `ExtensionContext`. Relation extensions get one
+`ExtensionInput` per available child, in relation order. Each input exposes its
+emitted column count, including any output mapping applied by that child. Other
+extension namespaces receive an empty input slice.
 
 Use `ArgsExtractor` for convenient argument parsing:
 
@@ -183,7 +189,7 @@ Register extensions to the appropriate namespace:
 ```rust,no_run
 # use prost::{Message, Name};
 # use substrait_explain::extensions::{
-#     Explainable, ExtensionArgs, ExtensionError, ExtensionRegistry,
+#     Explainable, ExtensionArgs, ExtensionContext, ExtensionError, ExtensionRegistry,
 # };
 #[derive(Clone, PartialEq, Message)]
 pub struct MySourceConfig {
@@ -199,7 +205,10 @@ impl Name for MySourceConfig {
 # impl Explainable for MySourceConfig {
 #     fn name() -> &'static str { "MySource" }
 #     fn from_args(_: &ExtensionArgs) -> Result<Self, ExtensionError> { Ok(Self::default()) }
-#     fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+#     fn to_args(
+#         &self,
+#         _context: &ExtensionContext<'_>,
+#     ) -> Result<ExtensionArgs, ExtensionError> {
 #         Ok(ExtensionArgs::default())
 #     }
 # }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,15 @@ serde = ["substrait/serde", "dep:pbjson-types"]
 # CLI functionality with additional dependencies.
 # Includes prost-reflect for JSON parsing: both Go protojson (@type encoding) and Rust
 # pbjson (typeUrl/value encoding) are handled
-cli = ["dep:clap", "dep:serde_json", "dep:serde_yaml", "dep:anyhow", "serde", "dep:prost-reflect", "substrait/embed-descriptor"]
+cli = [
+    "dep:clap",
+    "dep:serde_json",
+    "dep:serde_yaml",
+    "dep:anyhow",
+    "serde",
+    "dep:prost-reflect",
+    "substrait/embed-descriptor",
+]
 
 [dependencies]
 anyhow = { version = "1.0", optional = true }
@@ -73,3 +81,7 @@ serde_yaml = "0.9"
 prost = "0.14"
 prost-build = "0.14"
 protox = "0.9"
+
+[lints.clippy]
+absolute_paths = "warn"
+items_after_statements = "warn"

--- a/build.rs
+++ b/build.rs
@@ -1,20 +1,23 @@
+use std::error::Error;
 use std::path::PathBuf;
+use std::{env, fs};
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+use prost::Message;
+
+fn main() -> Result<(), Box<dyn Error>> {
     let proto = "tests/json_parsing/parquet_scan.proto";
 
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed={proto}");
 
-    let out_dir = PathBuf::from(std::env::var("OUT_DIR")?);
+    let out_dir = PathBuf::from(env::var("OUT_DIR")?);
 
     // Compile the proto using protox — pure Rust, no system protoc required.
     let fds = protox::compile([proto], ["tests/json_parsing/"])?;
 
     // Write the FileDescriptorSet binary for use with build_descriptor_pool in tests.
     // Tests include this via include_bytes!(concat!(env!("OUT_DIR"), "/parquet_scan.bin")).
-    use prost::Message;
-    std::fs::write(out_dir.join("parquet_scan.bin"), fds.encode_to_vec())?;
+    fs::write(out_dir.join("parquet_scan.bin"), fds.encode_to_vec())?;
 
     // Generate Rust types from the compiled descriptor. type_name_domains configures
     // impl prost::Name with the type.googleapis.com prefix so that type_url() returns

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+absolute-paths-max-segments = 2

--- a/examples/advanced_usage.rs
+++ b/examples/advanced_usage.rs
@@ -3,14 +3,13 @@
 //! This example shows how to parse a Substrait plan and format it with
 //! different output options.
 
+use std::error::Error;
+
 use substrait::proto::Plan;
 use substrait_explain::{OutputOptions, Parser, Visibility, format_with_options};
 
 /// Helper function to format a plan with given options and print the result with error handling
-fn print_with_errors(
-    plan: &Plan,
-    options: Option<&OutputOptions>,
-) -> Result<(), Box<dyn std::error::Error>> {
+fn print_with_errors(plan: &Plan, options: Option<&OutputOptions>) -> Result<(), Box<dyn Error>> {
     let default_options;
     let options = match options {
         Some(options) => options,
@@ -30,7 +29,7 @@ fn print_with_errors(
     }
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     // Parse a plan with extensions
     let plan_text = r#"
 === Extensions

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -2,9 +2,11 @@
 //!
 //! This example shows how to parse a Substrait plan and format it with different output options.
 
+use std::error::Error;
+
 use substrait_explain::{OutputOptions, Parser, format, format_with_options};
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     println!("=== Substrait-Explain Basic Usage ===\n");
 
     // Parse a plan with extensions

--- a/examples/extensions.rs
+++ b/examples/extensions.rs
@@ -15,7 +15,8 @@ use prost::{Message, Name};
 use substrait::proto::{self, plan_rel, rel};
 use substrait_explain::extensions::any::AnyRef;
 use substrait_explain::extensions::{
-    AnyConvertible, Explainable, ExtensionArgs, ExtensionColumn, ExtensionError, ExtensionRegistry,
+    AnyConvertible, Explainable, ExtensionArgs, ExtensionColumn, ExtensionContext, ExtensionError,
+    ExtensionRegistry,
 };
 use substrait_explain::{OutputOptions, Parser, format_with_registry};
 
@@ -102,7 +103,7 @@ impl Explainable for ParquetScanConfig {
         })
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
 
         // Add named arguments from the message

--- a/examples/extensions.rs
+++ b/examples/extensions.rs
@@ -12,7 +12,7 @@
 //! implementation following the same pattern shown for `Explainable`.
 
 use prost::{Message, Name};
-use substrait::proto::{self, plan_rel, rel};
+use substrait::proto::{self, Plan, PlanRel, Rel, plan_rel, rel};
 use substrait_explain::extensions::any::AnyRef;
 use substrait_explain::extensions::{
     AnyConvertible, Explainable, ExtensionArgs, ExtensionColumn, ExtensionError, ExtensionRegistry,
@@ -173,10 +173,10 @@ Root[customer_id, amount]
 }
 
 /// Extract the extension detail from the plan, for validation. Assumes Root -> ExtensionLeaf plan.
-fn extension_detail<'a>(plan: &'a substrait::proto::Plan) -> Result<AnyRef<'a>, anyhow::Error> {
+fn extension_detail<'a>(plan: &'a Plan) -> Result<AnyRef<'a>, anyhow::Error> {
     assert!(plan.relations.len() == 1);
     let root = match plan.relations.first().unwrap() {
-        substrait::proto::PlanRel {
+        PlanRel {
             rel_type: Some(plan_rel::RelType::Root(root)),
         } => root,
         rel => return Err(anyhow::anyhow!("expected Root relation, got {rel:?}")),
@@ -185,7 +185,7 @@ fn extension_detail<'a>(plan: &'a substrait::proto::Plan) -> Result<AnyRef<'a>, 
     let rel = root.input.as_ref().unwrap();
 
     match root.input.as_ref() {
-        Some(substrait::proto::Rel {
+        Some(Rel {
             rel_type: Some(rel::RelType::ExtensionLeaf(leaf)),
         }) => leaf
             .detail

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -478,7 +478,9 @@ mod tests {
     use substrait::proto::rel::RelType;
 
     use super::*;
-    use crate::extensions::{Explainable, ExtensionArgs, ExtensionColumn, ExtensionError};
+    use crate::extensions::{
+        Explainable, ExtensionArgs, ExtensionColumn, ExtensionContext, ExtensionError,
+    };
     use crate::fixtures::parse_type;
     use crate::parse;
 
@@ -913,7 +915,10 @@ Root[result]
             })
         }
 
-        fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+        fn to_args(
+            &self,
+            _context: &ExtensionContext<'_>,
+        ) -> Result<ExtensionArgs, ExtensionError> {
             let mut args = ExtensionArgs::default();
             args.insert("tag", self.tag.clone());
             args.output_columns.push(ExtensionColumn::Named {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,13 +1,18 @@
 use std::fs;
 use std::io::{self, Read, Write};
+use std::path::Path;
 use std::process::ExitCode;
+use std::str::FromStr;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use prost::Message;
+use substrait::proto::Plan;
 
 use crate::extensions::ExtensionRegistry;
-use crate::{FormatError, OutputOptions, Visibility, format_with_registry, parse_with_registry};
+use crate::{
+    FormatError, OutputOptions, Visibility, format_with_registry, json, parse_with_registry,
+};
 
 /// The outcome of a CLI operation.
 ///
@@ -301,7 +306,7 @@ pub enum Format {
     Protobuf,
 }
 
-impl std::str::FromStr for Format {
+impl FromStr for Format {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -324,7 +329,7 @@ impl Format {
             return None; // stdin/stdout - no extension
         }
 
-        let extension = std::path::Path::new(path)
+        let extension = Path::new(path)
             .extension()
             .and_then(|ext| ext.to_str())
             .map(|ext| ext.to_lowercase());
@@ -338,11 +343,7 @@ impl Format {
         }
     }
 
-    pub fn read_plan<R: Read>(
-        &self,
-        reader: R,
-        registry: &ExtensionRegistry,
-    ) -> Result<substrait::proto::Plan> {
+    pub fn read_plan<R: Read>(&self, reader: R, registry: &ExtensionRegistry) -> Result<Plan> {
         match self {
             Format::Text => {
                 let input_text = read_text_input(reader)?;
@@ -350,8 +351,8 @@ impl Format {
             }
             Format::Json => {
                 let input_text = read_text_input(reader)?;
-                let pool = crate::json::build_descriptor_pool(&registry.descriptors())?;
-                crate::json::parse_json(&input_text, &pool)
+                let pool = json::build_descriptor_pool(&registry.descriptors())?;
+                json::parse_json(&input_text, &pool)
             }
             Format::Yaml => {
                 #[cfg(feature = "serde")]
@@ -366,7 +367,7 @@ impl Format {
             }
             Format::Protobuf => {
                 let input_bytes = read_binary_input(reader)?;
-                Ok(substrait::proto::Plan::decode(&input_bytes[..])?)
+                Ok(Plan::decode(&input_bytes[..])?)
             }
         }
     }
@@ -374,7 +375,7 @@ impl Format {
     pub fn write_plan<W: Write>(
         &self,
         writer: W,
-        plan: &substrait::proto::Plan,
+        plan: &Plan,
         options: &OutputOptions,
         registry: &ExtensionRegistry,
     ) -> Result<Outcome> {
@@ -1023,7 +1024,7 @@ Root[val]
     }
 
     /// Creates a plan with an invalid function reference that will cause formatting errors.
-    fn make_plan_with_invalid_function_ref() -> substrait::proto::Plan {
+    fn make_plan_with_invalid_function_ref() -> Plan {
         const VALID_PLAN: &str = r#"=== Extensions
 URNs:
   @  1: https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml

--- a/src/extensions/args.rs
+++ b/src/extensions/args.rs
@@ -26,7 +26,9 @@
 //! into default Substrait literal expressions.
 
 use std::collections::HashSet;
-use std::fmt;
+use std::slice::Iter as SliceIter;
+use std::vec::IntoIter as VecIntoIter;
+use std::{fmt, thread};
 
 use indexmap::IndexMap;
 use substrait::proto;
@@ -289,7 +291,7 @@ impl<'a> ArgsExtractor<'a> {
 
 impl Drop for ArgsExtractor<'_> {
     fn drop(&mut self) {
-        if self.checked || std::thread::panicking() {
+        if self.checked || thread::panicking() {
             return;
         }
         // If we get here, the caller forgot to call check_exhausted().
@@ -316,14 +318,14 @@ impl TupleValue {
         self.0.is_empty()
     }
 
-    pub fn iter(&self) -> std::slice::Iter<'_, ExtensionValue> {
+    pub fn iter(&self) -> SliceIter<'_, ExtensionValue> {
         self.0.iter()
     }
 }
 
 impl<'a> IntoIterator for &'a TupleValue {
     type Item = &'a ExtensionValue;
-    type IntoIter = std::slice::Iter<'a, ExtensionValue>;
+    type IntoIter = SliceIter<'a, ExtensionValue>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()
@@ -332,7 +334,7 @@ impl<'a> IntoIterator for &'a TupleValue {
 
 impl IntoIterator for TupleValue {
     type Item = ExtensionValue;
-    type IntoIter = std::vec::IntoIter<ExtensionValue>;
+    type IntoIter = VecIntoIter<ExtensionValue>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()

--- a/src/extensions/examples.rs
+++ b/src/extensions/examples.rs
@@ -16,7 +16,9 @@
 //! integration tests, not a stable extension API.
 
 use crate::extensions::args::{EnumValue, ExtensionArgs, ExtensionValue};
-use crate::extensions::registry::{Explainable, ExtensionError, ExtensionRegistry};
+use crate::extensions::registry::{
+    Explainable, ExtensionContext, ExtensionError, ExtensionRegistry,
+};
 
 // ---------------------------------------------------------------------------
 // PartitionStrategy enum
@@ -147,7 +149,7 @@ impl Explainable for PartitionHint {
         })
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
         for &raw in &self.strategies {
             let s = PartitionStrategy::try_from(raw).unwrap_or(PartitionStrategy::Unspecified);
@@ -230,7 +232,7 @@ impl Explainable for PlanHint {
         Ok(PlanHint { hint })
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
         args.named
             .insert("hint".to_owned(), ExtensionValue::String(self.hint.clone()));
@@ -327,7 +329,7 @@ impl Explainable for BlobStoreRead {
         })
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
         args.positional
             .push(ExtensionValue::String(self.path.clone()));
@@ -381,7 +383,7 @@ mod tests {
     #[test]
     fn to_args_produces_enum_and_named() {
         let hint = make_hint(vec![PartitionStrategy::Hash], 8);
-        let args = hint.to_args().unwrap();
+        let args = hint.to_args(&ExtensionContext::default()).unwrap();
         assert_eq!(args.positional.len(), 1);
         assert!(matches!(&args.positional[0], ExtensionValue::Enum(s) if s == "HASH"));
         let count = args.named.get("count").expect("count arg");
@@ -391,14 +393,14 @@ mod tests {
     #[test]
     fn to_args_omits_zero_count() {
         let hint = make_hint(vec![PartitionStrategy::Broadcast], 0);
-        let args = hint.to_args().unwrap();
+        let args = hint.to_args(&ExtensionContext::default()).unwrap();
         assert!(args.named.is_empty(), "count=0 should be omitted");
     }
 
     #[test]
     fn from_args_round_trip() {
         let original = make_hint(vec![PartitionStrategy::Hash, PartitionStrategy::Range], 16);
-        let args = original.to_args().unwrap();
+        let args = original.to_args(&ExtensionContext::default()).unwrap();
         let decoded = PartitionHint::from_args(&args).unwrap();
         assert_eq!(original, decoded);
     }
@@ -438,7 +440,7 @@ mod tests {
     #[test]
     fn from_args_empty_strategies_roundtrip() {
         let original = make_hint(vec![], 0);
-        let args = original.to_args().unwrap();
+        let args = original.to_args(&ExtensionContext::default()).unwrap();
         let decoded = PartitionHint::from_args(&args).unwrap();
         assert_eq!(original, decoded);
         assert!(decoded.strategies.is_empty());
@@ -470,7 +472,7 @@ mod tests {
         let original = PlanHint {
             hint: "use_index".to_owned(),
         };
-        let args = original.to_args().unwrap();
+        let args = original.to_args(&ExtensionContext::default()).unwrap();
         let decoded = PlanHint::from_args(&args).unwrap();
         assert_eq!(original, decoded);
     }
@@ -504,7 +506,7 @@ mod tests {
             include_archived: true,
         };
 
-        let args = original.to_args().unwrap();
+        let args = original.to_args(&ExtensionContext::default()).unwrap();
         let decoded = BlobStoreRead::from_args(&args).unwrap();
 
         assert_eq!(original, decoded);

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -22,7 +22,7 @@ pub use args::{
     EnumValue, Expr, ExtensionArgs, ExtensionColumn, ExtensionValue, ExtensionValueKind, TupleValue,
 };
 pub use registry::{
-    AnyConvertible, Explainable, Extension, ExtensionError, ExtensionProtoConvert,
-    ExtensionRegistry, ExtensionType, RegistrationError,
+    AnyConvertible, Explainable, Extension, ExtensionContext, ExtensionError, ExtensionInput,
+    ExtensionProtoConvert, ExtensionRegistry, ExtensionType, RegistrationError,
 };
 pub use simple::{InsertError, SimpleExtension, SimpleExtensions};

--- a/src/extensions/registry.rs
+++ b/src/extensions/registry.rs
@@ -82,6 +82,7 @@
 
 use std::collections::HashMap;
 use std::fmt;
+use std::marker::PhantomData;
 use std::sync::Arc;
 
 use substrait::proto::NamedStruct;
@@ -322,7 +323,7 @@ trait ExtensionConverter: Send + Sync {
 ///
 /// The PhantomData is necessary because we don't actually store a T, but we need
 /// the type information to call T's static methods (from_args, from_any).
-struct ExtensionAdapter<T>(std::marker::PhantomData<T>);
+struct ExtensionAdapter<T>(PhantomData<T>);
 
 impl<T: AnyConvertible + Explainable + Send + Sync> ExtensionConverter for ExtensionAdapter<T> {
     fn parse_detail(&self, args: &ExtensionArgs) -> Result<Any, ExtensionError> {
@@ -387,8 +388,7 @@ impl ExtensionRegistry {
     {
         let canonical_name = T::name();
         let type_url = T::type_url();
-        let handler: Arc<dyn ExtensionConverter> =
-            Arc::new(ExtensionAdapter::<T>(std::marker::PhantomData));
+        let handler: Arc<dyn ExtensionConverter> = Arc::new(ExtensionAdapter::<T>(PhantomData));
 
         let key = (ext_type, canonical_name.to_string());
         if self.handlers.contains_key(&key) {
@@ -647,6 +647,8 @@ impl fmt::Debug for ExtensionRegistry {
 mod tests {
     use super::*;
     use crate::extensions::ExtensionColumn;
+    use crate::fixtures::parse_type;
+    use crate::textify::expressions::Reference;
 
     // Mock type for testing
     struct TestExtension {
@@ -789,12 +791,12 @@ mod tests {
         args.insert("batch_size", 1024_i64);
 
         // Add positional args
-        args.push(crate::textify::expressions::Reference(0));
+        args.push(Reference(0));
 
         // Add output columns
         args.output_columns.push(ExtensionColumn::Named {
             name: "col1".to_string(),
-            r#type: crate::fixtures::parse_type("i32"),
+            r#type: parse_type("i32"),
         });
 
         // Test retrieval - use extractor

--- a/src/extensions/registry.rs
+++ b/src/extensions/registry.rs
@@ -26,7 +26,8 @@
 //!
 //! ```rust
 //! use substrait_explain::extensions::{
-//!     Any, AnyConvertible, AnyRef, Explainable, ExtensionArgs, ExtensionError, ExtensionRegistry,
+//!     Any, AnyConvertible, AnyRef, Explainable, ExtensionArgs, ExtensionContext, ExtensionError,
+//!     ExtensionRegistry,
 //! };
 //!
 //! // Define a custom extension type
@@ -68,7 +69,10 @@
 //!         })
 //!     }
 //!
-//!     fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+//!     fn to_args(
+//!         &self,
+//!         _context: &ExtensionContext<'_>,
+//!     ) -> Result<ExtensionArgs, ExtensionError> {
 //!         let mut args = ExtensionArgs::default();
 //!         args.insert("path", self.path.clone());
 //!         Ok(args)
@@ -102,6 +106,46 @@ pub enum ExtensionType {
     Enhancement,
     /// Optimization attached to a relation (uses `+ Opt:` prefix in text format)
     Optimization,
+}
+
+/// Information about one input to an extension relation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExtensionInput {
+    emitted_column_count: usize,
+}
+
+impl ExtensionInput {
+    pub(crate) fn new(emitted_column_count: usize) -> Self {
+        Self {
+            emitted_column_count,
+        }
+    }
+
+    /// Number of columns emitted by this input after applying its output mapping.
+    pub fn emitted_column_count(&self) -> usize {
+        self.emitted_column_count
+    }
+}
+
+/// Context available while converting an extension payload to text arguments.
+///
+/// Relation extensions receive one entry per available input, in relation
+/// order. Other extension namespaces, and context-free registry decoding,
+/// receive an empty input slice.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ExtensionContext<'a> {
+    inputs: &'a [ExtensionInput],
+}
+
+impl<'a> ExtensionContext<'a> {
+    pub(crate) fn new(inputs: &'a [ExtensionInput]) -> Self {
+        Self { inputs }
+    }
+
+    /// Inputs to the extension relation, in relation order.
+    pub fn inputs(&self) -> &'a [ExtensionInput] {
+        self.inputs
+    }
 }
 
 /// Errors during extension registration (setup phase)
@@ -284,7 +328,7 @@ pub trait Explainable: Sized {
     fn from_args(args: &ExtensionArgs) -> Result<Self, ExtensionError>;
 
     /// Convert this type to extension arguments
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError>;
+    fn to_args(&self, context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError>;
 }
 
 /// Internal trait that converts between ExtensionArgs and protobuf Any messages.
@@ -303,7 +347,11 @@ pub trait Explainable: Sized {
 trait ExtensionConverter: Send + Sync {
     fn parse_detail(&self, args: &ExtensionArgs) -> Result<Any, ExtensionError>;
 
-    fn textify_detail(&self, detail: AnyRef<'_>) -> Result<ExtensionArgs, ExtensionError>;
+    fn textify_detail(
+        &self,
+        detail: AnyRef<'_>,
+        context: &ExtensionContext<'_>,
+    ) -> Result<ExtensionArgs, ExtensionError>;
 }
 
 /// Type adapter that implements ExtensionConverter for any type T that implements
@@ -329,9 +377,13 @@ impl<T: AnyConvertible + Explainable + Send + Sync> ExtensionConverter for Exten
         T::from_args(args)?.to_any()
     }
 
-    fn textify_detail(&self, detail: AnyRef<'_>) -> Result<ExtensionArgs, ExtensionError> {
+    fn textify_detail(
+        &self,
+        detail: AnyRef<'_>,
+        context: &ExtensionContext<'_>,
+    ) -> Result<ExtensionArgs, ExtensionError> {
         let owned_any = Any::new(detail.type_url.to_string(), detail.value.to_vec());
-        T::from_any(owned_any.as_ref())?.to_args()
+        T::from_any(owned_any.as_ref())?.to_args(context)
     }
 }
 
@@ -536,6 +588,15 @@ impl ExtensionRegistry {
         self.decode_with_type(ExtensionType::Relation, detail)
     }
 
+    /// Decode relation extension detail using information about its inputs.
+    pub(crate) fn decode_with_context(
+        &self,
+        detail: AnyRef<'_>,
+        context: &ExtensionContext<'_>,
+    ) -> Result<(String, ExtensionArgs), ExtensionError> {
+        self.decode_with_type_and_context(ExtensionType::Relation, detail, context)
+    }
+
     /// Decode ExtensionTable detail to extension name and ExtensionArgs
     ///
     /// This is the primary method for textification of ExtensionTable reads -
@@ -582,6 +643,15 @@ impl ExtensionRegistry {
         ext_type: ExtensionType,
         detail: AnyRef<'_>,
     ) -> Result<(String, ExtensionArgs), ExtensionError> {
+        self.decode_with_type_and_context(ext_type, detail, &ExtensionContext::default())
+    }
+
+    fn decode_with_type_and_context(
+        &self,
+        ext_type: ExtensionType,
+        detail: AnyRef<'_>,
+        context: &ExtensionContext<'_>,
+    ) -> Result<(String, ExtensionArgs), ExtensionError> {
         // Find extension name by type URL in the specified namespace
         let type_url_key = (ext_type, detail.type_url.to_string());
         let extension_name =
@@ -600,7 +670,7 @@ impl ExtensionRegistry {
                 name: extension_name.clone(),
             })?;
 
-        let args = handler.textify_detail(detail)?;
+        let args = handler.textify_detail(detail, context)?;
 
         Ok((extension_name.clone(), args))
     }
@@ -703,10 +773,13 @@ mod tests {
             })
         }
 
-        fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+        fn to_args(&self, context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
             let mut args = ExtensionArgs::default();
             args.insert("path", self.path.clone());
             args.insert("batch_size", self.batch_size);
+            if !context.inputs().is_empty() {
+                args.insert("input_count", context.inputs().len() as i64);
+            }
             Ok(args)
         }
     }
@@ -747,6 +820,28 @@ mod tests {
             <&str>::try_from(result.1.named.get("path").unwrap()).unwrap(),
             "test.parquet"
         );
+        assert!(!result.1.named.contains_key("input_count"));
+    }
+
+    #[test]
+    fn test_extension_registry_decode_with_context() {
+        let mut registry = ExtensionRegistry::new();
+        registry.register_relation::<TestExtension>().unwrap();
+
+        let mut args = ExtensionArgs::default();
+        args.insert("path", "data.parquet");
+        args.insert("batch_size", 2048_i64);
+        let any = registry.parse_extension("TestExtension", &args).unwrap();
+        let inputs = [ExtensionInput::new(4)];
+        let context = ExtensionContext::new(&inputs);
+
+        let (_, decoded_args) = registry
+            .decode_with_context(any.as_ref(), &context)
+            .unwrap();
+        assert_eq!(
+            i64::try_from(decoded_args.named.get("input_count").unwrap()).unwrap(),
+            1
+        );
     }
 
     #[test]
@@ -778,6 +873,7 @@ mod tests {
             <&str>::try_from(decoded_args.named.get("path").unwrap()).unwrap(),
             "test.parquet"
         );
+        assert!(!decoded_args.named.contains_key("input_count"));
     }
 
     #[test]
@@ -879,7 +975,10 @@ mod tests {
             Ok(TestEnhancement { hint })
         }
 
-        fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+        fn to_args(
+            &self,
+            _context: &ExtensionContext<'_>,
+        ) -> Result<ExtensionArgs, ExtensionError> {
             let mut args = ExtensionArgs::default();
             args.insert("hint", self.hint.clone());
             Ok(args)
@@ -1016,7 +1115,10 @@ mod tests {
             Ok(ConflictingExtension)
         }
 
-        fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+        fn to_args(
+            &self,
+            _context: &ExtensionContext<'_>,
+        ) -> Result<ExtensionArgs, ExtensionError> {
             Ok(ExtensionArgs::default())
         }
     }

--- a/src/json.rs
+++ b/src/json.rs
@@ -23,16 +23,18 @@
 //! let plan = parse_json(json_str, &pool).unwrap();
 //! ```
 
+use std::collections::HashSet;
+
 use anyhow::Context;
 use prost::Message;
 use prost_reflect::{DescriptorPool, DynamicMessage};
 use prost_types::FileDescriptorSet;
-use substrait::proto::Plan;
+use substrait::proto::{FILE_DESCRIPTOR_SET, Plan};
 
 /// Build a [`DescriptorPool`] covering the Substrait core schema plus any extra
 /// descriptor passed in.
 pub fn build_descriptor_pool(extra_descriptors: &[&[u8]]) -> anyhow::Result<DescriptorPool> {
-    let mut fds = FileDescriptorSet::decode(substrait::proto::FILE_DESCRIPTOR_SET)
+    let mut fds = FileDescriptorSet::decode(FILE_DESCRIPTOR_SET)
         .context("failed to decode substrait core descriptor")?;
 
     // Descriptor blobs compiled from proto files bundle their transitive dependencies,
@@ -41,8 +43,7 @@ pub fn build_descriptor_pool(extra_descriptors: &[&[u8]]) -> anyhow::Result<Desc
     // which are also present in substrait core protos.
     // DescriptorPool::decode treats duplicate filenames as a hard error.
     // Track filenames already in the set so we can skip duplicates.
-    let mut seen: std::collections::HashSet<String> =
-        fds.file.iter().map(|f| f.name().to_owned()).collect();
+    let mut seen: HashSet<String> = fds.file.iter().map(|f| f.name().to_owned()).collect();
 
     for blob in extra_descriptors {
         let extra =

--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -1,5 +1,8 @@
-use std::fmt;
+use std::{fmt, thread};
 
+use pest::error::{Error as PestError, ErrorVariant};
+use pest::iterators::{Pair, Pairs};
+use pest::{Parser as PestParser, Span};
 use pest_derive::Parser as PestDeriveParser;
 use thiserror::Error;
 
@@ -18,7 +21,7 @@ pub struct MessageParseError {
     message: &'static str,
     kind: ErrorKind,
     #[source]
-    error: Box<pest::error::Error<Rule>>,
+    error: Box<PestError<Rule>>,
 }
 
 #[derive(Debug, Clone)]
@@ -29,13 +32,9 @@ pub(crate) enum ErrorKind {
 }
 
 impl MessageParseError {
-    pub(crate) fn invalid(
-        message: &'static str,
-        span: pest::Span,
-        description: impl ToString,
-    ) -> Self {
-        let error = pest::error::Error::new_from_span(
-            pest::error::ErrorVariant::CustomError {
+    pub(crate) fn invalid(message: &'static str, span: Span, description: impl ToString) -> Self {
+        let error = PestError::new_from_span(
+            ErrorVariant::CustomError {
                 message: description.to_string(),
             },
             span,
@@ -46,11 +45,11 @@ impl MessageParseError {
     pub(crate) fn lookup(
         message: &'static str,
         missing: MissingReference,
-        span: pest::Span,
+        span: Span,
         description: impl ToString,
     ) -> Self {
-        let error = pest::error::Error::new_from_span(
-            pest::error::ErrorVariant::CustomError {
+        let error = PestError::new_from_span(
+            ErrorVariant::CustomError {
                 message: description.to_string(),
             },
             span,
@@ -60,11 +59,7 @@ impl MessageParseError {
 }
 
 impl MessageParseError {
-    pub(crate) fn new(
-        message: &'static str,
-        kind: ErrorKind,
-        error: Box<pest::error::Error<Rule>>,
-    ) -> Self {
+    pub(crate) fn new(message: &'static str, kind: ErrorKind, error: Box<PestError<Rule>>) -> Self {
         Self {
             message,
             kind,
@@ -83,7 +78,7 @@ impl fmt::Display for ErrorKind {
     }
 }
 
-pub(crate) fn unwrap_single_pair(pair: pest::iterators::Pair<Rule>) -> pest::iterators::Pair<Rule> {
+pub(crate) fn unwrap_single_pair(pair: Pair<Rule>) -> Pair<Rule> {
     let mut pairs = pair.into_inner();
     let pair = pairs.next().unwrap();
     assert_eq!(pairs.next(), None);
@@ -102,7 +97,7 @@ pub(crate) fn unwrap_single_pair(pair: pest::iterators::Pair<Rule>) -> pest::ite
 /// Panics if the rule is not `string_literal` or `quoted_name` (this should never happen
 /// if the pest grammar is working correctly).
 ///
-pub(crate) fn unescape_string(pair: pest::iterators::Pair<Rule>) -> String {
+pub(crate) fn unescape_string(pair: Pair<Rule>) -> String {
     let s = pair.as_str();
 
     // Determine opener/closer based on rule type
@@ -168,10 +163,10 @@ pub(crate) trait ParsePair: Sized {
     // Parse a single instance of this type from a pest::iterators::Pair<Rule>.
     // The input must match the rule returned by `rule`; otherwise, a panic is
     // expected.
-    fn parse_pair(pair: pest::iterators::Pair<Rule>) -> Self;
+    fn parse_pair(pair: Pair<Rule>) -> Self;
 
     fn parse_str(s: &str) -> Result<Self, MessageParseError> {
-        let mut pairs = <ExpressionParser as pest::Parser<Rule>>::parse(Self::rule(), s)
+        let mut pairs = <ExpressionParser as PestParser<Rule>>::parse(Self::rule(), s)
             .map_err(|e| MessageParseError::new(Self::message(), ErrorKind::Syntax, Box::new(e)))?;
         assert_eq!(pairs.as_str(), s);
         let pair = pairs.next().unwrap();
@@ -196,11 +191,11 @@ pub(crate) trait ScopedParsePair: Sized {
     // expected.
     fn parse_pair(
         extensions: &SimpleExtensions,
-        pair: pest::iterators::Pair<Rule>,
+        pair: Pair<Rule>,
     ) -> Result<Self, MessageParseError>;
 }
 
-pub(crate) fn iter_pairs(pair: pest::iterators::Pairs<'_, Rule>) -> RuleIter<'_> {
+pub(crate) fn iter_pairs(pair: Pairs<'_, Rule>) -> RuleIter<'_> {
     RuleIter {
         iter: pair,
         done: false,
@@ -208,24 +203,24 @@ pub(crate) fn iter_pairs(pair: pest::iterators::Pairs<'_, Rule>) -> RuleIter<'_>
 }
 
 pub(crate) struct RuleIter<'a> {
-    iter: pest::iterators::Pairs<'a, Rule>,
+    iter: Pairs<'a, Rule>,
     // Set to true when done is called, so destructor doesn't panic
     done: bool,
 }
 
-impl<'a> From<pest::iterators::Pairs<'a, Rule>> for RuleIter<'a> {
-    fn from(iter: pest::iterators::Pairs<'a, Rule>) -> Self {
+impl<'a> From<Pairs<'a, Rule>> for RuleIter<'a> {
+    fn from(iter: Pairs<'a, Rule>) -> Self {
         RuleIter { iter, done: false }
     }
 }
 
 impl<'a> RuleIter<'a> {
-    pub(crate) fn peek(&self) -> Option<pest::iterators::Pair<'a, Rule>> {
+    pub(crate) fn peek(&self) -> Option<Pair<'a, Rule>> {
         self.iter.peek()
     }
 
     // Pop the next pair if it matches the rule. Returns None if not.
-    pub(crate) fn try_pop(&mut self, rule: Rule) -> Option<pest::iterators::Pair<'a, Rule>> {
+    pub(crate) fn try_pop(&mut self, rule: Rule) -> Option<Pair<'a, Rule>> {
         match self.peek() {
             Some(pair) if pair.as_rule() == rule => {
                 self.iter.next();
@@ -236,7 +231,7 @@ impl<'a> RuleIter<'a> {
     }
 
     // Pop the next pair, asserting it matches the given rule. Panics if not.
-    pub(crate) fn pop(&mut self, rule: Rule) -> pest::iterators::Pair<'a, Rule> {
+    pub(crate) fn pop(&mut self, rule: Rule) -> Pair<'a, Rule> {
         let pair = self.iter.next().expect("expected another pair");
         assert_eq!(
             pair.as_rule(),
@@ -307,7 +302,7 @@ impl<'a> RuleIter<'a> {
 /// This is not strictly necessary, but it's a good way to catch bugs.
 impl Drop for RuleIter<'_> {
     fn drop(&mut self) {
-        if self.done || std::thread::panicking() {
+        if self.done || thread::panicking() {
             return;
         }
         // If the iterator is not done, something probably went wrong.

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -1,3 +1,6 @@
+use std::fmt;
+
+use substrait::proto::Plan;
 use thiserror::Error;
 
 use super::MessageParseError;
@@ -17,8 +20,8 @@ impl ParseContext {
     }
 }
 
-impl std::fmt::Display for ParseContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for ParseContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "line {}: '{}'", self.line_no, self.line)
     }
 }
@@ -61,4 +64,4 @@ pub enum ParseError {
 }
 
 /// Result type for the public Parser API
-pub type ParseResult = Result<substrait::proto::Plan, ParseError>;
+pub type ParseResult = Result<Plan, ParseError>;

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -79,17 +79,17 @@ impl ParsePair for FieldReference {
     }
 }
 
+const UNSIGNED_INT_KIND: Kind = Kind::I64(I64 {
+    type_variation_reference: 0,
+    nullability: Nullability::Required as i32,
+});
+
 fn to_int_literal(value: Pair<Rule>, typ: Option<Type>) -> Result<Literal, MessageParseError> {
     assert_eq!(value.as_rule(), Rule::integer);
     let parsed_value: i64 = value.as_str().parse().unwrap();
 
-    const DEFAULT_KIND: Kind = Kind::I64(I64 {
-        type_variation_reference: 0,
-        nullability: Nullability::Required as i32,
-    });
-
     // If no type is provided, we assume i64, Nullability::Required.
-    let kind = typ.and_then(|t| t.kind).unwrap_or(DEFAULT_KIND);
+    let kind = typ.and_then(|t| t.kind).unwrap_or(UNSIGNED_INT_KIND);
 
     let (lit, nullability, tvar) = match &kind {
         // If no type is provided, we assume i64, Nullability::Required.
@@ -129,17 +129,17 @@ fn to_int_literal(value: Pair<Rule>, typ: Option<Type>) -> Result<Literal, Messa
     })
 }
 
+const UNSIGNED_FLOAT_KIND: Kind = Kind::Fp64(Fp64 {
+    type_variation_reference: 0,
+    nullability: Nullability::Required as i32,
+});
+
 fn to_float_literal(value: Pair<Rule>, typ: Option<Type>) -> Result<Literal, MessageParseError> {
     assert_eq!(value.as_rule(), Rule::float);
     let parsed_value: f64 = value.as_str().parse().unwrap();
 
-    const DEFAULT_KIND: Kind = Kind::Fp64(Fp64 {
-        type_variation_reference: 0,
-        nullability: Nullability::Required as i32,
-    });
-
     // If no type is provided, we assume fp64, Nullability::Required.
-    let kind = typ.and_then(|t| t.kind).unwrap_or(DEFAULT_KIND);
+    let kind = typ.and_then(|t| t.kind).unwrap_or(UNSIGNED_FLOAT_KIND);
 
     let (lit, nullability, tvar) = match &kind {
         Kind::Fp32(f) => (

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime};
+use pest::iterators::Pair;
 use substrait::proto::aggregate_rel::Measure;
 use substrait::proto::expression::field_reference::{ReferenceType, RootReference, RootType};
 use substrait::proto::expression::if_then::IfClause;
@@ -53,7 +54,7 @@ impl ParsePair for FieldIndex {
         "FieldIndex"
     }
 
-    fn parse_pair(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse_pair(pair: Pair<Rule>) -> Self {
         assert_eq!(pair.as_rule(), Self::rule());
         let inner = unwrap_single_pair(pair);
         let index: i32 = inner.as_str().parse().unwrap();
@@ -70,7 +71,7 @@ impl ParsePair for FieldReference {
         "FieldReference"
     }
 
-    fn parse_pair(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse_pair(pair: Pair<Rule>) -> Self {
         assert_eq!(pair.as_rule(), Self::rule());
 
         // TODO: Other types of references.
@@ -78,10 +79,7 @@ impl ParsePair for FieldReference {
     }
 }
 
-fn to_int_literal(
-    value: pest::iterators::Pair<Rule>,
-    typ: Option<Type>,
-) -> Result<Literal, MessageParseError> {
+fn to_int_literal(value: Pair<Rule>, typ: Option<Type>) -> Result<Literal, MessageParseError> {
     assert_eq!(value.as_rule(), Rule::integer);
     let parsed_value: i64 = value.as_str().parse().unwrap();
 
@@ -131,10 +129,7 @@ fn to_int_literal(
     })
 }
 
-fn to_float_literal(
-    value: pest::iterators::Pair<Rule>,
-    typ: Option<Type>,
-) -> Result<Literal, MessageParseError> {
+fn to_float_literal(value: Pair<Rule>, typ: Option<Type>) -> Result<Literal, MessageParseError> {
     assert_eq!(value.as_rule(), Rule::float);
     let parsed_value: f64 = value.as_str().parse().unwrap();
 
@@ -173,10 +168,7 @@ fn to_float_literal(
     })
 }
 
-fn to_boolean_literal(
-    value: pest::iterators::Pair<Rule>,
-    typ: Option<Type>,
-) -> Result<Literal, MessageParseError> {
+fn to_boolean_literal(value: Pair<Rule>, typ: Option<Type>) -> Result<Literal, MessageParseError> {
     assert_eq!(value.as_rule(), Rule::boolean);
     let parsed_value: bool = value.as_str().parse().unwrap();
 
@@ -202,10 +194,7 @@ fn to_boolean_literal(
     })
 }
 
-fn to_string_literal(
-    value: pest::iterators::Pair<Rule>,
-    typ: Option<Type>,
-) -> Result<Literal, MessageParseError> {
+fn to_string_literal(value: Pair<Rule>, typ: Option<Type>) -> Result<Literal, MessageParseError> {
     assert_eq!(value.as_rule(), Rule::string_literal);
     let string_value = unescape_string(value.clone());
 
@@ -319,10 +308,7 @@ fn to_string_literal(
     }
 }
 
-fn to_null_literal(
-    value: pest::iterators::Pair<Rule>,
-    typ: Option<Type>,
-) -> Result<Literal, MessageParseError> {
+fn to_null_literal(value: Pair<Rule>, typ: Option<Type>) -> Result<Literal, MessageParseError> {
     assert_eq!(value.as_rule(), Rule::null);
     let typ = typ.ok_or_else(|| {
         MessageParseError::invalid(
@@ -558,7 +544,7 @@ impl ScopedParsePair for Literal {
 
     fn parse_pair(
         extensions: &SimpleExtensions,
-        pair: pest::iterators::Pair<Rule>,
+        pair: Pair<Rule>,
     ) -> Result<Self, MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
         let mut pairs = pair.into_inner();
@@ -591,7 +577,7 @@ impl ScopedParsePair for ScalarFunction {
 
     fn parse_pair(
         extensions: &SimpleExtensions,
-        pair: pest::iterators::Pair<Rule>,
+        pair: Pair<Rule>,
     ) -> Result<Self, MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
         let span = pair.as_span();
@@ -653,7 +639,7 @@ impl ScopedParsePair for Cast {
 
     fn parse_pair(
         extensions: &SimpleExtensions,
-        pair: pest::iterators::Pair<Rule>,
+        pair: Pair<Rule>,
     ) -> Result<Self, MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
         let mut pairs = pair.into_inner();
@@ -697,7 +683,7 @@ impl ScopedParsePair for Expression {
 
     fn parse_pair(
         extensions: &SimpleExtensions,
-        pair: pest::iterators::Pair<Rule>,
+        pair: Pair<Rule>,
     ) -> Result<Self, MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
         let inner = unwrap_single_pair(pair);
@@ -744,7 +730,7 @@ impl ScopedParsePair for IfClause {
 
     fn parse_pair(
         extensions: &SimpleExtensions,
-        pair: pest::iterators::Pair<Rule>,
+        pair: Pair<Rule>,
     ) -> Result<Self, MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
         let mut pairs = pair.into_inner(); // should have 2 children, 2 expressions
@@ -773,7 +759,7 @@ impl ScopedParsePair for IfThen {
 
     fn parse_pair(
         extensions: &SimpleExtensions,
-        pair: pest::iterators::Pair<Rule>,
+        pair: Pair<Rule>,
     ) -> Result<Self, MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
 
@@ -808,7 +794,7 @@ impl ParsePair for Name {
         "Name"
     }
 
-    fn parse_pair(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse_pair(pair: Pair<Rule>) -> Self {
         assert_eq!(pair.as_rule(), Self::rule());
         let inner = unwrap_single_pair(pair);
         match inner.as_rule() {
@@ -828,7 +814,7 @@ impl ParsePair for CompoundName {
         "CompoundName"
     }
 
-    fn parse_pair(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse_pair(pair: Pair<Rule>) -> Self {
         assert_eq!(pair.as_rule(), Self::rule());
         CompoundName::new(pair.as_str())
     }
@@ -845,7 +831,7 @@ impl ScopedParsePair for Measure {
 
     fn parse_pair(
         extensions: &SimpleExtensions,
-        pair: pest::iterators::Pair<Rule>,
+        pair: Pair<Rule>,
     ) -> Result<Self, MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
 
@@ -870,12 +856,14 @@ impl ScopedParsePair for Measure {
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Debug;
+
     use pest::Parser as PestParser;
 
     use super::*;
     use crate::parser::ExpressionParser;
 
-    fn parse_exact(rule: Rule, input: &'_ str) -> pest::iterators::Pair<'_, Rule> {
+    fn parse_exact(rule: Rule, input: &'_ str) -> Pair<'_, Rule> {
         let mut pairs = ExpressionParser::parse(rule, input).unwrap();
         assert_eq!(pairs.as_str(), input);
         let pair = pairs.next().unwrap();
@@ -883,13 +871,13 @@ mod tests {
         pair
     }
 
-    fn assert_parses_to<T: ParsePair + PartialEq + std::fmt::Debug>(input: &str, expected: T) {
+    fn assert_parses_to<T: ParsePair + PartialEq + Debug>(input: &str, expected: T) {
         let pair = parse_exact(T::rule(), input);
         let actual = T::parse_pair(pair);
         assert_eq!(actual, expected);
     }
 
-    fn assert_parses_with<T: ScopedParsePair + PartialEq + std::fmt::Debug>(
+    fn assert_parses_with<T: ScopedParsePair + PartialEq + Debug>(
         ext: &SimpleExtensions,
         input: &str,
         expected: T,
@@ -1479,27 +1467,12 @@ mod tests {
     fn make_extensions_for_fn_tests() -> SimpleExtensions {
         let mut exts = SimpleExtensions::default();
         exts.add_extension_urn("urn".to_string(), 1).unwrap();
-        exts.add_extension(
-            crate::extensions::simple::ExtensionKind::Function,
-            1,
-            1,
-            "equal:any_any".to_string(),
-        )
-        .unwrap();
-        exts.add_extension(
-            crate::extensions::simple::ExtensionKind::Function,
-            1,
-            2,
-            "equal:str_str".to_string(),
-        )
-        .unwrap();
-        exts.add_extension(
-            crate::extensions::simple::ExtensionKind::Function,
-            1,
-            3,
-            "add:i64_i64".to_string(),
-        )
-        .unwrap();
+        exts.add_extension(ExtensionKind::Function, 1, 1, "equal:any_any".to_string())
+            .unwrap();
+        exts.add_extension(ExtensionKind::Function, 1, 2, "equal:str_str".to_string())
+            .unwrap();
+        exts.add_extension(ExtensionKind::Function, 1, 3, "add:i64_i64".to_string())
+            .unwrap();
         exts
     }
 
@@ -1584,7 +1557,7 @@ mod tests {
         let mut exts = SimpleExtensions::default();
         exts.add_extension_urn("urn".to_string(), 1).unwrap();
         exts.add_extension(
-            crate::extensions::simple::ExtensionKind::Function,
+            ExtensionKind::Function,
             1,
             10,
             "json_extract_path:u!json_str".to_string(),
@@ -1629,7 +1602,7 @@ mod tests {
         // Target type should be i16
         let target = result.r#type.as_ref().unwrap();
         match &target.kind {
-            Some(substrait::proto::r#type::Kind::I16(_)) => {}
+            Some(Kind::I16(_)) => {}
             other => panic!("Expected i16 type, got: {:?}", other),
         }
 
@@ -1671,7 +1644,7 @@ mod tests {
         }
 
         match &result.r#type.as_ref().unwrap().kind {
-            Some(substrait::proto::r#type::Kind::I32(_)) => {}
+            Some(Kind::I32(_)) => {}
             other => panic!("Expected i32 outer type, got: {:?}", other),
         }
     }
@@ -1741,18 +1714,13 @@ mod tests {
         let mut extensions = SimpleExtensions::default();
         extensions.add_extension_urn("urn".to_string(), 1).unwrap();
         extensions
-            .add_extension(
-                crate::extensions::simple::ExtensionKind::Type,
-                1,
-                5,
-                "u!json".to_string(),
-            )
+            .add_extension(ExtensionKind::Type, 1, 5, "u!json".to_string())
             .unwrap();
 
         let pair = parse_exact(Rule::cast_expression, "($0)::u!json");
         let result = Cast::parse_pair(&extensions, pair).unwrap();
         match result.r#type.as_ref().unwrap().kind.as_ref().unwrap() {
-            substrait::proto::r#type::Kind::UserDefined(u) => {
+            Kind::UserDefined(u) => {
                 assert_eq!(u.type_reference, 5);
             }
             other => panic!("expected UserDefined, got {other:?}"),

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -12,12 +12,15 @@ use super::{
     ErrorKind, ExpressionParser, MessageParseError, ParsePair, Rule, RuleIter, ScopedParsePair,
     unescape_string, unwrap_single_pair,
 };
+use crate::extensions::any::Any;
 use crate::extensions::simple::{self, ExtensionKind};
 use crate::extensions::{
     AddendumKind, ExtensionArgs, ExtensionColumn, ExtensionValue, InsertError, SimpleExtensions,
     TupleValue,
 };
+use crate::parser::expressions::{FieldIndex, Name};
 use crate::parser::structural::IndentedLine;
+use crate::textify::expressions::Reference;
 
 #[derive(Debug, Clone, Error)]
 pub enum ExtensionParseError {
@@ -261,10 +264,6 @@ impl SimpleExtensionDeclaration {
 
 // Extension relation parsing implementations
 // These were moved from extensions/registry.rs to maintain clean architecture
-
-use crate::extensions::any::Any;
-use crate::parser::expressions::{FieldIndex, Name};
-use crate::textify::expressions::Reference;
 
 impl ScopedParsePair for ExtensionValue {
     fn rule() -> Rule {

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -1,7 +1,11 @@
 use std::fmt;
 use std::str::FromStr;
 
-use substrait::proto::{Expression, Type};
+use pest::iterators::Pair;
+use substrait::proto::rel::RelType;
+use substrait::proto::{
+    Expression, ExtensionLeafRel, ExtensionMultiRel, ExtensionSingleRel, Rel, Type,
+};
 use thiserror::Error;
 
 use super::{
@@ -182,7 +186,7 @@ impl ParsePair for URNExtensionDeclaration {
         "URNExtensionDeclaration"
     }
 
-    fn parse_pair(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse_pair(pair: Pair<Rule>) -> Self {
         assert_eq!(pair.as_rule(), Self::rule());
 
         let mut iter = RuleIter::from(pair.into_inner());
@@ -273,7 +277,7 @@ impl ScopedParsePair for ExtensionValue {
 
     fn parse_pair(
         extensions: &SimpleExtensions,
-        pair: pest::iterators::Pair<Rule>,
+        pair: Pair<Rule>,
     ) -> Result<Self, MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
 
@@ -335,7 +339,7 @@ impl ScopedParsePair for ExtensionColumn {
 
     fn parse_pair(
         extensions: &SimpleExtensions,
-        pair: pest::iterators::Pair<Rule>,
+        pair: Pair<Rule>,
     ) -> Result<Self, MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
 
@@ -414,14 +418,7 @@ impl ExtensionRelationKind {
     }
 
     /// Create appropriate relation structure from extension detail and children.
-    pub(crate) fn create_rel(
-        self,
-        detail: Option<Any>,
-        children: Vec<substrait::proto::Rel>,
-    ) -> substrait::proto::Rel {
-        use substrait::proto::rel::RelType;
-        use substrait::proto::{ExtensionLeafRel, ExtensionMultiRel, ExtensionSingleRel};
-
+    pub(crate) fn create_rel(self, detail: Option<Any>, children: Vec<Rel>) -> Rel {
         let rel_type = match self {
             ExtensionRelationKind::Leaf => RelType::ExtensionLeaf(ExtensionLeafRel {
                 common: None,
@@ -442,7 +439,7 @@ impl ExtensionRelationKind {
             }),
         };
 
-        substrait::proto::Rel {
+        Rel {
             rel_type: Some(rel_type),
         }
     }
@@ -468,7 +465,7 @@ impl ScopedParsePair for ExtensionInvocation {
 
     fn parse_pair(
         extensions: &SimpleExtensions,
-        pair: pest::iterators::Pair<Rule>,
+        pair: Pair<Rule>,
     ) -> Result<Self, MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
 
@@ -542,7 +539,7 @@ impl ScopedParsePair for AddendumInvocation {
 
     fn parse_pair(
         extensions: &SimpleExtensions,
-        pair: pest::iterators::Pair<Rule>,
+        pair: Pair<Rule>,
     ) -> Result<Self, MessageParseError> {
         assert_eq!(pair.as_rule(), Self::rule());
 
@@ -578,7 +575,7 @@ impl ScopedParsePair for AddendumInvocation {
 
 fn arguments_rule_parsing(
     extensions: &SimpleExtensions,
-    inner_pair: pest::iterators::Pair<'_, Rule>,
+    inner_pair: Pair<'_, Rule>,
     args: &mut ExtensionArgs,
 ) -> Result<(), MessageParseError> {
     for arg in inner_pair.into_inner() {
@@ -616,8 +613,8 @@ mod tests {
     use super::*;
     use crate::extensions::{Expr, ExtensionValue};
     use crate::fixtures::TestContext;
-    use crate::parser::Parser;
     use crate::parser::common::test_support::ScopedParse;
+    use crate::parser::{ParseError, Parser};
     use crate::{OutputOptions, format};
 
     fn parse_extension_value(text: &str) -> ExtensionValue {
@@ -822,7 +819,7 @@ Root[result]
         assert!(
             matches!(
                 err,
-                crate::parser::ParseError::Extension(_, ExtensionParseError::Message(_))
+                ParseError::Extension(_, ExtensionParseError::Message(_))
             ),
             "expected parser-level MessageParseError, got: {err}"
         );
@@ -846,7 +843,7 @@ Functions:
         // Compound names must survive the roundtrip
         assert_eq!(
             extensions
-                .find_by_anchor(crate::extensions::simple::ExtensionKind::Function, 1)
+                .find_by_anchor(ExtensionKind::Function, 1)
                 .unwrap()
                 .1
                 .full(),
@@ -854,7 +851,7 @@ Functions:
         );
         assert_eq!(
             extensions
-                .find_by_anchor(crate::extensions::simple::ExtensionKind::Function, 3)
+                .find_by_anchor(ExtensionKind::Function, 3)
                 .unwrap()
                 .1
                 .full(),

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use pest::iterators::Pair;
+use pest::iterators::{Pair, Pairs};
 use prost::Message;
 use substrait::proto::aggregate_rel::Grouping;
 use substrait::proto::expression::literal::LiteralType;
@@ -286,10 +286,7 @@ pub struct ParsedNamedArgs<'a> {
 }
 
 impl<'a> ParsedNamedArgs<'a> {
-    pub fn new(
-        pairs: pest::iterators::Pairs<'a, Rule>,
-        rule: Rule,
-    ) -> Result<Self, MessageParseError> {
+    pub fn new(pairs: Pairs<'a, Rule>, rule: Rule) -> Result<Self, MessageParseError> {
         let mut map = HashMap::new();
         for pair in pairs {
             assert_eq!(pair.as_rule(), rule);
@@ -954,7 +951,7 @@ impl ScopedParsePair for SortField {
         iter.done();
         Ok(SortField {
             expr: Some(Expression {
-                rex_type: Some(substrait::proto::expression::RexType::Selection(Box::new(
+                rex_type: Some(RexType::Selection(Box::new(
                     field_index.to_field_reference(),
                 ))),
             }),
@@ -2308,7 +2305,7 @@ mod tests {
         assert!(result.is_err());
     }
 
-    fn parse_exact(rule: Rule, input: &'_ str) -> pest::iterators::Pair<'_, Rule> {
+    fn parse_exact(rule: Rule, input: &'_ str) -> Pair<'_, Rule> {
         let mut pairs = ExpressionParser::parse(rule, input).unwrap();
         assert_eq!(pairs.as_str(), input);
         let pair = pairs.next().unwrap();

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -4,9 +4,10 @@
 //! for tracking which section of the file we are currently parsing, and parsing
 //! each line separately.
 
-use std::fmt;
+use std::{fmt, mem};
 
-use pest::iterators::Pair;
+use pest::Parser as PestParser;
+use pest::iterators::{Pair, Pairs};
 use substrait::proto::extensions::AdvancedExtension;
 use substrait::proto::{
     AggregateRel, CrossRel, FetchRel, FilterRel, JoinRel, Plan, PlanRel, ProjectRel, ReadRel, Rel,
@@ -94,8 +95,8 @@ pub enum LineNode<'a> {
 
 impl<'a> LineNode<'a> {
     pub fn parse(line: &'a str, line_no: i64) -> Result<Self, ParseError> {
-        let mut pairs: pest::iterators::Pairs<'a, Rule> =
-            <ExpressionParser as pest::Parser<Rule>>::parse(Rule::planNode, line).map_err(|e| {
+        let mut pairs: Pairs<'a, Rule> =
+            <ExpressionParser as PestParser<Rule>>::parse(Rule::planNode, line).map_err(|e| {
                 ParseError::Plan(
                     ParseContext {
                         line_no,
@@ -125,10 +126,9 @@ impl<'a> LineNode<'a> {
 
     /// Parse the line as a top-level relation at depth 0 (either root_relation or regular relation)
     pub fn parse_root(line: &'a str, line_no: i64) -> Result<Self, ParseError> {
-        let mut pairs: pest::iterators::Pairs<'a, Rule> = <ExpressionParser as pest::Parser<
-            Rule,
-        >>::parse(
-            Rule::top_level_relation, line
+        let mut pairs: Pairs<'a, Rule> = <ExpressionParser as PestParser<Rule>>::parse(
+            Rule::top_level_relation,
+            line,
         )
         .map_err(|e| {
             ParseError::Plan(
@@ -289,7 +289,7 @@ impl<'a> TreeBuilder<'a> {
         if let Some(node) = self.current.take() {
             self.completed.push(node);
         }
-        std::mem::take(&mut self.completed)
+        mem::take(&mut self.completed)
     }
 }
 

--- a/src/textify/expressions.rs
+++ b/src/textify/expressions.rs
@@ -805,7 +805,7 @@ impl Textify for AggregateFunction {
 #[cfg(test)]
 mod tests {
     use substrait::proto::Type;
-    use substrait::proto::expression::{cast, if_then};
+    use substrait::proto::expression::{cast, field_reference, if_then};
     use substrait::proto::r#type::{Boolean, I16, I32, I64, Kind, Nullability, UserDefined};
 
     use super::*;
@@ -1388,8 +1388,6 @@ mod tests {
 
     #[test]
     fn test_field_reference_outer_reference_unimplemented() {
-        use substrait::proto::expression::field_reference;
-
         let ctx = TestContext::new();
         let mut fr = struct_field_reference(3);
         fr.root_type = Some(RootType::OuterReference(field_reference::OuterReference {

--- a/src/textify/foundation.rs
+++ b/src/textify/foundation.rs
@@ -1,6 +1,7 @@
 //! Foundation types for textifying a plan.
 
 use std::borrow::Cow;
+use std::error::Error as StdError;
 use std::fmt;
 use std::rc::Rc;
 use std::sync::mpsc;
@@ -194,11 +195,11 @@ impl fmt::Debug for ErrorList {
 }
 
 #[cfg(test)]
-impl std::error::Error for ErrorList {}
+impl StdError for ErrorList {}
 
 impl<'e> IntoIterator for &'e ErrorQueue {
     type Item = FormatError;
-    type IntoIter = std::sync::mpsc::TryIter<'e, FormatError>;
+    type IntoIter = mpsc::TryIter<'e, FormatError>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.receiver.try_iter()
@@ -381,7 +382,7 @@ impl fmt::Display for FormatErrorType {
     }
 }
 
-impl std::error::Error for PlanError {}
+impl StdError for PlanError {}
 
 impl fmt::Display for PlanError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -21,7 +21,7 @@ use super::values::{Arguments, NamedArg, Value, ValueEnum, decode_enum_field};
 use super::{PlanError, Scope, Textify};
 use crate::FormatError;
 use crate::extensions::any::AnyRef;
-use crate::extensions::{ExtensionArgs, ExtensionError};
+use crate::extensions::{ExtensionContext, ExtensionError, ExtensionInput};
 
 pub trait NamedRelation {
     fn name(&self) -> &'static str;
@@ -611,45 +611,61 @@ impl<'a> Relation<'a> {
     }
 
     fn from_extension_leaf<S: Scope>(rel: &'a ExtensionLeafRel, ctx: &S) -> Self {
-        let detail_ref = rel.detail.as_ref().map(AnyRef::from);
-        let decoded = match detail_ref {
-            Some(d) => ctx.extension_registry().decode(d),
-            None => Err(ExtensionError::MissingDetail),
-        };
-        Relation::from_extension("ExtensionLeaf", decoded, vec![], ctx)
+        Relation::from_extension(
+            "ExtensionLeaf",
+            rel.detail.as_ref().map(AnyRef::from),
+            vec![],
+            ctx,
+        )
     }
 
     fn from_extension_single<S: Scope>(rel: &'a ExtensionSingleRel, ctx: &S) -> Self {
-        let detail_ref = rel.detail.as_ref().map(AnyRef::from);
-        let decoded = match detail_ref {
-            Some(d) => ctx.extension_registry().decode(d),
-            None => Err(ExtensionError::MissingDetail),
-        };
-        Relation::from_extension("ExtensionSingle", decoded, vec![rel.input.as_deref()], ctx)
+        Relation::from_extension(
+            "ExtensionSingle",
+            rel.detail.as_ref().map(AnyRef::from),
+            vec![rel.input.as_deref()],
+            ctx,
+        )
     }
 
     fn from_extension_multi<S: Scope>(rel: &'a ExtensionMultiRel, ctx: &S) -> Self {
-        let detail_ref = rel.detail.as_ref().map(AnyRef::from);
-        let decoded = match detail_ref {
-            Some(d) => ctx.extension_registry().decode(d),
-            None => Err(ExtensionError::MissingDetail),
-        };
         let mut child_refs: Vec<Option<&'a Rel>> = vec![];
         for input in &rel.inputs {
             child_refs.push(Some(input));
         }
-        Relation::from_extension("ExtensionMulti", decoded, child_refs, ctx)
+        Relation::from_extension(
+            "ExtensionMulti",
+            rel.detail.as_ref().map(AnyRef::from),
+            child_refs,
+            ctx,
+        )
     }
 
     fn from_extension<S: Scope>(
         ext_type: &'static str,
-        decoded: Result<(String, ExtensionArgs), ExtensionError>,
+        detail: Option<AnyRef<'a>>,
         child_refs: Vec<Option<&'a Rel>>,
         ctx: &S,
     ) -> Self {
+        let (children, _) = Relation::convert_children(child_refs, ctx);
+        let inputs = children
+            .iter()
+            .filter_map(|child| {
+                child
+                    .as_ref()
+                    .map(|child| ExtensionInput::new(child.emitted()))
+            })
+            .collect::<Vec<_>>();
+        let context = ExtensionContext::new(&inputs);
+        let decoded = match detail {
+            Some(detail) => ctx
+                .extension_registry()
+                .decode_with_context(detail, &context),
+            None => Err(ExtensionError::MissingDetail),
+        };
+
         match decoded {
             Ok((name, args)) => {
-                let (children, _) = Relation::convert_children(child_refs, ctx);
                 let mut positional = vec![];
                 for value in args.positional {
                     positional.push(Value::ExtensionArgument(value));
@@ -661,10 +677,11 @@ impl<'a> Relation<'a> {
                         value: Value::ExtensionArgument(value),
                     });
                 }
-                let mut columns = vec![];
-                for col in args.output_columns {
-                    columns.push(Value::ExtColumn(col));
-                }
+                let columns = args
+                    .output_columns
+                    .into_iter()
+                    .map(Value::ExtColumn)
+                    .collect();
                 Relation {
                     name: Cow::Owned(format!("{}:{}", ext_type, name)),
                     arguments: Some(RelationArgs::inline(positional, named)),
@@ -678,22 +695,19 @@ impl<'a> Relation<'a> {
                     children,
                 }
             }
-            Err(error) => {
-                let (children, _) = Relation::convert_children(child_refs, ctx);
-                Relation {
-                    name: Cow::Borrowed(ext_type),
-                    arguments: None,
-                    columns: vec![Value::Missing(PlanError::invalid(
-                        "extension",
-                        None::<&str>,
-                        error.to_string(),
-                    ))],
-                    emit: None,
-                    output_syntax: OutputSyntax::Implicit,
-                    addenda: AddendumLines::none(),
-                    children,
-                }
-            }
+            Err(error) => Relation {
+                name: Cow::Borrowed(ext_type),
+                arguments: None,
+                columns: vec![Value::Missing(PlanError::invalid(
+                    "extension",
+                    None::<&str>,
+                    error.to_string(),
+                ))],
+                emit: None,
+                output_syntax: OutputSyntax::Implicit,
+                addenda: AddendumLines::none(),
+                children,
+            },
         }
     }
 

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -1119,7 +1119,8 @@ mod tests {
     use substrait::proto::rel_common::{Direct, Emit};
     use substrait::proto::r#type::{self as ptype, Boolean, I64, Kind, Nullability, Struct};
     use substrait::proto::{
-        AggregateFunction, Expression, FunctionArgument, NamedStruct, ReadRel, Type, aggregate_rel,
+        AggregateFunction, Expression, FunctionArgument, NamedStruct, ReadRel, ReferenceRel, Type,
+        aggregate_rel,
     };
 
     use super::*;
@@ -1854,8 +1855,6 @@ Cross[$0, $3]
 
     #[test]
     fn test_unsupported_rel_type_produces_failure_token() {
-        use substrait::proto::ReferenceRel;
-
         let ctx = TestContext::new();
 
         // ReferenceRel is a valid Substrait relation type that the textifier

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -4,7 +4,7 @@ use std::convert::TryFrom;
 use std::fmt;
 
 use prost::Message;
-use substrait::proto::fetch_rel::CountMode;
+use substrait::proto::fetch_rel::{CountMode, OffsetMode};
 use substrait::proto::plan_rel::RelType as PlanRelType;
 use substrait::proto::read_rel::ReadType;
 use substrait::proto::rel::RelType;
@@ -911,14 +911,14 @@ impl<'a> Relation<'a> {
         }
         if let Some(offset) = &rel.offset_mode {
             match offset {
-                substrait::proto::fetch_rel::OffsetMode::OffsetExpr(expr) => {
+                OffsetMode::OffsetExpr(expr) => {
                     named_args.push(NamedArg {
                         name: Cow::Borrowed("offset"),
                         value: Value::Expression(expr),
                     });
                 }
                 #[allow(deprecated)]
-                substrait::proto::fetch_rel::OffsetMode::Offset(val) => {
+                OffsetMode::Offset(val) => {
                     named_args.push(NamedArg {
                         name: Cow::Borrowed("offset"),
                         value: Value::Integer(*val),
@@ -1126,6 +1126,7 @@ mod tests {
     use crate::fixtures::TestContext;
     use crate::parser::expressions::FieldIndex;
     use crate::textify::expressions::Reference;
+    use crate::textify::foundation::FormatErrorType;
 
     #[test]
     fn test_read_rel() {
@@ -1879,10 +1880,7 @@ Cross[$0, $3]
         match &errors.0[0] {
             FormatError::Format(plan_err) => {
                 assert_eq!(plan_err.message, "Rel");
-                assert_eq!(
-                    plan_err.error_type,
-                    crate::textify::foundation::FormatErrorType::Unimplemented
-                );
+                assert_eq!(plan_err.error_type, FormatErrorType::Unimplemented);
                 assert!(
                     plan_err
                         .lookup

--- a/src/textify/types.rs
+++ b/src/textify/types.rs
@@ -702,7 +702,7 @@ mod tests {
     use super::*;
     use crate::extensions::simple::{ExtensionKind, MissingReference};
     use crate::fixtures::TestContext;
-    use crate::textify::foundation::FormatError;
+    use crate::textify::foundation::{ErrorQueue, FormatError};
 
     #[test]
     fn type_display() {
@@ -968,7 +968,7 @@ mod tests {
         // `add:i64_i64` is the only function with base name "add".
         // Compact mode: show base name only, no anchor (compound name unique).
         let ctx = overloaded_ctx();
-        let eq = crate::textify::ErrorQueue::default();
+        let eq = ErrorQueue::default();
         let scope = ctx.scope(&eq);
         let na = NamedAnchor::lookup(&scope, ExtensionKind::Function, 3);
         assert!(na.base_name_unique, "add should have unique base name");
@@ -984,7 +984,7 @@ mod tests {
         // Compact mode: base name not unique → show full compound name.
         // Compound name is unique (only one URN) → no anchor.
         let ctx = overloaded_ctx();
-        let eq = crate::textify::ErrorQueue::default();
+        let eq = ErrorQueue::default();
         let scope = ctx.scope(&eq);
         let na = NamedAnchor::lookup(&scope, ExtensionKind::Function, 1);
         assert!(!na.base_name_unique, "equal base name should not be unique");
@@ -1003,7 +1003,7 @@ mod tests {
         let mut ctx = overloaded_ctx();
         ctx.options.show_simple_extension_anchors = Visibility::Always;
 
-        let eq = crate::textify::ErrorQueue::default();
+        let eq = ErrorQueue::default();
         let scope = ctx.scope(&eq);
         let na = NamedAnchor::lookup(&scope, ExtensionKind::Function, 3);
         let s = ctx.textify_no_errors(&na);
@@ -1016,7 +1016,7 @@ mod tests {
         let mut ctx = overloaded_ctx();
         ctx.options.show_simple_extension_anchors = Visibility::Always;
 
-        let eq = crate::textify::ErrorQueue::default();
+        let eq = ErrorQueue::default();
         let scope = ctx.scope(&eq);
         let na = NamedAnchor::lookup(&scope, ExtensionKind::Function, 2);
         let s = ctx.textify_no_errors(&na);
@@ -1033,7 +1033,7 @@ mod tests {
             .with_function(1, 1, "equal:any_any")
             .with_function(2, 2, "equal:any_any");
 
-        let eq = crate::textify::ErrorQueue::default();
+        let eq = ErrorQueue::default();
         let scope = ctx.scope(&eq);
         let na = NamedAnchor::lookup(&scope, ExtensionKind::Function, 1);
         assert!(!na.base_name_unique);
@@ -1053,7 +1053,7 @@ mod tests {
             .with_urn(1, "urn")
             .with_function(1, 5, "count:");
 
-        let eq = crate::textify::ErrorQueue::default();
+        let eq = ErrorQueue::default();
         let scope = ctx.scope(&eq);
         let na = NamedAnchor::lookup(&scope, ExtensionKind::Function, 5);
         assert!(na.base_name_unique);
@@ -1071,7 +1071,7 @@ mod tests {
             .with_function(1, 5, "count:");
         ctx.options.show_simple_extension_anchors = Visibility::Always;
 
-        let eq = crate::textify::ErrorQueue::default();
+        let eq = ErrorQueue::default();
         let scope = ctx.scope(&eq);
         let na = NamedAnchor::lookup(&scope, ExtensionKind::Function, 5);
 
@@ -1085,7 +1085,7 @@ mod tests {
             .with_urn(1, "urn")
             .with_function(1, 10, "coalesce");
 
-        let eq = crate::textify::ErrorQueue::default();
+        let eq = ErrorQueue::default();
         let scope = ctx.scope(&eq);
         let na = NamedAnchor::lookup(&scope, ExtensionKind::Function, 10);
         assert!(na.base_name_unique);
@@ -1139,7 +1139,7 @@ mod tests {
             .with_function(1, 231, "duplicated")
             .with_function(2, 232, "duplicated");
 
-        let eq = crate::textify::ErrorQueue::default();
+        let eq = ErrorQueue::default();
         let scope = ctx.scope(&eq);
         let na = NamedAnchor::lookup(&scope, ExtensionKind::Function, 231);
         assert!(!na.base_name_unique);

--- a/src/textify/values.rs
+++ b/src/textify/values.rs
@@ -12,7 +12,7 @@ use substrait::proto::expression::field_reference::ReferenceType as FieldReferen
 use substrait::proto::expression::reference_segment::ReferenceType as SegmentReferenceType;
 use substrait::proto::sort_field::{SortDirection, SortKind};
 use substrait::proto::{
-    AggregateFunction, AggregationPhase, Expression, SortField, join_rel, set_rel,
+    AggregateFunction, AggregationPhase, Expression, SortField, Type, join_rel, set_rel,
 };
 
 use super::types::Name;
@@ -34,7 +34,7 @@ pub struct NamedArg<'a> {
 #[derive(Debug, Clone)]
 pub enum Value<'a> {
     TableName(Vec<Name<'a>>),
-    Field(Option<Name<'a>>, Option<&'a substrait::proto::Type>),
+    Field(Option<Name<'a>>, Option<&'a Type>),
     Tuple(Vec<Value<'a>>),
     Reference(i32),
     Expression(&'a Expression),

--- a/src/types_tests.rs
+++ b/src/types_tests.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Debug, Display};
+
 use substrait::proto::expression::{FieldReference, Literal, ScalarFunction};
 use substrait::proto::{Expression, Type};
 
@@ -9,7 +11,7 @@ use crate::textify::foundation::ErrorQueue;
 use crate::textify::{OutputOptions, Textify};
 
 /// Helper function to parse and check for errors, panicking if either fails
-fn must_parse<T, E: std::fmt::Display>(result: Result<T, E>, input: &str) -> T {
+fn must_parse<T, E: Display>(result: Result<T, E>, input: &str) -> T {
     let errors = ErrorQueue::default();
     let t = match result {
         Ok(t) => t,
@@ -22,21 +24,21 @@ fn must_parse<T, E: std::fmt::Display>(result: Result<T, E>, input: &str) -> T {
     t
 }
 
-fn roundtrip_parse<T: Parse + Textify + std::fmt::Debug>(ctx: &TestContext, input: &str) {
+fn roundtrip_parse<T: Parse + Textify + Debug>(ctx: &TestContext, input: &str) {
     let t = must_parse(T::parse(input), input);
 
     let actual = ctx.textify_no_errors(&t);
     assert_eq!(actual, input);
 }
 
-fn assert_roundtrip<T: ScopedParse + Textify + std::fmt::Debug>(ctx: &TestContext, input: &str) {
+fn assert_roundtrip<T: ScopedParse + Textify + Debug>(ctx: &TestContext, input: &str) {
     let t = must_parse(T::parse(&ctx.extensions, input), input);
 
     let actual = ctx.textify_no_errors(&t);
     assert_eq!(actual, input);
 }
 
-fn roundtrip_with_simple_output<T: ScopedParse + Textify + std::fmt::Debug>(
+fn roundtrip_with_simple_output<T: ScopedParse + Textify + Debug>(
     extensions: SimpleExtensions,
     verbose: &str,
     simple: &str,

--- a/tests/adv_extension_roundtrip.rs
+++ b/tests/adv_extension_roundtrip.rs
@@ -5,9 +5,11 @@
 
 mod common;
 
+use adv_ext_with_columns_fixture::EnhancementWithColumns;
 use common::parse_type;
 use substrait::proto::plan_rel;
 use substrait::proto::rel::RelType;
+use substrait::proto::rel_common::EmitKind;
 use substrait_explain::extensions::ExtensionRegistry;
 use substrait_explain::extensions::examples::{PartitionHint, PartitionStrategy};
 use substrait_explain::extensions::registry::ExtensionError;
@@ -574,10 +576,6 @@ mod extension_child_fixture {
 /// With the fix it must be `[0, 1, 2]`.
 #[test]
 fn test_project_over_extension_leaf_emit_mapping() {
-    use substrait::proto::plan_rel;
-    use substrait::proto::rel::RelType;
-    use substrait::proto::rel_common::EmitKind;
-
     let mut registry = ExtensionRegistry::new();
     registry
         .register_relation::<extension_child_fixture::TwoColumnScan>()
@@ -892,8 +890,6 @@ mod adv_ext_with_columns_fixture {
 /// `+ Enh:Name[args => col:type]`, which the addendum grammar cannot parse.
 #[test]
 fn test_adv_ext_output_columns_produces_failure_token() {
-    use adv_ext_with_columns_fixture::EnhancementWithColumns;
-
     let mut registry = ExtensionRegistry::new();
     registry
         .register_enhancement::<EnhancementWithColumns>()

--- a/tests/adv_extension_roundtrip.rs
+++ b/tests/adv_extension_roundtrip.rs
@@ -165,7 +165,9 @@ Root[result]
 /// A minimal Explainable + prost::Message used to register as an optimization.
 mod opt_fixture {
     use prost::Name;
-    use substrait_explain::extensions::{Explainable, ExtensionArgs, ExtensionError};
+    use substrait_explain::extensions::{
+        Explainable, ExtensionArgs, ExtensionContext, ExtensionError,
+    };
 
     #[derive(Clone, PartialEq, prost::Message)]
     pub struct PlanHint {
@@ -198,7 +200,10 @@ mod opt_fixture {
             Ok(PlanHint { hint })
         }
 
-        fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+        fn to_args(
+            &self,
+            _context: &ExtensionContext<'_>,
+        ) -> Result<ExtensionArgs, ExtensionError> {
             let mut args = ExtensionArgs::default();
             args.insert("hint", self.hint.clone());
             Ok(args)
@@ -520,7 +525,7 @@ Root[result]
 mod extension_child_fixture {
     use prost::Name;
     use substrait_explain::extensions::{
-        Explainable, ExtensionArgs, ExtensionColumn, ExtensionError,
+        Explainable, ExtensionArgs, ExtensionColumn, ExtensionContext, ExtensionError,
     };
 
     #[derive(Clone, PartialEq, prost::Message)]
@@ -552,7 +557,10 @@ mod extension_child_fixture {
             Ok(TwoColumnScan {})
         }
 
-        fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+        fn to_args(
+            &self,
+            _context: &ExtensionContext<'_>,
+        ) -> Result<ExtensionArgs, ExtensionError> {
             let mut args = ExtensionArgs::default();
             args.output_columns.push(ExtensionColumn::Named {
                 name: "col0".to_owned(),
@@ -844,7 +852,7 @@ Root[result]
 mod adv_ext_with_columns_fixture {
     use prost::Name;
     use substrait_explain::extensions::{
-        Explainable, ExtensionArgs, ExtensionColumn, ExtensionError,
+        Explainable, ExtensionArgs, ExtensionColumn, ExtensionContext, ExtensionError,
     };
 
     #[derive(Clone, PartialEq, prost::Message)]
@@ -874,7 +882,10 @@ mod adv_ext_with_columns_fixture {
             Ok(EnhancementWithColumns {})
         }
 
-        fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+        fn to_args(
+            &self,
+            _context: &ExtensionContext<'_>,
+        ) -> Result<ExtensionArgs, ExtensionError> {
             let mut args = ExtensionArgs::default();
             // Deliberately populate output_columns - the addendum grammar
             // has no "=> columns" clause, so this cannot be round-tripped.

--- a/tests/adv_extension_roundtrip.rs
+++ b/tests/adv_extension_roundtrip.rs
@@ -578,7 +578,7 @@ fn test_project_over_extension_leaf_emit_mapping() {
     use substrait::proto::rel::RelType;
     use substrait::proto::rel_common::EmitKind;
 
-    let mut registry = substrait_explain::extensions::ExtensionRegistry::new();
+    let mut registry = ExtensionRegistry::new();
     registry
         .register_relation::<extension_child_fixture::TwoColumnScan>()
         .expect("register_relation");

--- a/tests/extension_roundtrip.rs
+++ b/tests/extension_roundtrip.rs
@@ -136,50 +136,50 @@ Root[result]
     assert!(result.is_err());
 }
 
+// An additional type of config, for variety
+#[derive(Clone, PartialEq, Message)]
+pub struct FilterConfig {
+    #[prost(string, tag = "1")]
+    pub expression: String,
+}
+
+impl Name for FilterConfig {
+    const NAME: &'static str = "FilterConfig";
+    const PACKAGE: &'static str = "test";
+
+    fn full_name() -> String {
+        "test.FilterConfig".to_string()
+    }
+
+    fn type_url() -> String {
+        "type.googleapis.com/test.FilterConfig".to_string()
+    }
+}
+
+impl Explainable for FilterConfig {
+    fn name() -> &'static str {
+        "TestFilter"
+    }
+
+    fn from_args(args: &ExtensionArgs) -> Result<Self, ExtensionError> {
+        let mut extractor = args.extractor();
+        let expression: String = extractor.expect_named_arg::<&str>("expr")?.to_string();
+        extractor.check_exhausted()?;
+
+        Ok(FilterConfig { expression })
+    }
+
+    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+        let mut args = ExtensionArgs::default();
+        args.insert("expr", self.expression.clone());
+        Ok(args)
+    }
+}
+
 #[test]
 fn test_multiple_extensions_in_plan() {
     let mut registry = ExtensionRegistry::new();
     registry.register_relation::<UserTableConfig>().unwrap();
-
-    // Also register a second type for variety
-    #[derive(Clone, PartialEq, Message)]
-    pub struct FilterConfig {
-        #[prost(string, tag = "1")]
-        pub expression: String,
-    }
-
-    impl Name for FilterConfig {
-        const NAME: &'static str = "FilterConfig";
-        const PACKAGE: &'static str = "test";
-
-        fn full_name() -> String {
-            "test.FilterConfig".to_string()
-        }
-
-        fn type_url() -> String {
-            "type.googleapis.com/test.FilterConfig".to_string()
-        }
-    }
-
-    impl Explainable for FilterConfig {
-        fn name() -> &'static str {
-            "TestFilter"
-        }
-
-        fn from_args(args: &ExtensionArgs) -> Result<Self, ExtensionError> {
-            let mut extractor = args.extractor();
-            let expression: String = extractor.expect_named_arg::<&str>("expr")?.to_string();
-            extractor.check_exhausted()?;
-
-            Ok(FilterConfig { expression })
-        }
-
-        fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-            let mut args = ExtensionArgs::default();
-            args.insert("expr", self.expression.clone());
-            Ok(args)
-        }
-    }
 
     registry.register_relation::<FilterConfig>().unwrap();
 

--- a/tests/extension_roundtrip.rs
+++ b/tests/extension_roundtrip.rs
@@ -10,7 +10,7 @@ use substrait::proto::expression::literal::LiteralType;
 use substrait::proto::r#type::Nullability;
 use substrait_explain::extensions::examples::PartitionHint;
 use substrait_explain::extensions::{
-    EnumValue, Explainable, Expr, ExtensionArgs, ExtensionColumn, ExtensionError,
+    EnumValue, Explainable, Expr, ExtensionArgs, ExtensionColumn, ExtensionContext, ExtensionError,
     ExtensionProtoConvert, ExtensionRegistry, ExtensionValue, TupleValue,
 };
 use substrait_explain::{Parser, format_with_registry};
@@ -80,7 +80,7 @@ impl Explainable for UserTableConfig {
         })
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
 
         // Add named arguments
@@ -174,7 +174,10 @@ fn test_multiple_extensions_in_plan() {
             Ok(FilterConfig { expression })
         }
 
-        fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+        fn to_args(
+            &self,
+            _context: &ExtensionContext<'_>,
+        ) -> Result<ExtensionArgs, ExtensionError> {
             let mut args = ExtensionArgs::default();
             args.insert("expr", self.expression.clone());
             Ok(args)
@@ -264,7 +267,7 @@ impl Explainable for LiteralConfig {
         })
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
         args.insert("path", self.path.clone());
         args.insert("big", self.big);
@@ -352,7 +355,7 @@ impl Explainable for EmptySource {
         })
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         Ok(ExtensionArgs::default())
     }
 }
@@ -405,9 +408,7 @@ Root[result]
 // ExtensionSingle and ExtensionMulti fixtures
 // ---------------------------------------------------------------------------
 
-/// A minimal ExtensionSingle: no arguments, passes through its single input
-/// column unchanged.  The `_ => $0` syntax uses the empty-args placeholder
-/// and a reference-style output column.
+/// A minimal ExtensionSingle that derives its output from its input fields.
 #[derive(Clone, PartialEq, Message)]
 pub struct PassThroughWrapper {}
 
@@ -433,9 +434,14 @@ impl Explainable for PassThroughWrapper {
         Ok(PassThroughWrapper {})
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
-        args.output_columns.push(ExtensionColumn::field(0));
+        let input = context.inputs().first().ok_or_else(|| {
+            ExtensionError::InvalidArgument("PassThrough expects one input".to_owned())
+        })?;
+        args.output_columns.extend(
+            (0..input.emitted_column_count()).map(|index| ExtensionColumn::field(index as i32)),
+        );
         Ok(args)
     }
 }
@@ -467,7 +473,7 @@ impl Explainable for BinaryMerge {
         Ok(BinaryMerge {})
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
         args.output_columns.push(ExtensionColumn::field(0));
         args.output_columns.push(ExtensionColumn::field(1));
@@ -485,9 +491,28 @@ fn test_extension_single_over_read_roundtrip() {
     registry.register_relation::<PassThroughWrapper>().unwrap();
 
     let plan_text = r#"=== Plan
-Root[col]
-  ExtensionSingle:PassThrough[_ => $0]
-    Read[my.table => col:i64]"#;
+Root[a, b, c, d]
+  ExtensionSingle:PassThrough[_ => $0, $1, $2, $3]
+    Read[my.table => a:i64, b:i64, c:i64, d:i64]"#;
+
+    let parser = Parser::new().with_extension_registry(registry.clone());
+    let plan = parser.parse_plan(plan_text).expect("parse failed");
+
+    let (formatted, errors) = format_with_registry(&plan, &Default::default(), &registry);
+    assert!(errors.is_empty(), "unexpected format errors: {errors:?}");
+    assert_eq!(formatted.trim(), plan_text.trim());
+}
+
+#[test]
+fn test_extension_single_input_output_uses_emitted_child_width() {
+    let mut registry = ExtensionRegistry::new();
+    registry.register_relation::<PassThroughWrapper>().unwrap();
+
+    let plan_text = r#"=== Plan
+Root[a, d]
+  ExtensionSingle:PassThrough[_ => $0, $1]
+    Project[$0, $3]
+      Read[my.table => a:i64, b:i64, c:i64, d:i64]"#;
 
     let parser = Parser::new().with_extension_registry(registry.clone());
     let plan = parser.parse_plan(plan_text).expect("parse failed");
@@ -632,7 +657,7 @@ impl Explainable for TupleSortHint {
         Ok(TupleSortHint { directions })
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
         let tv: TupleValue = self
             .directions

--- a/tests/extension_table.rs
+++ b/tests/extension_table.rs
@@ -4,7 +4,7 @@ mod common;
 
 use prost::{Message, Name};
 use substrait_explain::extensions::{
-    Explainable, ExtensionArgs, ExtensionError, ExtensionRegistry, examples,
+    Explainable, ExtensionArgs, ExtensionContext, ExtensionError, ExtensionRegistry, examples,
 };
 use substrait_explain::{Parser, format_with_registry};
 
@@ -43,7 +43,7 @@ impl Explainable for UserTable {
         })
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
         args.insert("name", self.name.clone());
         Ok(args)

--- a/tests/json_parsing.rs
+++ b/tests/json_parsing.rs
@@ -5,6 +5,8 @@
 //! and the compiled descriptor binary are all generated at build time by
 //! `build.rs` using protox and prost-build.
 
+use std::io::Cursor;
+
 use substrait::proto;
 use substrait_explain::cli::{Cli, Commands, Format};
 use substrait_explain::extensions::{
@@ -79,7 +81,7 @@ fn build_registry() -> ExtensionRegistry {
     r
 }
 
-fn format_plan(plan: &substrait::proto::Plan) -> String {
+fn format_plan(plan: &proto::Plan) -> String {
     let registry = build_registry();
     let (text, errors) = format_with_registry(plan, &OutputOptions::default(), &registry);
     assert!(
@@ -203,7 +205,7 @@ fn test_cli_parses_rustjson() {
     let registry = build_registry();
     let mut output = Vec::new();
 
-    cli.run_with_io(std::io::Cursor::new(PLAN_PBJSON), &mut output, &registry)
+    cli.run_with_io(Cursor::new(PLAN_PBJSON), &mut output, &registry)
         .expect("CLI failed to parse pbjson");
 
     let result = String::from_utf8(output).unwrap();
@@ -220,7 +222,7 @@ fn test_cli_parses_gojson() {
     let registry = build_registry();
     let mut output = Vec::new();
 
-    cli.run_with_io(std::io::Cursor::new(PLAN_PROTOJSON), &mut output, &registry)
+    cli.run_with_io(Cursor::new(PLAN_PROTOJSON), &mut output, &registry)
         .expect("CLI failed to parse go protojson");
 
     let result = String::from_utf8(output).unwrap();
@@ -261,7 +263,7 @@ fn test_cli_parses_standard_plan_json() {
     let mut output = Vec::new();
 
     cli.run_with_io(
-        std::io::Cursor::new(standard_json),
+        Cursor::new(standard_json),
         &mut output,
         &ExtensionRegistry::default(),
     )

--- a/tests/json_parsing.rs
+++ b/tests/json_parsing.rs
@@ -13,8 +13,16 @@ use substrait_explain::extensions::{
 use substrait_explain::json::{build_descriptor_pool, parse_json};
 use substrait_explain::{OutputOptions, Parser, format_with_registry};
 
-// ParquetScanConfig struct + impl prost::Name — generated from parquet_scan.proto by build.rs.
-include!(concat!(env!("OUT_DIR"), "/example.rs"));
+mod example_protos {
+    #![allow(
+        clippy::absolute_paths,
+        reason = "prost-build generates fully qualified paths"
+    )]
+
+    include!(concat!(env!("OUT_DIR"), "/example.rs"));
+}
+
+use example_protos::ParquetScanConfig;
 
 // Compiled FileDescriptorSet for ParquetScanConfig, written to OUT_DIR by build.rs.
 // Passed to build_descriptor_pool so prost-reflect can resolve the type URL when

--- a/tests/json_parsing.rs
+++ b/tests/json_parsing.rs
@@ -8,7 +8,8 @@
 use substrait::proto;
 use substrait_explain::cli::{Cli, Commands, Format};
 use substrait_explain::extensions::{
-    Explainable, ExtensionArgs, ExtensionColumn, ExtensionError, ExtensionRegistry,
+    Explainable, ExtensionArgs, ExtensionColumn, ExtensionContext, ExtensionError,
+    ExtensionRegistry,
 };
 use substrait_explain::json::{build_descriptor_pool, parse_json};
 use substrait_explain::{OutputOptions, Parser, format_with_registry};
@@ -38,7 +39,7 @@ impl Explainable for ParquetScanConfig {
         })
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
         args.insert("path", self.path.clone());
         args.insert("batch_size", self.batch_size);

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -669,8 +669,6 @@ Root[result]
 
 #[test]
 fn test_malformed_input_error_handling() {
-    use substrait_explain::Parser;
-
     // Test malformed input: unclosed bracket in extension relation
     let malformed_plan = r#"=== Plan
 Root[result]


### PR DESCRIPTION
## Description

Enabled a couple more Clippy lints and updated code to address them.

In particular, added the `absolute_paths` lint, which warns for things like `foo:bar::baz::fizzbuzz(y)`, suggesting an import of either `baz` or `fizzbuzz` so that qualified paths are shorter.

## Commits

This is perhaps easiest reviewed by commit / commit-grouping.

- The first commit enables the lints
- the second adds the exception for generated code
- the last three commits apply the style changes

## Changes

- Enable `clippy::absolute_paths` and `clippy::items_after_statements` individually in `Cargo.toml` rather than enabling the full restriction lint group.
- Followed through in code:
  - Shorten absolute paths across the library, CLI, tests, and examples.
  - Move function-local imports and declarations to their module scope.
  - Add an exception for generated code module