### PR TITLE
feat(extensions)!: Add context to to_args in Explainable trait

### DIFF
--- a/API.md
+++ b/API.md
@@ -139,6 +139,9 @@ syntax around those arguments:
 - `name()` - The extension name used in text (e.g., `"ParquetScan"`)
 - `from_args(args)` - Parse text arguments into your type
 - `to_args(&self)` - Convert your type to text arguments
+- `to_args_with_context(context)` - Optionally use information about relation
+  inputs when constructing extension arguments. Its default implementation
+  delegates to `to_args()`.
 
 The extension API works across three representations:
 
@@ -157,6 +160,12 @@ represented as expression values.
 `ExtensionProtoConvert` converts between extension arguments and Substrait
 protobuf values in either direction, such as output columns and relation
 `NamedStruct`s.
+
+Relation extensions receive an `ExtensionContext` containing one
+`ExtensionInput` per available child, in relation order. Each input exposes its
+emitted column count, including any output mapping applied by that child. Other
+extension namespaces receive an empty input slice. Existing implementations do
+not need to implement this method because its default calls `to_args()`.
 
 Use `ArgsExtractor` for convenient argument parsing:
 

--- a/API.md
+++ b/API.md
@@ -138,10 +138,8 @@ syntax around those arguments:
 
 - `name()` - The extension name used in text (e.g., `"ParquetScan"`)
 - `from_args(args)` - Parse text arguments into your type
-- `to_args(&self)` - Convert your type to text arguments
-- `to_args_with_context(context)` - Optionally use information about relation
-  inputs when constructing extension arguments. Its default implementation
-  delegates to `to_args()`.
+- `to_args(&self, context)` - Convert your type to text arguments, optionally
+  using information about relation inputs.
 
 The extension API works across three representations:
 
@@ -161,11 +159,10 @@ represented as expression values.
 protobuf values in either direction, such as output columns and relation
 `NamedStruct`s.
 
-Relation extensions receive an `ExtensionContext` containing one
+The `to_args` method receives an `ExtensionContext`. Relation extensions get one
 `ExtensionInput` per available child, in relation order. Each input exposes its
 emitted column count, including any output mapping applied by that child. Other
-extension namespaces receive an empty input slice. Existing implementations do
-not need to implement this method because its default calls `to_args()`.
+extension namespaces receive an empty input slice.
 
 Use `ArgsExtractor` for convenient argument parsing:
 
@@ -192,7 +189,7 @@ Register extensions to the appropriate namespace:
 ```rust,no_run
 # use prost::{Message, Name};
 # use substrait_explain::extensions::{
-#     Explainable, ExtensionArgs, ExtensionError, ExtensionRegistry,
+#     Explainable, ExtensionArgs, ExtensionContext, ExtensionError, ExtensionRegistry,
 # };
 #[derive(Clone, PartialEq, Message)]
 pub struct MySourceConfig {
@@ -208,7 +205,10 @@ impl Name for MySourceConfig {
 # impl Explainable for MySourceConfig {
 #     fn name() -> &'static str { "MySource" }
 #     fn from_args(_: &ExtensionArgs) -> Result<Self, ExtensionError> { Ok(Self::default()) }
-#     fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+#     fn to_args(
+#         &self,
+#         _context: &ExtensionContext<'_>,
+#     ) -> Result<ExtensionArgs, ExtensionError> {
 #         Ok(ExtensionArgs::default())
 #     }
 # }

--- a/examples/extensions.rs
+++ b/examples/extensions.rs
@@ -15,7 +15,8 @@ use prost::{Message, Name};
 use substrait::proto::{self, plan_rel, rel};
 use substrait_explain::extensions::any::AnyRef;
 use substrait_explain::extensions::{
-    AnyConvertible, Explainable, ExtensionArgs, ExtensionColumn, ExtensionError, ExtensionRegistry,
+    AnyConvertible, Explainable, ExtensionArgs, ExtensionColumn, ExtensionContext, ExtensionError,
+    ExtensionRegistry,
 };
 use substrait_explain::{OutputOptions, Parser, format_with_registry};
 
@@ -102,7 +103,7 @@ impl Explainable for ParquetScanConfig {
         })
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
 
         // Add named arguments from the message

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -478,7 +478,9 @@ mod tests {
     use substrait::proto::rel::RelType;
 
     use super::*;
-    use crate::extensions::{Explainable, ExtensionArgs, ExtensionColumn, ExtensionError};
+    use crate::extensions::{
+        Explainable, ExtensionArgs, ExtensionColumn, ExtensionContext, ExtensionError,
+    };
     use crate::fixtures::parse_type;
     use crate::parse;
 
@@ -913,7 +915,10 @@ Root[result]
             })
         }
 
-        fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+        fn to_args(
+            &self,
+            _context: &ExtensionContext<'_>,
+        ) -> Result<ExtensionArgs, ExtensionError> {
             let mut args = ExtensionArgs::default();
             args.insert("tag", self.tag.clone());
             args.output_columns.push(ExtensionColumn::Named {

--- a/src/extensions/examples.rs
+++ b/src/extensions/examples.rs
@@ -16,7 +16,9 @@
 //! integration tests, not a stable extension API.
 
 use crate::extensions::args::{EnumValue, ExtensionArgs, ExtensionValue};
-use crate::extensions::registry::{Explainable, ExtensionError, ExtensionRegistry};
+use crate::extensions::registry::{
+    Explainable, ExtensionContext, ExtensionError, ExtensionRegistry,
+};
 
 // ---------------------------------------------------------------------------
 // PartitionStrategy enum
@@ -147,7 +149,7 @@ impl Explainable for PartitionHint {
         })
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
         for &raw in &self.strategies {
             let s = PartitionStrategy::try_from(raw).unwrap_or(PartitionStrategy::Unspecified);
@@ -230,7 +232,7 @@ impl Explainable for PlanHint {
         Ok(PlanHint { hint })
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
         args.named
             .insert("hint".to_owned(), ExtensionValue::String(self.hint.clone()));
@@ -327,7 +329,7 @@ impl Explainable for BlobStoreRead {
         })
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
         args.positional
             .push(ExtensionValue::String(self.path.clone()));
@@ -381,7 +383,7 @@ mod tests {
     #[test]
     fn to_args_produces_enum_and_named() {
         let hint = make_hint(vec![PartitionStrategy::Hash], 8);
-        let args = hint.to_args().unwrap();
+        let args = hint.to_args(&ExtensionContext::default()).unwrap();
         assert_eq!(args.positional.len(), 1);
         assert!(matches!(&args.positional[0], ExtensionValue::Enum(s) if s == "HASH"));
         let count = args.named.get("count").expect("count arg");
@@ -391,14 +393,14 @@ mod tests {
     #[test]
     fn to_args_omits_zero_count() {
         let hint = make_hint(vec![PartitionStrategy::Broadcast], 0);
-        let args = hint.to_args().unwrap();
+        let args = hint.to_args(&ExtensionContext::default()).unwrap();
         assert!(args.named.is_empty(), "count=0 should be omitted");
     }
 
     #[test]
     fn from_args_round_trip() {
         let original = make_hint(vec![PartitionStrategy::Hash, PartitionStrategy::Range], 16);
-        let args = original.to_args().unwrap();
+        let args = original.to_args(&ExtensionContext::default()).unwrap();
         let decoded = PartitionHint::from_args(&args).unwrap();
         assert_eq!(original, decoded);
     }
@@ -438,7 +440,7 @@ mod tests {
     #[test]
     fn from_args_empty_strategies_roundtrip() {
         let original = make_hint(vec![], 0);
-        let args = original.to_args().unwrap();
+        let args = original.to_args(&ExtensionContext::default()).unwrap();
         let decoded = PartitionHint::from_args(&args).unwrap();
         assert_eq!(original, decoded);
         assert!(decoded.strategies.is_empty());
@@ -470,7 +472,7 @@ mod tests {
         let original = PlanHint {
             hint: "use_index".to_owned(),
         };
-        let args = original.to_args().unwrap();
+        let args = original.to_args(&ExtensionContext::default()).unwrap();
         let decoded = PlanHint::from_args(&args).unwrap();
         assert_eq!(original, decoded);
     }
@@ -504,7 +506,7 @@ mod tests {
             include_archived: true,
         };
 
-        let args = original.to_args().unwrap();
+        let args = original.to_args(&ExtensionContext::default()).unwrap();
         let decoded = BlobStoreRead::from_args(&args).unwrap();
 
         assert_eq!(original, decoded);

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -22,7 +22,7 @@ pub use args::{
     EnumValue, Expr, ExtensionArgs, ExtensionColumn, ExtensionValue, ExtensionValueKind, TupleValue,
 };
 pub use registry::{
-    AnyConvertible, Explainable, Extension, ExtensionError, ExtensionProtoConvert,
-    ExtensionRegistry, ExtensionType, RegistrationError,
+    AnyConvertible, Explainable, Extension, ExtensionContext, ExtensionError, ExtensionInput,
+    ExtensionProtoConvert, ExtensionRegistry, ExtensionType, RegistrationError,
 };
 pub use simple::{InsertError, SimpleExtension, SimpleExtensions};

--- a/src/extensions/registry.rs
+++ b/src/extensions/registry.rs
@@ -26,7 +26,8 @@
 //!
 //! ```rust
 //! use substrait_explain::extensions::{
-//!     Any, AnyConvertible, AnyRef, Explainable, ExtensionArgs, ExtensionError, ExtensionRegistry,
+//!     Any, AnyConvertible, AnyRef, Explainable, ExtensionArgs, ExtensionContext, ExtensionError,
+//!     ExtensionRegistry,
 //! };
 //!
 //! // Define a custom extension type
@@ -68,7 +69,10 @@
 //!         })
 //!     }
 //!
-//!     fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+//!     fn to_args(
+//!         &self,
+//!         _context: &ExtensionContext<'_>,
+//!     ) -> Result<ExtensionArgs, ExtensionError> {
 //!         let mut args = ExtensionArgs::default();
 //!         args.insert("path", self.path.clone());
 //!         Ok(args)
@@ -324,21 +328,7 @@ pub trait Explainable: Sized {
     fn from_args(args: &ExtensionArgs) -> Result<Self, ExtensionError>;
 
     /// Convert this type to extension arguments
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError>;
-
-    /// Convert this type to extension arguments with information about its inputs.
-    ///
-    /// The default delegates to [`Explainable::to_args()`], preserving the
-    /// behavior of existing implementations. Relation extensions receive
-    /// their inputs in relation order; other extension namespaces receive an
-    /// empty input slice.
-    fn to_args_with_context(
-        &self,
-        context: &ExtensionContext<'_>,
-    ) -> Result<ExtensionArgs, ExtensionError> {
-        let _ = context;
-        self.to_args()
-    }
+    fn to_args(&self, context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError>;
 }
 
 /// Internal trait that converts between ExtensionArgs and protobuf Any messages.
@@ -393,7 +383,7 @@ impl<T: AnyConvertible + Explainable + Send + Sync> ExtensionConverter for Exten
         context: &ExtensionContext<'_>,
     ) -> Result<ExtensionArgs, ExtensionError> {
         let owned_any = Any::new(detail.type_url.to_string(), detail.value.to_vec());
-        T::from_any(owned_any.as_ref())?.to_args_with_context(context)
+        T::from_any(owned_any.as_ref())?.to_args(context)
     }
 }
 
@@ -783,18 +773,10 @@ mod tests {
             })
         }
 
-        fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+        fn to_args(&self, context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
             let mut args = ExtensionArgs::default();
             args.insert("path", self.path.clone());
             args.insert("batch_size", self.batch_size);
-            Ok(args)
-        }
-
-        fn to_args_with_context(
-            &self,
-            context: &ExtensionContext<'_>,
-        ) -> Result<ExtensionArgs, ExtensionError> {
-            let mut args = self.to_args()?;
             if !context.inputs().is_empty() {
                 args.insert("input_count", context.inputs().len() as i64);
             }
@@ -993,7 +975,10 @@ mod tests {
             Ok(TestEnhancement { hint })
         }
 
-        fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+        fn to_args(
+            &self,
+            _context: &ExtensionContext<'_>,
+        ) -> Result<ExtensionArgs, ExtensionError> {
             let mut args = ExtensionArgs::default();
             args.insert("hint", self.hint.clone());
             Ok(args)
@@ -1130,7 +1115,10 @@ mod tests {
             Ok(ConflictingExtension)
         }
 
-        fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+        fn to_args(
+            &self,
+            _context: &ExtensionContext<'_>,
+        ) -> Result<ExtensionArgs, ExtensionError> {
             Ok(ExtensionArgs::default())
         }
     }

--- a/src/extensions/registry.rs
+++ b/src/extensions/registry.rs
@@ -104,6 +104,46 @@ pub enum ExtensionType {
     Optimization,
 }
 
+/// Information about one input to an extension relation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExtensionInput {
+    emitted_column_count: usize,
+}
+
+impl ExtensionInput {
+    pub(crate) fn new(emitted_column_count: usize) -> Self {
+        Self {
+            emitted_column_count,
+        }
+    }
+
+    /// Number of columns emitted by this input after applying its output mapping.
+    pub fn emitted_column_count(&self) -> usize {
+        self.emitted_column_count
+    }
+}
+
+/// Context available while converting an extension payload to text arguments.
+///
+/// Relation extensions receive one entry per available input, in relation
+/// order. Other extension namespaces, and context-free registry decoding,
+/// receive an empty input slice.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ExtensionContext<'a> {
+    inputs: &'a [ExtensionInput],
+}
+
+impl<'a> ExtensionContext<'a> {
+    pub(crate) fn new(inputs: &'a [ExtensionInput]) -> Self {
+        Self { inputs }
+    }
+
+    /// Inputs to the extension relation, in relation order.
+    pub fn inputs(&self) -> &'a [ExtensionInput] {
+        self.inputs
+    }
+}
+
 /// Errors during extension registration (setup phase)
 #[derive(Debug, Error, Clone)]
 pub enum RegistrationError {
@@ -285,6 +325,20 @@ pub trait Explainable: Sized {
 
     /// Convert this type to extension arguments
     fn to_args(&self) -> Result<ExtensionArgs, ExtensionError>;
+
+    /// Convert this type to extension arguments with information about its inputs.
+    ///
+    /// The default delegates to [`Explainable::to_args()`], preserving the
+    /// behavior of existing implementations. Relation extensions receive
+    /// their inputs in relation order; other extension namespaces receive an
+    /// empty input slice.
+    fn to_args_with_context(
+        &self,
+        context: &ExtensionContext<'_>,
+    ) -> Result<ExtensionArgs, ExtensionError> {
+        let _ = context;
+        self.to_args()
+    }
 }
 
 /// Internal trait that converts between ExtensionArgs and protobuf Any messages.
@@ -303,7 +357,11 @@ pub trait Explainable: Sized {
 trait ExtensionConverter: Send + Sync {
     fn parse_detail(&self, args: &ExtensionArgs) -> Result<Any, ExtensionError>;
 
-    fn textify_detail(&self, detail: AnyRef<'_>) -> Result<ExtensionArgs, ExtensionError>;
+    fn textify_detail(
+        &self,
+        detail: AnyRef<'_>,
+        context: &ExtensionContext<'_>,
+    ) -> Result<ExtensionArgs, ExtensionError>;
 }
 
 /// Type adapter that implements ExtensionConverter for any type T that implements
@@ -329,9 +387,13 @@ impl<T: AnyConvertible + Explainable + Send + Sync> ExtensionConverter for Exten
         T::from_args(args)?.to_any()
     }
 
-    fn textify_detail(&self, detail: AnyRef<'_>) -> Result<ExtensionArgs, ExtensionError> {
+    fn textify_detail(
+        &self,
+        detail: AnyRef<'_>,
+        context: &ExtensionContext<'_>,
+    ) -> Result<ExtensionArgs, ExtensionError> {
         let owned_any = Any::new(detail.type_url.to_string(), detail.value.to_vec());
-        T::from_any(owned_any.as_ref())?.to_args()
+        T::from_any(owned_any.as_ref())?.to_args_with_context(context)
     }
 }
 
@@ -536,6 +598,15 @@ impl ExtensionRegistry {
         self.decode_with_type(ExtensionType::Relation, detail)
     }
 
+    /// Decode relation extension detail using information about its inputs.
+    pub(crate) fn decode_with_context(
+        &self,
+        detail: AnyRef<'_>,
+        context: &ExtensionContext<'_>,
+    ) -> Result<(String, ExtensionArgs), ExtensionError> {
+        self.decode_with_type_and_context(ExtensionType::Relation, detail, context)
+    }
+
     /// Decode ExtensionTable detail to extension name and ExtensionArgs
     ///
     /// This is the primary method for textification of ExtensionTable reads -
@@ -582,6 +653,15 @@ impl ExtensionRegistry {
         ext_type: ExtensionType,
         detail: AnyRef<'_>,
     ) -> Result<(String, ExtensionArgs), ExtensionError> {
+        self.decode_with_type_and_context(ext_type, detail, &ExtensionContext::default())
+    }
+
+    fn decode_with_type_and_context(
+        &self,
+        ext_type: ExtensionType,
+        detail: AnyRef<'_>,
+        context: &ExtensionContext<'_>,
+    ) -> Result<(String, ExtensionArgs), ExtensionError> {
         // Find extension name by type URL in the specified namespace
         let type_url_key = (ext_type, detail.type_url.to_string());
         let extension_name =
@@ -600,7 +680,7 @@ impl ExtensionRegistry {
                 name: extension_name.clone(),
             })?;
 
-        let args = handler.textify_detail(detail)?;
+        let args = handler.textify_detail(detail, context)?;
 
         Ok((extension_name.clone(), args))
     }
@@ -709,6 +789,17 @@ mod tests {
             args.insert("batch_size", self.batch_size);
             Ok(args)
         }
+
+        fn to_args_with_context(
+            &self,
+            context: &ExtensionContext<'_>,
+        ) -> Result<ExtensionArgs, ExtensionError> {
+            let mut args = self.to_args()?;
+            if !context.inputs().is_empty() {
+                args.insert("input_count", context.inputs().len() as i64);
+            }
+            Ok(args)
+        }
     }
 
     #[test]
@@ -747,6 +838,28 @@ mod tests {
             <&str>::try_from(result.1.named.get("path").unwrap()).unwrap(),
             "test.parquet"
         );
+        assert!(!result.1.named.contains_key("input_count"));
+    }
+
+    #[test]
+    fn test_extension_registry_decode_with_context() {
+        let mut registry = ExtensionRegistry::new();
+        registry.register_relation::<TestExtension>().unwrap();
+
+        let mut args = ExtensionArgs::default();
+        args.insert("path", "data.parquet");
+        args.insert("batch_size", 2048_i64);
+        let any = registry.parse_extension("TestExtension", &args).unwrap();
+        let inputs = [ExtensionInput::new(4)];
+        let context = ExtensionContext::new(&inputs);
+
+        let (_, decoded_args) = registry
+            .decode_with_context(any.as_ref(), &context)
+            .unwrap();
+        assert_eq!(
+            i64::try_from(decoded_args.named.get("input_count").unwrap()).unwrap(),
+            1
+        );
     }
 
     #[test]
@@ -778,6 +891,7 @@ mod tests {
             <&str>::try_from(decoded_args.named.get("path").unwrap()).unwrap(),
             "test.parquet"
         );
+        assert!(!decoded_args.named.contains_key("input_count"));
     }
 
     #[test]

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -21,7 +21,7 @@ use super::values::{Arguments, NamedArg, Value, ValueEnum, decode_enum_field};
 use super::{PlanError, Scope, Textify};
 use crate::FormatError;
 use crate::extensions::any::AnyRef;
-use crate::extensions::{ExtensionArgs, ExtensionError};
+use crate::extensions::{ExtensionContext, ExtensionError, ExtensionInput};
 
 pub trait NamedRelation {
     fn name(&self) -> &'static str;
@@ -611,45 +611,61 @@ impl<'a> Relation<'a> {
     }
 
     fn from_extension_leaf<S: Scope>(rel: &'a ExtensionLeafRel, ctx: &S) -> Self {
-        let detail_ref = rel.detail.as_ref().map(AnyRef::from);
-        let decoded = match detail_ref {
-            Some(d) => ctx.extension_registry().decode(d),
-            None => Err(ExtensionError::MissingDetail),
-        };
-        Relation::from_extension("ExtensionLeaf", decoded, vec![], ctx)
+        Relation::from_extension(
+            "ExtensionLeaf",
+            rel.detail.as_ref().map(AnyRef::from),
+            vec![],
+            ctx,
+        )
     }
 
     fn from_extension_single<S: Scope>(rel: &'a ExtensionSingleRel, ctx: &S) -> Self {
-        let detail_ref = rel.detail.as_ref().map(AnyRef::from);
-        let decoded = match detail_ref {
-            Some(d) => ctx.extension_registry().decode(d),
-            None => Err(ExtensionError::MissingDetail),
-        };
-        Relation::from_extension("ExtensionSingle", decoded, vec![rel.input.as_deref()], ctx)
+        Relation::from_extension(
+            "ExtensionSingle",
+            rel.detail.as_ref().map(AnyRef::from),
+            vec![rel.input.as_deref()],
+            ctx,
+        )
     }
 
     fn from_extension_multi<S: Scope>(rel: &'a ExtensionMultiRel, ctx: &S) -> Self {
-        let detail_ref = rel.detail.as_ref().map(AnyRef::from);
-        let decoded = match detail_ref {
-            Some(d) => ctx.extension_registry().decode(d),
-            None => Err(ExtensionError::MissingDetail),
-        };
         let mut child_refs: Vec<Option<&'a Rel>> = vec![];
         for input in &rel.inputs {
             child_refs.push(Some(input));
         }
-        Relation::from_extension("ExtensionMulti", decoded, child_refs, ctx)
+        Relation::from_extension(
+            "ExtensionMulti",
+            rel.detail.as_ref().map(AnyRef::from),
+            child_refs,
+            ctx,
+        )
     }
 
     fn from_extension<S: Scope>(
         ext_type: &'static str,
-        decoded: Result<(String, ExtensionArgs), ExtensionError>,
+        detail: Option<AnyRef<'a>>,
         child_refs: Vec<Option<&'a Rel>>,
         ctx: &S,
     ) -> Self {
+        let (children, _) = Relation::convert_children(child_refs, ctx);
+        let inputs = children
+            .iter()
+            .filter_map(|child| {
+                child
+                    .as_ref()
+                    .map(|child| ExtensionInput::new(child.emitted()))
+            })
+            .collect::<Vec<_>>();
+        let context = ExtensionContext::new(&inputs);
+        let decoded = match detail {
+            Some(detail) => ctx
+                .extension_registry()
+                .decode_with_context(detail, &context),
+            None => Err(ExtensionError::MissingDetail),
+        };
+
         match decoded {
             Ok((name, args)) => {
-                let (children, _) = Relation::convert_children(child_refs, ctx);
                 let mut positional = vec![];
                 for value in args.positional {
                     positional.push(Value::ExtensionArgument(value));
@@ -661,10 +677,11 @@ impl<'a> Relation<'a> {
                         value: Value::ExtensionArgument(value),
                     });
                 }
-                let mut columns = vec![];
-                for col in args.output_columns {
-                    columns.push(Value::ExtColumn(col));
-                }
+                let columns = args
+                    .output_columns
+                    .into_iter()
+                    .map(Value::ExtColumn)
+                    .collect();
                 Relation {
                     name: Cow::Owned(format!("{}:{}", ext_type, name)),
                     arguments: Some(RelationArgs::inline(positional, named)),
@@ -678,22 +695,19 @@ impl<'a> Relation<'a> {
                     children,
                 }
             }
-            Err(error) => {
-                let (children, _) = Relation::convert_children(child_refs, ctx);
-                Relation {
-                    name: Cow::Borrowed(ext_type),
-                    arguments: None,
-                    columns: vec![Value::Missing(PlanError::invalid(
-                        "extension",
-                        None::<&str>,
-                        error.to_string(),
-                    ))],
-                    emit: None,
-                    output_syntax: OutputSyntax::Implicit,
-                    addenda: AddendumLines::none(),
-                    children,
-                }
-            }
+            Err(error) => Relation {
+                name: Cow::Borrowed(ext_type),
+                arguments: None,
+                columns: vec![Value::Missing(PlanError::invalid(
+                    "extension",
+                    None::<&str>,
+                    error.to_string(),
+                ))],
+                emit: None,
+                output_syntax: OutputSyntax::Implicit,
+                addenda: AddendumLines::none(),
+                children,
+            },
         }
     }
 

--- a/tests/adv_extension_roundtrip.rs
+++ b/tests/adv_extension_roundtrip.rs
@@ -165,7 +165,9 @@ Root[result]
 /// A minimal Explainable + prost::Message used to register as an optimization.
 mod opt_fixture {
     use prost::Name;
-    use substrait_explain::extensions::{Explainable, ExtensionArgs, ExtensionError};
+    use substrait_explain::extensions::{
+        Explainable, ExtensionArgs, ExtensionContext, ExtensionError,
+    };
 
     #[derive(Clone, PartialEq, prost::Message)]
     pub struct PlanHint {
@@ -198,7 +200,10 @@ mod opt_fixture {
             Ok(PlanHint { hint })
         }
 
-        fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+        fn to_args(
+            &self,
+            _context: &ExtensionContext<'_>,
+        ) -> Result<ExtensionArgs, ExtensionError> {
             let mut args = ExtensionArgs::default();
             args.insert("hint", self.hint.clone());
             Ok(args)
@@ -520,7 +525,7 @@ Root[result]
 mod extension_child_fixture {
     use prost::Name;
     use substrait_explain::extensions::{
-        Explainable, ExtensionArgs, ExtensionColumn, ExtensionError,
+        Explainable, ExtensionArgs, ExtensionColumn, ExtensionContext, ExtensionError,
     };
 
     #[derive(Clone, PartialEq, prost::Message)]
@@ -552,7 +557,10 @@ mod extension_child_fixture {
             Ok(TwoColumnScan {})
         }
 
-        fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+        fn to_args(
+            &self,
+            _context: &ExtensionContext<'_>,
+        ) -> Result<ExtensionArgs, ExtensionError> {
             let mut args = ExtensionArgs::default();
             args.output_columns.push(ExtensionColumn::Named {
                 name: "col0".to_owned(),
@@ -844,7 +852,7 @@ Root[result]
 mod adv_ext_with_columns_fixture {
     use prost::Name;
     use substrait_explain::extensions::{
-        Explainable, ExtensionArgs, ExtensionColumn, ExtensionError,
+        Explainable, ExtensionArgs, ExtensionColumn, ExtensionContext, ExtensionError,
     };
 
     #[derive(Clone, PartialEq, prost::Message)]
@@ -874,7 +882,10 @@ mod adv_ext_with_columns_fixture {
             Ok(EnhancementWithColumns {})
         }
 
-        fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+        fn to_args(
+            &self,
+            _context: &ExtensionContext<'_>,
+        ) -> Result<ExtensionArgs, ExtensionError> {
             let mut args = ExtensionArgs::default();
             // Deliberately populate output_columns - the addendum grammar
             // has no "=> columns" clause, so this cannot be round-tripped.

--- a/tests/extension_roundtrip.rs
+++ b/tests/extension_roundtrip.rs
@@ -10,7 +10,7 @@ use substrait::proto::expression::literal::LiteralType;
 use substrait::proto::r#type::Nullability;
 use substrait_explain::extensions::examples::PartitionHint;
 use substrait_explain::extensions::{
-    EnumValue, Explainable, Expr, ExtensionArgs, ExtensionColumn, ExtensionError,
+    EnumValue, Explainable, Expr, ExtensionArgs, ExtensionColumn, ExtensionContext, ExtensionError,
     ExtensionProtoConvert, ExtensionRegistry, ExtensionValue, TupleValue,
 };
 use substrait_explain::{Parser, format_with_registry};
@@ -405,9 +405,7 @@ Root[result]
 // ExtensionSingle and ExtensionMulti fixtures
 // ---------------------------------------------------------------------------
 
-/// A minimal ExtensionSingle: no arguments, passes through its single input
-/// column unchanged.  The `_ => $0` syntax uses the empty-args placeholder
-/// and a reference-style output column.
+/// A minimal ExtensionSingle that derives its output from its input fields.
 #[derive(Clone, PartialEq, Message)]
 pub struct PassThroughWrapper {}
 
@@ -434,8 +432,20 @@ impl Explainable for PassThroughWrapper {
     }
 
     fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-        let mut args = ExtensionArgs::default();
-        args.output_columns.push(ExtensionColumn::field(0));
+        Ok(ExtensionArgs::default())
+    }
+
+    fn to_args_with_context(
+        &self,
+        context: &ExtensionContext<'_>,
+    ) -> Result<ExtensionArgs, ExtensionError> {
+        let mut args = self.to_args()?;
+        let input = context.inputs().first().ok_or_else(|| {
+            ExtensionError::InvalidArgument("PassThrough expects one input".to_owned())
+        })?;
+        args.output_columns.extend(
+            (0..input.emitted_column_count()).map(|index| ExtensionColumn::field(index as i32)),
+        );
         Ok(args)
     }
 }
@@ -485,9 +495,28 @@ fn test_extension_single_over_read_roundtrip() {
     registry.register_relation::<PassThroughWrapper>().unwrap();
 
     let plan_text = r#"=== Plan
-Root[col]
-  ExtensionSingle:PassThrough[_ => $0]
-    Read[my.table => col:i64]"#;
+Root[a, b, c, d]
+  ExtensionSingle:PassThrough[_ => $0, $1, $2, $3]
+    Read[my.table => a:i64, b:i64, c:i64, d:i64]"#;
+
+    let parser = Parser::new().with_extension_registry(registry.clone());
+    let plan = parser.parse_plan(plan_text).expect("parse failed");
+
+    let (formatted, errors) = format_with_registry(&plan, &Default::default(), &registry);
+    assert!(errors.is_empty(), "unexpected format errors: {errors:?}");
+    assert_eq!(formatted.trim(), plan_text.trim());
+}
+
+#[test]
+fn test_extension_single_input_output_uses_emitted_child_width() {
+    let mut registry = ExtensionRegistry::new();
+    registry.register_relation::<PassThroughWrapper>().unwrap();
+
+    let plan_text = r#"=== Plan
+Root[a, d]
+  ExtensionSingle:PassThrough[_ => $0, $1]
+    Project[$0, $3]
+      Read[my.table => a:i64, b:i64, c:i64, d:i64]"#;
 
     let parser = Parser::new().with_extension_registry(registry.clone());
     let plan = parser.parse_plan(plan_text).expect("parse failed");

--- a/tests/extension_roundtrip.rs
+++ b/tests/extension_roundtrip.rs
@@ -80,7 +80,7 @@ impl Explainable for UserTableConfig {
         })
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
 
         // Add named arguments
@@ -174,7 +174,10 @@ fn test_multiple_extensions_in_plan() {
             Ok(FilterConfig { expression })
         }
 
-        fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+        fn to_args(
+            &self,
+            _context: &ExtensionContext<'_>,
+        ) -> Result<ExtensionArgs, ExtensionError> {
             let mut args = ExtensionArgs::default();
             args.insert("expr", self.expression.clone());
             Ok(args)
@@ -264,7 +267,7 @@ impl Explainable for LiteralConfig {
         })
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
         args.insert("path", self.path.clone());
         args.insert("big", self.big);
@@ -352,7 +355,7 @@ impl Explainable for EmptySource {
         })
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         Ok(ExtensionArgs::default())
     }
 }
@@ -431,15 +434,8 @@ impl Explainable for PassThroughWrapper {
         Ok(PassThroughWrapper {})
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
-        Ok(ExtensionArgs::default())
-    }
-
-    fn to_args_with_context(
-        &self,
-        context: &ExtensionContext<'_>,
-    ) -> Result<ExtensionArgs, ExtensionError> {
-        let mut args = self.to_args()?;
+    fn to_args(&self, context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
+        let mut args = ExtensionArgs::default();
         let input = context.inputs().first().ok_or_else(|| {
             ExtensionError::InvalidArgument("PassThrough expects one input".to_owned())
         })?;
@@ -477,7 +473,7 @@ impl Explainable for BinaryMerge {
         Ok(BinaryMerge {})
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
         args.output_columns.push(ExtensionColumn::field(0));
         args.output_columns.push(ExtensionColumn::field(1));
@@ -661,7 +657,7 @@ impl Explainable for TupleSortHint {
         Ok(TupleSortHint { directions })
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
         let tv: TupleValue = self
             .directions

--- a/tests/extension_table.rs
+++ b/tests/extension_table.rs
@@ -4,7 +4,7 @@ mod common;
 
 use prost::{Message, Name};
 use substrait_explain::extensions::{
-    Explainable, ExtensionArgs, ExtensionError, ExtensionRegistry, examples,
+    Explainable, ExtensionArgs, ExtensionContext, ExtensionError, ExtensionRegistry, examples,
 };
 use substrait_explain::{Parser, format_with_registry};
 
@@ -43,7 +43,7 @@ impl Explainable for UserTable {
         })
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
         args.insert("name", self.name.clone());
         Ok(args)

--- a/tests/json_parsing.rs
+++ b/tests/json_parsing.rs
@@ -8,7 +8,8 @@
 use substrait::proto;
 use substrait_explain::cli::{Cli, Commands, Format};
 use substrait_explain::extensions::{
-    Explainable, ExtensionArgs, ExtensionColumn, ExtensionError, ExtensionRegistry,
+    Explainable, ExtensionArgs, ExtensionColumn, ExtensionContext, ExtensionError,
+    ExtensionRegistry,
 };
 use substrait_explain::json::{build_descriptor_pool, parse_json};
 use substrait_explain::{OutputOptions, Parser, format_with_registry};
@@ -38,7 +39,7 @@ impl Explainable for ParquetScanConfig {
         })
     }
 
-    fn to_args(&self) -> Result<ExtensionArgs, ExtensionError> {
+    fn to_args(&self, _context: &ExtensionContext<'_>) -> Result<ExtensionArgs, ExtensionError> {
         let mut args = ExtensionArgs::default();
         args.insert("path", self.path.clone());
         args.insert("batch_size", self.batch_size);


### PR DESCRIPTION
The goal of this change is to give access to information about the inputs when we compute the args of an extension.

I called this parameter `context` so that it can be extended with other information (ie format options) if we need to.

The concrete use case I have for this is the following one: I have an `ExtensionSingle` for which the number of output columns is equal to the number of inputs columns. When I define the extension for that `ExtensionSingle`, I extend `Explainable` and in the `to_args` method, I have no information about the input, so I cannot compute correctly the `ExtensionArgs.output_columns`.

If the current change is merged, I would use `context.inputs().emitted_column_count()` to compute the `ExtensionArgs.output_columns`.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the project's contributing guide
     - 👷‍♀️ Create small PRs.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

## Description

Brief description of what this PR does and why it's needed.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Example update
- [ ] Other (please describe)

## Testing

- [ ] Added tests for new functionality
- [ ] All existing tests pass
- [ ] Ran examples to verify behavior

## Checklist

- [ ] Code follows Rust conventions
- [ ] Documentation updated if needed
- [ ] No breaking changes (or breaking changes documented)
- [ ] Pre-commit hooks pass

## Related Issues

Closes #(issue number)
-->
