### PR TITLE
feat(extensions)!: improve argument handling

### DIFF
--- a/API.md
+++ b/API.md
@@ -166,8 +166,8 @@ extension namespaces receive an empty input slice.
 
 Use `ArgsExtractor` for convenient argument parsing:
 
-- `extractor.expect_named_arg::<T>(name)` - Required argument
-- `extractor.get_named_or::<T>(name, default)` - Optional with default
+- `extractor.expect_named::<T>(name)` - Required argument
+- `extractor.get_named::<T>(name)?` - Optional argument, returning `Option<T>`
 - `extractor.check_exhausted()` - Verify no unexpected arguments
 
 ### Extension Namespaces

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -218,32 +218,20 @@ Enum fields in arguments are represented as &-prefixed variants (e.g., `&AscNull
 
 - `&AscNullsFirst`, `&AscNullsLast`, `&DescNullsFirst`, `&DescNullsLast` - sort directions
 
-### `literal`
+### Scalar values
 
-A literal can be an integer, float, boolean, string, or null. Literals may include a type annotation:
-
-`literal := (float / integer / boolean / string / "null") (":" type)?`
+These are basic terminals used in [expressions](#expression-literals)
+and [arguments](#arguments).
 
 - **`integer`**` := "-"? digit+`
   - Examples: `42`, `-10`, `0`
-  - Default to `i64` type; other integer types may be assigned
 - **`float`**` := "-"? digit+ "." digit+`
   - Examples: `3.14`, `-2.5`, `1.0`
-  - Default to `fp64` type; other float types may be assigned
 - **`boolean`**` := "true" / "false"`
   - Examples: `true`, `false`
-  - May only be boolean type
 - **`string`**` := "'" ("\\" . / !"'" .)* "'"`
   - Examples: `'hello'`, `'table name'`, `'C:\path\to\file'`, `'line1\nline2'`, `'quote\'s here'`
-  - Default to `string` type; other types may also be assigned
 - **`null`**` := "null"`
-  - Examples: `null:i64?`, `null:string?`, `null:date?`
-  - A type annotation is required for `null`
-- **`typed_literal`**` := string ":" type`
-  - String literals with type annotations for non-primitive types
-  - Examples: `'2023-01-01':date`, `'2023-12-25T14:30:45.123':timestamp`, `'2023-01-01T12:00:00.123456789':precisiontimestamp<9>`, `'14:30:45.123456':precisiontime<6>`
-
-All basic literal types (`integer`, `float`, `boolean`, and `string`) are supported, plus `date`, `time`, `timestamp`, `precisiontime`, `precisiontimestamp`, `precisiontimestamptz`, and typed null literals. Other Substrait literal types (e.g., `interval_year`, `decimal`, `uuid`) are not yet implemented. The deprecated `timestamp_tz` literal is also not yet implemented; use `precisiontimestamptz<6>` instead.
 
 ## Types
 
@@ -326,8 +314,8 @@ The precision parameter follows the Substrait unit convention: `0` means
 seconds, `3` milliseconds, `6` microseconds, `9` nanoseconds, and `12`
 picoseconds. Two different subsets apply:
 
-- *Types* accept the full Substrait range, any precision from `0` through `12`.
-- *Literals* accept only `0`, `3`, `6`, and `9`.
+- _Types_ accept the full Substrait range, any precision from `0` through `12`.
+- _Literals_ accept only `0`, `3`, `6`, and `9`.
 
 The literal restriction is a limitation of this implementation, not of
 Substrait, which supports every precision from 0 to 12.
@@ -335,8 +323,8 @@ Substrait, which supports every precision from 0 to 12.
 Literals stop at `9` because chrono (the underlying date/time library) has no
 sub-nanosecond resolution, so precision-12 literals cannot be parsed.
 Textifying a precision-12 value from a protobuf plan is still supported: the
-*value* is truncated to nanosecond resolution and a truncation diagnostic is
-emitted, but the declared *type* is preserved as `<12>` (truncating the value
+_value_ is truncated to nanosecond resolution and a truncation diagnostic is
+emitted, but the declared _type_ is preserved as `<12>` (truncating the value
 does not silently rewrite its type).
 
 #### Examples
@@ -412,7 +400,7 @@ Root[result]
 
 #### Syntax
 
-`expression := function_call / reference / literal / if_then`
+`expression := function_call / reference / expression_literal / if_then`
 
 ### Examples
 
@@ -420,6 +408,45 @@ Root[result]
 add($3, 10):i64              // Simple function call with required output type
 add#10@2($3, 10):i64         // Function call with anchors and output type
 ```
+
+### Expression Literals
+
+An `expression_literal` represents a Substrait `Literal` expression and
+therefore always has a type. The text format may infer the conventional type
+for a non-null scalar when its type ascription is omitted:
+
+```text
+expression_literal := (float / integer / boolean / string) (":" type)?
+                    / "null" ":" type
+```
+
+- An unannotated `integer` has type `i64`; an annotation can select another
+  integer type, as in `5:i16`.
+- An unannotated `float` has type `fp64`; an annotation can select another
+  floating-point type.
+- A `boolean` may only have boolean type.
+- An unannotated `string` has type `string`. String values may be annotated as
+  other supported literal types, such as `'2023-01-01':date`.
+- A `null` literal requires an explicit type, such as `null:i64?`,
+  `null:string?`, or `null:date?`.
+
+#### Examples
+
+```text
+null:i64?
+null:string?
+null:date?
+'2023-01-01':date
+'2023-12-25T14:30:45.123':timestamp
+'2023-01-01T12:00:00.123456789':precisiontimestamp<9>
+'14:30:45.123456':precisiontime<6>
+```
+
+The supported non-primitive literal types are `date`, `time`, `timestamp`,
+`precisiontime`, `precisiontimestamp`, and `precisiontimestamptz`. Other
+Substrait literal types, including `interval_year`, `decimal`, and `uuid`, are
+not yet implemented. The deprecated `timestamp_tz` literal is also not
+implemented; use `precisiontimestamptz<6>` instead.
 
 ### Field References
 
@@ -542,17 +569,19 @@ All relations follow this general pattern:
 #### Syntax
 
 ```text
-relation := name "[" (arguments ("," named_arguments)? ("=>" columns)?)? "]"
+relation := name "[" (relation_arguments ("=>" columns)?)? "]"
+relation_arguments := (arguments ("," named_arguments)?) / named_arguments
 columns := name ("," name)* / reference_list
 ```
 
 Where:
 
-- **`name`**: The type of operation (Read, Filter, Project, Root, etc.)
-- **`arguments`**: Input expressions, field references, function calls, or other parameters (optional)
-- **`named_arguments`**: Named arguments (optional)
-- **`=>`**: Separator between arguments and output columns (optional, only present when both arguments and columns are specified)
-- **`columns`**: Output column names and types, or field references for pass-through (all relations specify outputs, but format varies)
+- **`name`**: The type of operation (`Read`, `Filter`, `Project`, etc.)
+- **`relation_arguments`**: Positional arguments, named arguments, or both (optional)
+- **`arguments`**: Positional expressions, field references, enums, tuples, or parameter literals
+- **`named_arguments`**: Named arguments, following any positional arguments
+- **`=>`**: Separator before an optional output clause
+- **`columns`**: Output column names and types, or field references for pass-through
 - **`reference_list := reference ("," reference)*`**: comma-separated list of field references
 
 #### Example
@@ -564,10 +593,8 @@ RelationName[arguments, named_arguments => columns]
 #### Special cases
 
 - **Root relation**: Only specifies output column names, no arguments or `=>` separator
-- **Project relation**: Only specifies expressions, no `=>` separator or output columns
-- Some relations may use '...' instead of column names when they pass through all fields
 
-The exact structure varies by relation type, but all follow this basic pattern.
+The arguments allowed and format of output columns varies by relation type.
 
 #### Emit
 
@@ -578,23 +605,26 @@ consumer can rely on — it would have to infer `Direct`.
 
 ### Arguments
 
-Arguments in relations can be literals, expressions, enums, or tuples thereof.
+Arguments in relations can be parameter literals, expressions, enums, or tuples thereof.
 
 #### Syntax
 
 ```text
-argument := enum / reference / literal / expression / tuple
+arguments := argument ("," argument)*
+named_arguments := name "=" argument ("," name "=" argument)*
+argument := enum / reference / parameter_literal / expression / tuple
+parameter_literal := float / integer / boolean / string / null
 tuple := "(" ")"                                        // 0-tuple
        / "(" argument "," ")"                           // 1-tuple (trailing comma required)
        / "(" argument ("," argument)+ ","? ")"          // 2+-tuple (trailing comma optional)
-arguments := argument ("," argument)*
-named_arguments := name "=" argument ("," name "=" argument)*
 ```
 
-Tuples follow the Python/Rust trailing-comma convention to disambiguate from parenthesised
-expressions: `(x)` is a parenthesised expression, not a tuple. A trailing comma is required to
-form a 1-element tuple: `(x,)`. For 2+ elements the trailing comma is optional: `(x, y)` and
-`(x, y,)` are equivalent.
+A `parameter_literal` supplies a scalar value directly to a relation parameter
+and never has a type ascription. An `expression_literal` is part of an
+expression and therefore has a Substrait type. The relation-specific grammar
+determines which interpretation applies.
+
+Tuples follow the Python/Rust trailing-comma convention to disambiguate from parenthesised expressions: `(x)` is a parenthesised expression, not a tuple. A trailing comma is required to form a 1-element tuple: `(x,)`. For 2+ elements the trailing comma is optional: `(x, y)` and `(x, y,)` are equivalent.
 
 #### Examples
 
@@ -991,16 +1021,20 @@ sort_direction := "&AscNullsFirst" / "&AscNullsLast" / "&DescNullsFirst" / "&Des
 
 ### Join Relation
 
-**Syntax**: `"Join" "[" join_type "," expression ("," "post_filter" "=" expression)? "=>" reference_list "]"`
+#### Syntax
 
-**Components**:
+```text
+"Join" "[" join_type "," expression ("," "post_filter" "=" expression)? "=>" reference_list "]"
+```
+
+#### Components
 
 - `join_type` - Join type enum with `&` prefix (e.g., `&Inner`, `&Left`, `&Right`, `&Outer`)
 - `expression` - Join condition (boolean expression relating left and right inputs), with field references over input order
 - `post_filter` - Optional post-join filter expression, applied after join matching, with field references over direct output order
 - `reference_list` - comma-separated list of field references for output columns, with field references over direct output order
 
-**Field Reference Mapping**:
+#### Field Reference Mapping
 
 For join conditions, field references map to the combined schema of left and
 right inputs:
@@ -1016,7 +1050,7 @@ direct output order:
 - right semi, right anti, and right single joins output right fields only, renumbered from `$0`
 - left mark and right mark joins output the retained side's fields followed by the mark column
 
-**Example**:
+#### Example
 
 ```rust
 # use substrait_explain::Parser;
@@ -1041,7 +1075,7 @@ Root[user_orders]
 
 ### Set Relation
 
-#### Syntax 
+#### Syntax
 
 `"Set" "[" set_op "=>" reference_list "]"`
 
@@ -1128,7 +1162,7 @@ extension_relation := extension_type ":" name "[" (empty / extension_args)? ("=>
 extension_type := "ExtensionLeaf" / "ExtensionSingle" / "ExtensionMulti"
 extension_args := (positional_args ("," named_args)?) / named_args
 positional_args := extension_arg ("," extension_arg)*
-extension_arg := enum / reference / literal / expression / tuple
+extension_arg := enum / reference / parameter_literal / expression / tuple
 named_args := named_arg ("," named_arg)*
 named_arg := name "=" extension_arg
 extension_columns := (extension_column ("," extension_column)*)?
@@ -1142,18 +1176,18 @@ Note: the parser also accepts the `=>` section being omitted entirely (e.g. `Ext
 - **`extension_type`** - One of `ExtensionLeaf`, `ExtensionSingle`, or `ExtensionMulti`
 - **`name`** - The extension name (registered with `ExtensionRegistry`)
 - **`empty`** (`_`) - Explicitly marks an extension with no arguments
-- **`extension_args`** - Positional arguments (enums, references, literals, expressions, or tuples) and/or named arguments (`key=value` pairs); both are optional
+- **`extension_args`** - Positional arguments (enums, references, parameter literals, expressions, or tuples) and/or named arguments (`key=value` pairs); both are optional
 - **`extension_columns`** - Output column definitions: named columns (`name:type`), field references (`$0`), or expressions
 
-Untyped scalar extension arguments such as `2`, `2.4`, `true`, `'path'`, and
-`null` are treated as extension scalar values and render without expression
-type suffixes, even in verbose output. Bare `null` is distinct from an absent
-argument. The typed extractor treats it as a present value that must be
-handled explicitly. Other untyped scalar values can still be consumed by
-extension handlers as expressions, in which case they widen to default
-non-nullable Substrait literal expressions. Typed literals such as `2:i16` or
-`'2024-01-01':date`, field references, function calls, and casts are expression
-values.
+A `parameter_literal` is a direct scalar parameter. Values such as
+`2`, `2.4`, `true`, `'path'`, and `null` therefore render without type
+ascriptions, even in verbose output.
+
+A registered extension may interpret a non-null parameter literal as an
+expression, in which case it has the default non-nullable type described under
+[Expression Literals](#expression-literals). An explicitly ascribed literal such
+as `2:i16`, `'2024-01-01':date`, or `null:i64?` is an expression. Field
+references, function calls, and casts are also expression values.
 
 #### Examples
 
@@ -1208,16 +1242,8 @@ Addendum lines are **indented one level deeper** than the relation they annotate
 
 ### Argument Syntax
 
-Extension arguments follow the same rules as extension-relation arguments. Enum values are written with a `&` prefix:
-
-```text
-enum_value := "&" identifier
-```
-
-#### Examples
-
-- `&HASH`, `&RANGE`, `&BROADCAST` — `PartitionStrategy` variants for `PartitionHint`
-- `&AscNullsFirst` — sort direction enum in a relation argument
+Enhancement and Optimization arguments follow the same rules as extension-relation arguments,
+including `parameter_literal` for scalar parameters without type ascriptions.
 
 ### Example: Enhancement on a Read Relation
 

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -1145,11 +1145,13 @@ Note: the parser also accepts the `=>` section being omitted entirely (e.g. `Ext
 - **`extension_args`** - Positional arguments (enums, references, literals, expressions, or tuples) and/or named arguments (`key=value` pairs); both are optional
 - **`extension_columns`** - Output column definitions: named columns (`name:type`), field references (`$0`), or expressions
 
-Untyped scalar extension arguments such as `2`, `2.4`, `true`, and `'path'`
-are treated as extension scalar values and render without expression type
-suffixes, even in verbose output. They can still be consumed by extension
-handlers as expressions, in which case they widen to default non-nullable
-Substrait literal expressions. Typed literals such as `2:i16` or
+Untyped scalar extension arguments such as `2`, `2.4`, `true`, `'path'`, and
+`null` are treated as extension scalar values and render without expression
+type suffixes, even in verbose output. Bare `null` is distinct from an absent
+argument. The typed extractor treats it as a present value that must be
+handled explicitly. Other untyped scalar values can still be consumed by
+extension handlers as expressions, in which case they widen to default
+non-nullable Substrait literal expressions. Typed literals such as `2:i16` or
 `'2024-01-01':date`, field references, function calls, and casts are expression
 values.
 

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -400,7 +400,7 @@ Root[result]
 
 #### Syntax
 
-`expression := function_call / reference / expression_literal / if_then`
+`expression := function_call / reference / expression_literal / cast_expression / if_then`
 
 ### Examples
 
@@ -523,6 +523,32 @@ count():i64
 // Signature: resolves if "count:" is registered exactly once with
 // type signature "" (zero arguments)
 count:():i64
+```
+
+### Cast Expressions
+
+A cast converts an expression to a target type. Its optional failure behavior
+controls what happens when the value cannot be converted.
+
+#### Syntax
+
+```text
+cast_expression := "(" expression ")" "::" cast_failure_behavior? type
+cast_failure_behavior := "?" / "!"
+```
+
+Where:
+
+- no failure prefix leaves the behavior unspecified
+- `?` returns null when the cast fails
+- `!` raises an error when the cast fails
+
+#### Examples
+
+```text
+(78:i32)::i16
+($0)::?i16
+($0)::!i16
 ```
 
 ### Aggregate Measures
@@ -1018,6 +1044,45 @@ sort_direction := "&AscNullsFirst" / "&AscNullsLast" / "&DescNullsFirst" / "&Des
 - Each sort field is a tuple: `(reference, sort_direction)`
 - Sort directions follow the general `enum` syntax and specify null handling
 - `reference_list` - comma-separated list of field references to pass through
+
+### Fetch Relation
+
+A Fetch relation limits or offsets rows from its input.
+
+#### Syntax
+
+```text
+fetch_relation := "Fetch" "[" fetch_args "=>" reference_list "]"
+fetch_args := fetch_arg ("," fetch_arg)* / "_"
+fetch_arg := ("limit" / "offset") "=" (integer / expression)
+```
+
+#### Components
+
+- `limit` - maximum number of rows to return
+- `offset` - number of rows to skip
+- `_` - no limit or offset
+- `reference_list` - fields to pass through, optionally reordered
+
+`limit` and `offset` may appear in either order, but no more than once each. A
+bare integer is a parameter literal and must be non-negative; other values are
+expressions.
+
+#### Example
+
+```rust
+# use substrait_explain::Parser;
+#
+# let plan_text = r#"
+=== Plan
+Root[id, name]
+  Fetch[limit=10, offset=5 => $0, $1]
+    Read[records => id:i64, name:string]
+# "#;
+#
+# let plan = Parser::parse(plan_text).unwrap();
+# assert_eq!(plan.relations.len(), 1);
+```
 
 ### Join Relation
 

--- a/examples/extensions.rs
+++ b/examples/extensions.rs
@@ -72,10 +72,10 @@ impl Explainable for ParquetScanConfig {
     fn from_args(args: &ExtensionArgs) -> Result<Self, ExtensionError> {
         let mut extractor = args.extractor();
         // path is required
-        let path: &str = extractor.expect_named_arg("path")?;
+        let path: &str = extractor.expect_named("path")?;
         // batch_size and use_dictionary are optional, with default values
-        let batch_size: i64 = extractor.get_named_or("batch_size", 1024)?;
-        let use_dictionary: bool = extractor.get_named_or("use_dictionary", true)?;
+        let batch_size: i64 = extractor.get_named("batch_size")?.unwrap_or(1024);
+        let use_dictionary: bool = extractor.get_named("use_dictionary")?.unwrap_or(true);
 
         // Validate there are no other named arguments
         extractor.check_exhausted()?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -909,7 +909,7 @@ Root[result]
 
         fn from_args(args: &ExtensionArgs) -> Result<Self, ExtensionError> {
             let mut extractor = args.extractor();
-            let tag: &str = extractor.expect_named_arg("tag")?;
+            let tag: &str = extractor.expect_named("tag")?;
             extractor.check_exhausted()?;
             Ok(TestSource {
                 tag: tag.to_string(),

--- a/src/extensions/args.rs
+++ b/src/extensions/args.rs
@@ -241,7 +241,12 @@ impl<'a> ArgsExtractor<'a> {
         T::Error: Into<ExtensionError>,
     {
         self.get_named_arg(name)
-            .map(|value| T::try_from(value).map_err(Into::into))
+            .map(|value| {
+                T::try_from(value).map_err(|error| ExtensionError::NamedArgumentConversion {
+                    name: name.to_string(),
+                    source: Box::new(error.into()),
+                })
+            })
             .transpose()
     }
 
@@ -661,6 +666,23 @@ mod tests {
 
         assert_eq!(extractor.get_named::<i64>("count").unwrap(), Some(8));
         assert_eq!(extractor.get_named::<i64>("missing").unwrap(), None);
+        assert!(extractor.check_exhausted().is_ok());
+    }
+
+    #[test]
+    fn get_named_contextualizes_conversion_errors() {
+        let mut args = ExtensionArgs::default();
+        args.insert("count", "eight");
+        let mut extractor = args.extractor();
+
+        let error = extractor
+            .get_named::<i64>("count")
+            .expect_err("string should not convert to i64");
+
+        assert_eq!(
+            error.to_string(),
+            "Invalid named argument 'count': Invalid argument: expected integer, got string"
+        );
         assert!(extractor.check_exhausted().is_ok());
     }
 

--- a/src/extensions/args.rs
+++ b/src/extensions/args.rs
@@ -373,6 +373,8 @@ pub enum ExtensionValue {
     Boolean(bool),
     /// An untyped null literal.
     Null,
+    /// A conversion or formatting error preserved for best-effort textification.
+    Error(ExtensionError),
 
     /// Substrait expression value, including typed literals and field references.
     ///
@@ -397,6 +399,7 @@ pub enum ExtensionValueKind {
     Float,
     Boolean,
     Null,
+    Error,
     Reference,
     Enum,
     Tuple,
@@ -411,6 +414,7 @@ impl fmt::Display for ExtensionValueKind {
             ExtensionValueKind::Float => write!(f, "float"),
             ExtensionValueKind::Boolean => write!(f, "boolean"),
             ExtensionValueKind::Null => write!(f, "null"),
+            ExtensionValueKind::Error => write!(f, "error"),
             ExtensionValueKind::Reference => write!(f, "reference"),
             ExtensionValueKind::Enum => write!(f, "enum"),
             ExtensionValueKind::Tuple => write!(f, "tuple"),
@@ -428,10 +432,17 @@ impl ExtensionValue {
             ExtensionValue::Float(_) => ExtensionValueKind::Float,
             ExtensionValue::Boolean(_) => ExtensionValueKind::Boolean,
             ExtensionValue::Null => ExtensionValueKind::Null,
+            ExtensionValue::Error(_) => ExtensionValueKind::Error,
             ExtensionValue::Expr(_) => ExtensionValueKind::Expression,
             ExtensionValue::Enum(_) => ExtensionValueKind::Enum,
             ExtensionValue::Tuple(_) => ExtensionValueKind::Tuple,
         }
+    }
+}
+
+impl From<ExtensionError> for ExtensionValue {
+    fn from(error: ExtensionError) -> Self {
+        ExtensionValue::Error(error)
     }
 }
 
@@ -489,10 +500,18 @@ impl From<&str> for ExtensionValue {
     }
 }
 
-fn invalid_type(expected: ExtensionValueKind, actual: &ExtensionValue) -> ExtensionError {
-    ExtensionError::InvalidArgumentType {
-        expected,
-        actual: actual.kind(),
+impl ExtensionError {
+    fn invalid_type(expected: ExtensionValueKind, actual: &ExtensionValue) -> Self {
+        match actual {
+            ExtensionValue::Error(source) => Self::ArgumentConversion {
+                expected,
+                source: Box::new(source.clone()),
+            },
+            _ => Self::InvalidArgumentType {
+                expected,
+                actual: actual.kind(),
+            },
+        }
     }
 }
 
@@ -502,7 +521,7 @@ impl<'a> TryFrom<&'a ExtensionValue> for &'a str {
     fn try_from(value: &'a ExtensionValue) -> Result<&'a str, Self::Error> {
         match value {
             ExtensionValue::String(s) => Ok(s),
-            v => Err(invalid_type(ExtensionValueKind::String, v)),
+            v => Err(ExtensionError::invalid_type(ExtensionValueKind::String, v)),
         }
     }
 }
@@ -524,7 +543,7 @@ impl<'a> TryFrom<&'a ExtensionValue> for EnumValue {
     fn try_from(value: &'a ExtensionValue) -> Result<EnumValue, Self::Error> {
         match value {
             ExtensionValue::Enum(s) => Ok(EnumValue(s.clone())),
-            v => Err(invalid_type(ExtensionValueKind::Enum, v)),
+            v => Err(ExtensionError::invalid_type(ExtensionValueKind::Enum, v)),
         }
     }
 }
@@ -535,7 +554,7 @@ impl<'a> TryFrom<&'a ExtensionValue> for &'a TupleValue {
     fn try_from(value: &'a ExtensionValue) -> Result<&'a TupleValue, Self::Error> {
         match value {
             ExtensionValue::Tuple(tv) => Ok(tv),
-            v => Err(invalid_type(ExtensionValueKind::Tuple, v)),
+            v => Err(ExtensionError::invalid_type(ExtensionValueKind::Tuple, v)),
         }
     }
 }
@@ -546,7 +565,7 @@ impl TryFrom<&ExtensionValue> for i64 {
     fn try_from(value: &ExtensionValue) -> Result<i64, Self::Error> {
         match value {
             ExtensionValue::Integer(i) => Ok(*i),
-            v => Err(invalid_type(ExtensionValueKind::Integer, v)),
+            v => Err(ExtensionError::invalid_type(ExtensionValueKind::Integer, v)),
         }
     }
 }
@@ -557,7 +576,7 @@ impl TryFrom<&ExtensionValue> for f64 {
     fn try_from(value: &ExtensionValue) -> Result<f64, Self::Error> {
         match value {
             ExtensionValue::Float(f) => Ok(*f),
-            v => Err(invalid_type(ExtensionValueKind::Float, v)),
+            v => Err(ExtensionError::invalid_type(ExtensionValueKind::Float, v)),
         }
     }
 }
@@ -568,7 +587,7 @@ impl TryFrom<&ExtensionValue> for bool {
     fn try_from(value: &ExtensionValue) -> Result<bool, Self::Error> {
         match value {
             ExtensionValue::Boolean(b) => Ok(*b),
-            v => Err(invalid_type(ExtensionValueKind::Boolean, v)),
+            v => Err(ExtensionError::invalid_type(ExtensionValueKind::Boolean, v)),
         }
     }
 }
@@ -581,8 +600,11 @@ impl TryFrom<&ExtensionValue> for Reference {
             ExtensionValue::Expr(expr) => expr
                 .as_direct_reference()
                 .map(Reference)
-                .ok_or_else(|| invalid_type(ExtensionValueKind::Reference, value)),
-            v => Err(invalid_type(ExtensionValueKind::Reference, v)),
+                .ok_or_else(|| ExtensionError::invalid_type(ExtensionValueKind::Reference, value)),
+            v => Err(ExtensionError::invalid_type(
+                ExtensionValueKind::Reference,
+                v,
+            )),
         }
     }
 }
@@ -603,7 +625,10 @@ impl TryFrom<&ExtensionValue> for Expr {
             ExtensionValue::Float(f) => Ok(Expr::from(*f)),
             ExtensionValue::String(s) => Ok(Expr::from(s.as_str())),
             ExtensionValue::Boolean(b) => Ok(Expr::from(*b)),
-            v => Err(invalid_type(ExtensionValueKind::Expression, v)),
+            v => Err(ExtensionError::invalid_type(
+                ExtensionValueKind::Expression,
+                v,
+            )),
         }
     }
 }
@@ -689,6 +714,25 @@ mod tests {
             "Invalid named argument 'count': Invalid argument: expected integer, got null"
         );
         assert!(extractor.check_exhausted().is_ok());
+    }
+
+    #[test]
+    fn error_value_reports_expected_type_and_source_when_extracted() {
+        let value = ExtensionValue::Error(ExtensionError::Custom("bad value".to_string()));
+
+        let error = i64::try_from(&value).expect_err("error value should not convert");
+
+        assert_eq!(
+            error.to_string(),
+            "Cannot convert argument to integer: bad value"
+        );
+        assert!(matches!(
+            &error,
+            ExtensionError::ArgumentConversion {
+                expected: ExtensionValueKind::Integer,
+                source,
+            } if matches!(source.as_ref(), ExtensionError::Custom(message) if message == "bad value")
+        ));
     }
 
     #[test]

--- a/src/extensions/args.rs
+++ b/src/extensions/args.rs
@@ -232,32 +232,31 @@ impl<'a> ArgsExtractor<'a> {
         }
     }
 
-    /// Get a named argument value or return an error
-    /// Marks the argument as consumed if found
-    pub fn expect_named_arg<T>(&mut self, name: &str) -> Result<T, ExtensionError>
+    /// Get a named argument converted to `T`, or `None` if it is absent.
+    ///
+    /// Marks the argument as consumed if it exists in the source args.
+    pub fn get_named<T>(&mut self, name: &str) -> Result<Option<T>, ExtensionError>
     where
         T: TryFrom<&'a ExtensionValue>,
         T::Error: Into<ExtensionError>,
     {
-        match self.get_named_arg(name) {
-            Some(value) => T::try_from(value).map_err(Into::into),
-            None => Err(ExtensionError::MissingArgument {
-                name: name.to_string(),
-            }),
-        }
+        self.get_named_arg(name)
+            .map(|value| T::try_from(value).map_err(Into::into))
+            .transpose()
     }
 
-    /// Get a named argument value or default
-    /// Marks the argument as consumed if it exists in the source args
-    pub fn get_named_or<T>(&mut self, name: &str, default: T) -> Result<T, ExtensionError>
+    /// Get a required named argument converted to `T`.
+    ///
+    /// Marks the argument as consumed if found.
+    pub fn expect_named<T>(&mut self, name: &str) -> Result<T, ExtensionError>
     where
         T: TryFrom<&'a ExtensionValue>,
         T::Error: Into<ExtensionError>,
     {
-        match self.get_named_arg(name) {
-            Some(value) => T::try_from(value).map_err(Into::into),
-            None => Ok(default),
-        }
+        self.get_named(name)?
+            .ok_or_else(|| ExtensionError::MissingArgument {
+                name: name.to_string(),
+            })
     }
 
     /// Check that all named arguments in the source have been consumed,
@@ -647,5 +646,34 @@ impl ExtensionArgs {
     /// Create an extractor for validating named arguments
     pub fn extractor(&self) -> ArgsExtractor<'_> {
         ArgsExtractor::new(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_named_converts_present_values_and_returns_none_for_missing_values() {
+        let mut args = ExtensionArgs::default();
+        args.insert("count", 8_i64);
+        let mut extractor = args.extractor();
+
+        assert_eq!(extractor.get_named::<i64>("count").unwrap(), Some(8));
+        assert_eq!(extractor.get_named::<i64>("missing").unwrap(), None);
+        assert!(extractor.check_exhausted().is_ok());
+    }
+
+    #[test]
+    fn expect_named_reports_missing_argument_name() {
+        let args = ExtensionArgs::default();
+        let mut extractor = args.extractor();
+
+        let error = extractor
+            .expect_named::<i64>("count")
+            .expect_err("missing argument should fail");
+
+        assert_eq!(error.to_string(), "Missing required argument: count");
+        assert!(extractor.check_exhausted().is_ok());
     }
 }

--- a/src/extensions/args.rs
+++ b/src/extensions/args.rs
@@ -371,6 +371,8 @@ pub enum ExtensionValue {
     Integer(i64),
     Float(f64),
     Boolean(bool),
+    /// An untyped null literal.
+    Null,
 
     /// Substrait expression value, including typed literals and field references.
     ///
@@ -394,6 +396,7 @@ pub enum ExtensionValueKind {
     Integer,
     Float,
     Boolean,
+    Null,
     Reference,
     Enum,
     Tuple,
@@ -407,6 +410,7 @@ impl fmt::Display for ExtensionValueKind {
             ExtensionValueKind::Integer => write!(f, "integer"),
             ExtensionValueKind::Float => write!(f, "float"),
             ExtensionValueKind::Boolean => write!(f, "boolean"),
+            ExtensionValueKind::Null => write!(f, "null"),
             ExtensionValueKind::Reference => write!(f, "reference"),
             ExtensionValueKind::Enum => write!(f, "enum"),
             ExtensionValueKind::Tuple => write!(f, "tuple"),
@@ -423,6 +427,7 @@ impl ExtensionValue {
             ExtensionValue::Integer(_) => ExtensionValueKind::Integer,
             ExtensionValue::Float(_) => ExtensionValueKind::Float,
             ExtensionValue::Boolean(_) => ExtensionValueKind::Boolean,
+            ExtensionValue::Null => ExtensionValueKind::Null,
             ExtensionValue::Expr(_) => ExtensionValueKind::Expression,
             ExtensionValue::Enum(_) => ExtensionValueKind::Enum,
             ExtensionValue::Tuple(_) => ExtensionValueKind::Tuple,
@@ -672,16 +677,16 @@ mod tests {
     #[test]
     fn get_named_contextualizes_conversion_errors() {
         let mut args = ExtensionArgs::default();
-        args.insert("count", "eight");
+        args.insert("count", ExtensionValue::Null);
         let mut extractor = args.extractor();
 
         let error = extractor
             .get_named::<i64>("count")
-            .expect_err("string should not convert to i64");
+            .expect_err("null should not convert to i64");
 
         assert_eq!(
             error.to_string(),
-            "Invalid named argument 'count': Invalid argument: expected integer, got string"
+            "Invalid named argument 'count': Invalid argument: expected integer, got null"
         );
         assert!(extractor.check_exhausted().is_ok());
     }

--- a/src/extensions/examples.rs
+++ b/src/extensions/examples.rs
@@ -140,7 +140,7 @@ impl Explainable for PartitionHint {
             .collect();
 
         let mut extractor = args.extractor();
-        let count: i64 = extractor.get_named_or("count", 0)?;
+        let count: i64 = extractor.get_named("count")?.unwrap_or_default();
         extractor.check_exhausted()?;
 
         Ok(PartitionHint {
@@ -227,7 +227,7 @@ impl Explainable for PlanHint {
         }
 
         let mut extractor = args.extractor();
-        let hint: String = extractor.expect_named_arg::<&str>("hint")?.to_owned();
+        let hint: String = extractor.expect_named::<&str>("hint")?.to_owned();
         extractor.check_exhausted()?;
         Ok(PlanHint { hint })
     }
@@ -318,8 +318,8 @@ impl Explainable for BlobStoreRead {
 
         let path = <&str>::try_from(&args.positional[0])?.to_owned();
         let mut extractor = args.extractor();
-        let limit: i64 = extractor.get_named_or("limit", 0)?;
-        let include_archived: bool = extractor.get_named_or("include_archived", false)?;
+        let limit: i64 = extractor.get_named("limit")?.unwrap_or_default();
+        let include_archived: bool = extractor.get_named("include_archived")?.unwrap_or(false);
         extractor.check_exhausted()?;
 
         Ok(Self {

--- a/src/extensions/registry.rs
+++ b/src/extensions/registry.rs
@@ -185,6 +185,14 @@ pub enum ExtensionError {
         source: Box<ExtensionError>,
     },
 
+    /// An argument containing an earlier error could not be converted.
+    #[error("Cannot convert argument to {expected}: {source}")]
+    ArgumentConversion {
+        expected: ExtensionValueKind,
+        #[source]
+        source: Box<ExtensionError>,
+    },
+
     /// Invalid argument type found while extracting an extension argument.
     #[error("Invalid argument: expected {expected}, got {actual}")]
     InvalidArgumentType {

--- a/src/extensions/registry.rs
+++ b/src/extensions/registry.rs
@@ -177,6 +177,14 @@ pub enum ExtensionError {
     #[error("Missing required argument: {name}")]
     MissingArgument { name: String },
 
+    /// A named argument failed conversion to the requested type.
+    #[error("Invalid named argument '{name}': {source}")]
+    NamedArgumentConversion {
+        name: String,
+        #[source]
+        source: Box<ExtensionError>,
+    },
+
     /// Invalid argument type found while extracting an extension argument.
     #[error("Invalid argument: expected {expected}, got {actual}")]
     InvalidArgumentType {

--- a/src/extensions/registry.rs
+++ b/src/extensions/registry.rs
@@ -62,7 +62,7 @@
 //!
 //!     fn from_args(args: &ExtensionArgs) -> Result<Self, ExtensionError> {
 //!         let mut extractor = args.extractor();
-//!         let path: &str = extractor.expect_named_arg("path")?;
+//!         let path: &str = extractor.expect_named("path")?;
 //!         extractor.check_exhausted()?;
 //!         Ok(CustomScanConfig {
 //!             path: path.to_string(),
@@ -765,8 +765,8 @@ mod tests {
 
         fn from_args(args: &ExtensionArgs) -> Result<Self, ExtensionError> {
             let mut extractor = args.extractor();
-            let path: String = extractor.expect_named_arg::<&str>("path")?.to_string();
-            let batch_size: i64 = extractor.expect_named_arg("batch_size")?;
+            let path: String = extractor.expect_named::<&str>("path")?.to_string();
+            let batch_size: i64 = extractor.expect_named("batch_size")?;
             extractor.check_exhausted()?;
 
             Ok(TestExtension {
@@ -972,7 +972,7 @@ mod tests {
 
         fn from_args(args: &ExtensionArgs) -> Result<Self, ExtensionError> {
             let mut extractor = args.extractor();
-            let hint: String = extractor.expect_named_arg::<&str>("hint")?.to_string();
+            let hint: String = extractor.expect_named::<&str>("hint")?.to_string();
             extractor.check_exhausted()?;
             Ok(TestEnhancement { hint })
         }

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -54,8 +54,8 @@ function_signature = @{ identifier ~ (":" ~ argument_signature?)? }
 // Expression Components
 // Field reference
 reference = { "$" ~ integer }
-// Literal
-literal = { (float | integer | boolean | string_literal | null) ~ (":" ~ sp ~ type)? }
+// A Substrait literal expression. Its type may be inferred or explicitly ascribed.
+expression_literal = { (float | integer | boolean | string_literal | null) ~ (":" ~ sp ~ type)? }
 
 // -- Components for types and functions
 anchor     = { "#" ~ sp ~ integer }
@@ -185,8 +185,8 @@ cast_expression = { "(" ~ sp ~ expression ~ sp ~ ")" ~ sp ~ "::" ~ sp ~ cast_fai
 
 // Top-level Expression Rule
 // Order matters for PEGs: Since an identifier can be a function call, we put that first.
-// cast_expression must come before literal/function_call since it starts with "("
-expression = { if_then | cast_expression | function_call | reference | literal }
+// cast_expression must come before expression_literal/function_call since it starts with "("
+expression = { if_then | cast_expression | function_call | reference | expression_literal }
 
 // == Extensions ==
 // These rules are for parsing extension declarations, by line.
@@ -366,22 +366,21 @@ cross_relation = { "Cross" ~ "[" ~ reference_list ~ "]" }
 // - ExtensionLeaf:ParquetScan[path='data/*.parquet', schema='auto' => col1:i32, col2:string]
 // - ExtensionSingle:VectorNormalize[method='l2', dimensions=128 => $0, $1]
 // - ExtensionMulti:FuzzyJoin[algorithm='lsh', threshold=0.8 => $0, $1, $2, $3]
-extension_relation = { extension_name ~ "[" ~ sp ~ arguments ~ (sp ~ "=>" ~ sp ~ extension_columns)? ~ "]" }
+extension_relation = { extension_name ~ "[" ~ sp ~ extension_args ~ (sp ~ "=>" ~ sp ~ extension_columns)? ~ "]" }
 
 // Extension name format: ExtensionType:CustomExtensionName
 extension_name = { extension_type ~ ":" ~ name }
 extension_type = { "ExtensionLeaf" | "ExtensionSingle" | "ExtensionMulti" }
 
-arguments = { (empty | (extension_arguments ~ (sp ~ "," ~ sp ~ extension_named_arguments)?) | extension_named_arguments)? }
+extension_args = { (empty | (extension_arguments ~ (sp ~ "," ~ sp ~ extension_named_arguments)?) | extension_named_arguments)? }
 // Positional arguments (expressions, literals, references, enums, tuples)
 extension_arguments = { extension_argument ~ (sp ~ "," ~ sp ~ extension_argument)* }
 
-// Untyped scalar extension literals render independently of expression literal
-// verbosity. Typed literals (for example, 2:i16 or '2024-01-01':date) fall
-// through to expression parsing so their Substrait type information is
-// preserved. Bare null is an untyped extension value; typed null falls
-// through to expression parsing for the same reason as other typed literals.
-untyped_literal = { (float | integer | boolean | string_literal | null) ~ !(":") }
+// Parameter literals are direct scalar values without type ascriptions.
+// Ascribed literals (for example, 2:i16 or '2024-01-01':date) fall through to
+// expression parsing so their Substrait type information is preserved. Bare
+// null is a parameter value; ascribed null falls through to expression parsing.
+parameter_literal = { (float | integer | boolean | string_literal | null) ~ !(":") }
 
 // Tuples follow the Python/Rust trailing-comma convention to disambiguate from parenthesised
 // expressions.
@@ -395,7 +394,7 @@ tuple = {
               ~ (sp ~ "," ~ sp ~ extension_argument)+
               ~ (sp ~ ",")? ~ sp ~ ")"
         }
-extension_argument  = { enum_value | untyped_literal | reference | expression | tuple }
+extension_argument  = { enum_value | parameter_literal | reference | expression | tuple }
 
 // Named arguments (name=value pairs)
 extension_named_arguments = { extension_named_argument ~ (sp ~ "," ~ sp ~ extension_named_argument)* }
@@ -411,5 +410,5 @@ extension_column  = { named_column | reference | expression }
 // - + Enh:PartitionHint[&HASH, count=8]
 // - + Opt:SomeOptimization[threshold=100, mode='fast']
 // - + Ext:BlobStoreRead['path/to/file']
-addendum      = { "+" ~ sp ~ addendum_type ~ ":" ~ name ~ "[" ~ arguments ~ "]" }
+addendum      = { "+" ~ sp ~ addendum_type ~ ":" ~ name ~ "[" ~ extension_args ~ "]" }
 addendum_type = { "Enh" | "Opt" | "Ext" }

--- a/src/parser/expression_grammar.pest
+++ b/src/parser/expression_grammar.pest
@@ -379,8 +379,9 @@ extension_arguments = { extension_argument ~ (sp ~ "," ~ sp ~ extension_argument
 // Untyped scalar extension literals render independently of expression literal
 // verbosity. Typed literals (for example, 2:i16 or '2024-01-01':date) fall
 // through to expression parsing so their Substrait type information is
-// preserved.
-untyped_literal = { (float | integer | boolean | string_literal) ~ !(":") }
+// preserved. Bare null is an untyped extension value; typed null falls
+// through to expression parsing for the same reason as other typed literals.
+untyped_literal = { (float | integer | boolean | string_literal | null) ~ !(":") }
 
 // Tuples follow the Python/Rust trailing-comma convention to disambiguate from parenthesised
 // expressions.

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -535,7 +535,7 @@ fn parse_time_to_precision_units(
 
 impl ScopedParsePair for Literal {
     fn rule() -> Rule {
-        Rule::literal
+        Rule::expression_literal
     }
 
     fn message() -> &'static str {
@@ -753,7 +753,7 @@ impl ScopedParsePair for Expression {
         assert_eq!(pair.as_rule(), Self::rule());
         let inner = unwrap_single_pair(pair);
         match inner.as_rule() {
-            Rule::literal => Ok(Expression {
+            Rule::expression_literal => Ok(Expression {
                 rex_type: Some(RexType::Literal(Literal::parse_pair(extensions, inner)?)),
             }),
             Rule::function_call => Ok(Expression {
@@ -777,7 +777,7 @@ impl ScopedParsePair for Expression {
                 )?))),
             }),
             _ => unreachable!(
-                "Grammar guarantees expression can only be literal, function_call, reference, if_then, or cast_expression, got: {:?}",
+                "Grammar guarantees expression can only be expression_literal, function_call, reference, if_then, or cast_expression, got: {:?}",
                 inner.as_rule()
             ),
         }
@@ -1065,7 +1065,7 @@ mod tests {
     #[test]
     fn test_parse_float_literal_with_fp32_type() {
         let extensions = SimpleExtensions::default();
-        let pair = parse_exact(Rule::literal, "3.82:fp32");
+        let pair = parse_exact(Rule::expression_literal, "3.82:fp32");
         let result = Literal::parse_pair(&extensions, pair).unwrap();
 
         match result.literal_type {
@@ -1077,7 +1077,7 @@ mod tests {
     #[test]
     fn test_parse_date_literal() {
         let extensions = SimpleExtensions::default();
-        let pair = parse_exact(Rule::literal, "'2023-12-25':date");
+        let pair = parse_exact(Rule::expression_literal, "'2023-12-25':date");
         let result = Literal::parse_pair(&extensions, pair).unwrap();
 
         match result.literal_type {
@@ -1096,7 +1096,7 @@ mod tests {
     #[test]
     fn test_parse_time_literal() {
         let extensions = SimpleExtensions::default();
-        let pair = parse_exact(Rule::literal, "'14:30:45':time");
+        let pair = parse_exact(Rule::expression_literal, "'14:30:45':time");
         let result = Literal::parse_pair(&extensions, pair).unwrap();
 
         match result.literal_type {
@@ -1113,7 +1113,7 @@ mod tests {
     #[test]
     fn test_parse_timestamp_literal_with_t() {
         let extensions = SimpleExtensions::default();
-        let pair = parse_exact(Rule::literal, "'2023-01-01T12:00:00':timestamp");
+        let pair = parse_exact(Rule::expression_literal, "'2023-01-01T12:00:00':timestamp");
         let result = Literal::parse_pair(&extensions, pair).unwrap();
 
         match result.literal_type {
@@ -1134,7 +1134,7 @@ mod tests {
     #[test]
     fn test_parse_timestamp_literal_with_space() {
         let extensions = SimpleExtensions::default();
-        let pair = parse_exact(Rule::literal, "'2023-01-01 12:00:00':timestamp");
+        let pair = parse_exact(Rule::expression_literal, "'2023-01-01 12:00:00':timestamp");
         let result = Literal::parse_pair(&extensions, pair).unwrap();
 
         match result.literal_type {
@@ -1156,7 +1156,7 @@ mod tests {
     fn test_parse_precision_timestamp_literal() {
         let extensions = SimpleExtensions::default();
         let pair = parse_exact(
-            Rule::literal,
+            Rule::expression_literal,
             "'2023-01-01T12:00:00.123456789':precisiontimestamp<9>",
         );
         let result = Literal::parse_pair(&extensions, pair).unwrap();
@@ -1181,7 +1181,7 @@ mod tests {
     fn test_parse_precision_timestamp_tz_literal_nullable() {
         let extensions = SimpleExtensions::default();
         let pair = parse_exact(
-            Rule::literal,
+            Rule::expression_literal,
             "'2023-01-01T12:00:00.123':precisiontimestamptz?<3>",
         );
         let result = Literal::parse_pair(&extensions, pair).unwrap();
@@ -1202,7 +1202,10 @@ mod tests {
     #[test]
     fn test_parse_precision_time_literal() {
         let extensions = SimpleExtensions::default();
-        let pair = parse_exact(Rule::literal, "'14:30:45.123456':precisiontime<6>");
+        let pair = parse_exact(
+            Rule::expression_literal,
+            "'14:30:45.123456':precisiontime<6>",
+        );
         let result = Literal::parse_pair(&extensions, pair).unwrap();
 
         match result.literal_type {
@@ -1222,7 +1225,7 @@ mod tests {
     fn test_parse_precision_timestamp_literal_precision_12_unsupported() {
         let extensions = SimpleExtensions::default();
         let pair = parse_exact(
-            Rule::literal,
+            Rule::expression_literal,
             "'2023-01-01T12:00:00':precisiontimestamp<12>",
         );
         let err = Literal::parse_pair(&extensions, pair).unwrap_err();
@@ -1233,7 +1236,10 @@ mod tests {
     fn test_parse_precision_timestamp_literal_invalid_precision() {
         let extensions = SimpleExtensions::default();
         // 5 isn't a recognized precision for precisiontimestamp, so this should error.
-        let pair = parse_exact(Rule::literal, "'2023-01-01T12:00:00':precisiontimestamp<5>");
+        let pair = parse_exact(
+            Rule::expression_literal,
+            "'2023-01-01T12:00:00':precisiontimestamp<5>",
+        );
         let err = Literal::parse_pair(&extensions, pair).unwrap_err();
         assert!(err.to_string().contains("Invalid precision 5"));
     }
@@ -1242,7 +1248,7 @@ mod tests {
     fn test_parse_precision_timestamp_literal_nullable() {
         let extensions = SimpleExtensions::default();
         let pair = parse_exact(
-            Rule::literal,
+            Rule::expression_literal,
             "'2023-01-01T12:00:00.123456789':precisiontimestamp?<9>",
         );
         let result = Literal::parse_pair(&extensions, pair).unwrap();
@@ -1252,7 +1258,10 @@ mod tests {
     #[test]
     fn test_parse_precision_time_literal_nullable() {
         let extensions = SimpleExtensions::default();
-        let pair = parse_exact(Rule::literal, "'14:30:45.123456':precisiontime?<6>");
+        let pair = parse_exact(
+            Rule::expression_literal,
+            "'14:30:45.123456':precisiontime?<6>",
+        );
         let result = Literal::parse_pair(&extensions, pair).unwrap();
         assert!(result.nullable);
     }
@@ -1263,7 +1272,7 @@ mod tests {
         // precisiontimestamp<0> declares second resolution, but the value has a
         // fractional second; this must error rather than silently drop the ".999".
         let pair = parse_exact(
-            Rule::literal,
+            Rule::expression_literal,
             "'2023-01-01T12:00:00.999':precisiontimestamp<0>",
         );
         let err = Literal::parse_pair(&extensions, pair).unwrap_err();
@@ -1275,7 +1284,10 @@ mod tests {
         let extensions = SimpleExtensions::default();
         // precisiontime<3> declares millisecond resolution, but the value has
         // more fractional digits than that; this must error, not truncate.
-        let pair = parse_exact(Rule::literal, "'14:30:45.123456':precisiontime<3>");
+        let pair = parse_exact(
+            Rule::expression_literal,
+            "'14:30:45.123456':precisiontime<3>",
+        );
         let err = Literal::parse_pair(&extensions, pair).unwrap_err();
         assert!(err.to_string().contains("fractional"));
     }
@@ -1285,7 +1297,10 @@ mod tests {
         let extensions = SimpleExtensions::default();
         // 2300 is past chrono's ~292-year-around-1970 nanosecond range,
         // so this must error rather than silently parsing to some truncated or zeroed value.
-        let pair = parse_exact(Rule::literal, "'2300-01-01T00:00:00':precisiontimestamp<9>");
+        let pair = parse_exact(
+            Rule::expression_literal,
+            "'2300-01-01T00:00:00':precisiontimestamp<9>",
+        );
         let err = Literal::parse_pair(&extensions, pair).unwrap_err();
         assert!(err.to_string().contains("out of range"));
     }

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -294,8 +294,8 @@ impl ScopedParsePair for ExtensionValue {
                 let field_index = FieldIndex::parse_pair(inner);
                 ExtensionValue::from(Reference(field_index.0))
             }
-            Rule::untyped_literal => {
-                // Literal can contain integer, float, boolean, string_literal, or null.
+            Rule::parameter_literal => {
+                // Parameter literals can contain integer, float, boolean, string, or null.
                 let value_pair = unwrap_single_pair(inner);
                 match value_pair.as_rule() {
                     Rule::string_literal => ExtensionValue::String(unescape_string(value_pair)),
@@ -308,7 +308,7 @@ impl ScopedParsePair for ExtensionValue {
                     Rule::boolean => ExtensionValue::Boolean(value_pair.as_str() == "true"),
                     Rule::null => ExtensionValue::Null,
                     _ => panic!(
-                        "Unexpected extension scalar literal type: {:?}",
+                        "Unexpected extension parameter literal type: {:?}",
                         value_pair.as_rule()
                     ),
                 }
@@ -491,8 +491,8 @@ impl ScopedParsePair for ExtensionInvocation {
         // Parse optional arguments
         let ext_arguments = iter.next().unwrap();
         match ext_arguments.as_rule() {
-            Rule::arguments => {
-                arguments_rule_parsing(extensions, ext_arguments, &mut args)?;
+            Rule::extension_args => {
+                extension_args_rule_parsing(extensions, ext_arguments, &mut args)?;
             }
             r => unreachable!("Unexpected rule in ExtensionArgs: {:?}", r),
         }
@@ -559,13 +559,13 @@ impl ScopedParsePair for AddendumInvocation {
         let name_pair = iter.next().unwrap();
         let name = Name::parse_pair(name_pair).0.to_string();
 
-        // Remaining token: arguments — grammar guarantees it is always present.
+        // Remaining token: extension_args — grammar guarantees it is always present.
         let mut args = ExtensionArgs::default();
 
         let arguments_pair = iter.next().unwrap();
         match arguments_pair.as_rule() {
-            Rule::arguments => {
-                arguments_rule_parsing(extensions, arguments_pair, &mut args)?;
+            Rule::extension_args => {
+                extension_args_rule_parsing(extensions, arguments_pair, &mut args)?;
             }
             r => unreachable!("Unexpected rule in AddendumInvocation args: {r:?}"),
         }
@@ -574,7 +574,7 @@ impl ScopedParsePair for AddendumInvocation {
     }
 }
 
-fn arguments_rule_parsing(
+fn extension_args_rule_parsing(
     extensions: &SimpleExtensions,
     inner_pair: Pair<'_, Rule>,
     args: &mut ExtensionArgs,
@@ -994,7 +994,7 @@ Functions:
     }
 
     #[test]
-    fn test_extension_scalar_literals_stay_scalar_in_verbose_output() {
+    fn test_extension_parameter_literals_stay_scalar_in_verbose_output() {
         let ctx = TestContext::new().with_options(OutputOptions::verbose());
 
         let scalar = ExtensionValue::from(42_i64);

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -295,7 +295,7 @@ impl ScopedParsePair for ExtensionValue {
                 ExtensionValue::from(Reference(field_index.0))
             }
             Rule::untyped_literal => {
-                // Literal can contain integer, float, boolean, or string_literal
+                // Literal can contain integer, float, boolean, string_literal, or null.
                 let value_pair = unwrap_single_pair(inner);
                 match value_pair.as_rule() {
                     Rule::string_literal => ExtensionValue::String(unescape_string(value_pair)),
@@ -306,6 +306,7 @@ impl ScopedParsePair for ExtensionValue {
                         ExtensionValue::Float(value_pair.as_str().parse::<f64>().unwrap())
                     }
                     Rule::boolean => ExtensionValue::Boolean(value_pair.as_str() == "true"),
+                    Rule::null => ExtensionValue::Null,
                     _ => panic!(
                         "Unexpected extension scalar literal type: {:?}",
                         value_pair.as_rule()
@@ -1004,12 +1005,19 @@ Functions:
     }
 
     #[test]
+    fn test_untyped_null_extension_literal_roundtrips() {
+        let value = parse_extension_value("null");
+        assert!(matches!(value, ExtensionValue::Null));
+        assert_eq!(TestContext::new().textify_no_errors(&value), "null");
+    }
+
+    #[test]
     fn test_typed_extension_literal_parses_as_expression() {
-        let value = parse_extension_value("42:i16");
+        let value = parse_extension_value("null:i64?");
         assert!(i64::try_from(&value).is_err());
 
         let expr = Expr::try_from(&value).unwrap();
-        assert_eq!(ctx_text(&expr), "42:i16");
+        assert_eq!(ctx_text(&expr), "null:i64?");
     }
 
     fn ctx_text(value: &Expr) -> String {

--- a/src/textify/extensions.rs
+++ b/src/textify/extensions.rs
@@ -7,6 +7,7 @@
 
 use std::fmt;
 
+use crate::FormatError;
 use crate::extensions::{Expr, ExtensionArgs, ExtensionColumn, ExtensionValue, TupleValue};
 use crate::textify::foundation::{Scope, Textify};
 use crate::textify::types::{Name, escaped};
@@ -40,6 +41,9 @@ impl Textify for ExtensionValue {
             ExtensionValue::Float(f) => write!(w, "{f}"),
             ExtensionValue::Boolean(b) => write!(w, "{b}"),
             ExtensionValue::Null => write!(w, "null"),
+            ExtensionValue::Error(error) => {
+                write!(w, "{}", ctx.failure(FormatError::Extension(error.clone())))
+            }
             ExtensionValue::Expr(expr) => expr.textify(ctx, w),
             ExtensionValue::Enum(e) => write!(w, "&{e}"),
             ExtensionValue::Tuple(tv) => tv.textify(ctx, w),
@@ -109,5 +113,28 @@ impl Textify for ExtensionArgs {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extensions::ExtensionError;
+    use crate::fixtures::TestContext;
+
+    #[test]
+    fn error_value_renders_failure_and_continues() {
+        let mut args = ExtensionArgs::default();
+        args.insert("bad", ExtensionError::Custom("malformed field".to_string()));
+        args.insert("good", "continues");
+
+        let (rendered, errors) = TestContext::new().textify(&args);
+
+        assert_eq!(rendered, "bad=!{extension}, good='continues'");
+        assert!(matches!(
+            errors.0.as_slice(),
+            [FormatError::Extension(ExtensionError::Custom(message))]
+                if message == "malformed field"
+        ));
     }
 }

--- a/src/textify/extensions.rs
+++ b/src/textify/extensions.rs
@@ -39,6 +39,7 @@ impl Textify for ExtensionValue {
             ExtensionValue::Integer(i) => write!(w, "{i}"),
             ExtensionValue::Float(f) => write!(w, "{f}"),
             ExtensionValue::Boolean(b) => write!(w, "{b}"),
+            ExtensionValue::Null => write!(w, "null"),
             ExtensionValue::Expr(expr) => expr.textify(ctx, w),
             ExtensionValue::Enum(e) => write!(w, "&{e}"),
             ExtensionValue::Tuple(tv) => tv.textify(ctx, w),

--- a/tests/adv_extension_roundtrip.rs
+++ b/tests/adv_extension_roundtrip.rs
@@ -197,7 +197,7 @@ mod opt_fixture {
 
         fn from_args(args: &ExtensionArgs) -> Result<Self, ExtensionError> {
             let mut extractor = args.extractor();
-            let hint: String = extractor.expect_named_arg::<&str>("hint")?.to_owned();
+            let hint: String = extractor.expect_named::<&str>("hint")?.to_owned();
             extractor.check_exhausted()?;
             Ok(PlanHint { hint })
         }

--- a/tests/extension_roundtrip.rs
+++ b/tests/extension_roundtrip.rs
@@ -51,9 +51,9 @@ impl Explainable for UserTableConfig {
 
     fn from_args(args: &ExtensionArgs) -> Result<Self, ExtensionError> {
         let mut extractor = args.extractor();
-        let table_name: &str = extractor.expect_named_arg("name")?;
-        let version: i64 = extractor.get_named_or("version", 1)?;
-        let is_temporary: bool = extractor.get_named_or("temp", false)?;
+        let table_name: &str = extractor.expect_named("name")?;
+        let version: i64 = extractor.get_named("version")?.unwrap_or(1);
+        let is_temporary: bool = extractor.get_named("temp")?.unwrap_or(false);
 
         extractor.check_exhausted()?;
 
@@ -163,7 +163,7 @@ impl Explainable for FilterConfig {
 
     fn from_args(args: &ExtensionArgs) -> Result<Self, ExtensionError> {
         let mut extractor = args.extractor();
-        let expression: String = extractor.expect_named_arg::<&str>("expr")?.to_string();
+        let expression: String = extractor.expect_named::<&str>("expr")?.to_string();
         extractor.check_exhausted()?;
 
         Ok(FilterConfig { expression })
@@ -232,8 +232,8 @@ impl Explainable for LiteralConfig {
 
     fn from_args(args: &ExtensionArgs) -> Result<Self, ExtensionError> {
         let mut extractor = args.extractor();
-        let path: String = extractor.expect_named_arg::<&str>("path")?.to_string();
-        let big: i64 = extractor.expect_named_arg("big")?;
+        let path: String = extractor.expect_named::<&str>("path")?.to_string();
+        let big: i64 = extractor.expect_named("big")?;
 
         // Manually handle ratio to support both Integer and Float types
         let ratio = match extractor.get_named_arg("ratio") {
@@ -252,7 +252,7 @@ impl Explainable for LiteralConfig {
             }
         };
 
-        let enabled: bool = extractor.expect_named_arg("enabled")?;
+        let enabled: bool = extractor.expect_named("enabled")?;
 
         extractor.check_exhausted()?;
 

--- a/tests/extension_table.rs
+++ b/tests/extension_table.rs
@@ -34,7 +34,7 @@ impl Explainable for UserTable {
 
     fn from_args(args: &ExtensionArgs) -> Result<Self, ExtensionError> {
         let mut extractor = args.extractor();
-        let name: &str = extractor.expect_named_arg("name")?;
+        let name: &str = extractor.expect_named("name")?;
 
         extractor.check_exhausted()?;
 

--- a/tests/json_parsing.rs
+++ b/tests/json_parsing.rs
@@ -40,8 +40,8 @@ impl Explainable for ParquetScanConfig {
 
     fn from_args(args: &ExtensionArgs) -> Result<Self, ExtensionError> {
         let mut x = args.extractor();
-        let path: &str = x.expect_named_arg("path")?;
-        let batch_size: i64 = x.get_named_or("batch_size", 1024)?;
+        let path: &str = x.expect_named("path")?;
+        let batch_size: i64 = x.get_named("batch_size")?.unwrap_or(1024);
         x.check_exhausted()?;
         Ok(Self {
             path: path.to_string(),


### PR DESCRIPTION
## Description

This changes the `ExtensionArgs` interface to follow standard `Option` usage / naming more closely, for ease of use:

```rust
fn from_args(args: &ExtensionArgs) -> Result<Self, ExtensionError> {
    let mut args = args.extractor();
    let path = args.expect_named::<&str>("path")?.to_owned();
    let batch_size = args.get_named::<i64>("batch_size")?.unwrap_or(1024);
    args.check_exhausted()?;
    Ok(Self { path, batch_size })
}
```

Also updates to error handling for extension errors, the addition of `ExtensionValue::Null`, and some `GRAMMAR.md` updates

## Changes

- Replaces `get_named_or` with `get_named::<T>() -> Result<Option<T>, ExtensionError>` and renames `expect_named_arg` to `expect_named`.
- Includes the argument name in conversion errors, for example `Invalid named argument 'count': ...`.
- Adds `ExtensionValue::Null` for a present, untyped `null` extension value. Typed nulls such as `null:i64?` remain expressions.
- Adds `ExtensionValue::Error`, allowing one malformed field to render as a local failure token without losing later arguments.
- Added `Fetch` and `Cast` to `GRAMMAR.md`, since they weren't there...

## API impact

This is a breaking public API change:

- `get_named_or` is removed (in favor of `get_named(...).unwrap_or(...)`, more standard `Option` naming) and `expect_named_arg` is renamed to `expect_named`.
- `ExtensionValue` and `ExtensionValueKind` have new `Null` and `Error` variants, which affects exhaustive matches.