### PR TITLE
feat: added support for setting common defaults explicitly

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -569,6 +569,13 @@ RelationName[arguments, named_arguments => columns]
 
 The exact structure varies by relation type, but all follow this basic pattern.
 
+#### Emit
+
+Every relation this crate parses carries an explicit `RelCommon.emit_kind`:
+`Direct` when the columns pass through unchanged, `Emit` when the text gives a
+remap. `emit_kind` is a protobuf `oneof`, so leaving it unset has no default a
+consumer can rely on — it would have to infer `Direct`.
+
 ### Arguments
 
 Arguments in relations can be literals, expressions, enums, or tuples thereof.
@@ -636,7 +643,7 @@ direct_output := "+>" named_column_list ("|>" reference_list)?
 - `named_column := name ":" type` - column name with type annotation
 - `named_column_list := (named_column ("," named_column)*)?` - the list of columns and their types to be read from the table `table_name`.
   - `=>` is used to mean implicit column ordering; for `Read`, this translates to `Direct` column ordering.
-  - When used with `+>` and no `|>`, the `named_column`s are in the expected order of the table, and `Direct` emit is used.
+  - `+>` with no `|>` also means `Direct`, and is accepted as an equivalent spelling of `=>`. The canonical form is `=>`.
   - When used with `+> … |>`, the `named_column`s are in the expected order of the table, and the emit order is a Remap specified by `reference_list`.
 
 #### Example
@@ -657,7 +664,7 @@ Root[result2]
 # let plan = Parser::parse(plan_text).unwrap();
 # assert_eq!(plan.relations.len(), 2);
 ```
-Use `+>` when the read's base schema records the direct output domain:
+`+>` with no `|>` is accepted as an equivalent of `=>`, and prints back as `=>`:
 
 ```rust
 # use substrait_explain::Parser;

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -19,6 +19,7 @@ use crate::extensions::{
     TupleValue,
 };
 use crate::parser::expressions::{FieldIndex, Name};
+use crate::parser::relations::direct_common;
 use crate::parser::structural::IndentedLine;
 use crate::textify::expressions::Reference;
 
@@ -420,19 +421,19 @@ impl ExtensionRelationKind {
     pub(crate) fn create_rel(self, detail: Option<Any>, children: Vec<Rel>) -> Rel {
         let rel_type = match self {
             ExtensionRelationKind::Leaf => RelType::ExtensionLeaf(ExtensionLeafRel {
-                common: None,
+                common: Some(direct_common()),
                 detail: detail.map(Into::into),
             }),
             ExtensionRelationKind::Single => {
                 let input = children.into_iter().next();
                 RelType::ExtensionSingle(Box::new(ExtensionSingleRel {
-                    common: None,
+                    common: Some(direct_common()),
                     detail: detail.map(Into::into),
                     input: input.map(Box::new),
                 }))
             }
             ExtensionRelationKind::Multi => RelType::ExtensionMulti(ExtensionMultiRel {
-                common: None,
+                common: Some(direct_common()),
                 detail: detail.map(Into::into),
                 inputs: children,
             }),

--- a/src/parser/relations.rs
+++ b/src/parser/relations.rs
@@ -226,6 +226,14 @@ fn make_emit(output_mapping: Vec<i32>, direct_output_count: usize) -> EmitKind {
     }
 }
 
+/// A [`RelCommon`] with an explicit `Direct` emit.
+pub(crate) fn direct_common() -> RelCommon {
+    RelCommon {
+        emit_kind: Some(EmitKind::Direct(Direct {})),
+        ..Default::default()
+    }
+}
+
 /// Parse a reference list into an emit and output field count.
 fn parse_emit(reference_list: Pair<Rule>, direct_output_count: usize) -> (EmitKind, usize) {
     let output_mapping = parse_output_mapping(reference_list);
@@ -246,7 +254,7 @@ fn parse_output(
             let columns = iter.parse_next_scoped::<NamedColumnList>(extensions)?.0;
             iter.done();
             let output_count = columns.len();
-            Ok((columns, None, output_count))
+            Ok((columns, Some(direct_common()), output_count))
         }
         Rule::direct_output => {
             let mut iter = RuleIter::from(output.into_inner());
@@ -443,6 +451,7 @@ impl RelationParsePair for VirtualReadRel {
         let output_count = columns.len();
         Ok((
             VirtualReadRel(ReadRel {
+                common: Some(direct_common()),
                 base_schema: Some(build_named_struct(columns)),
                 read_type: Some(read_rel::ReadType::VirtualTable(read_rel::VirtualTable {
                     expressions: rows,
@@ -499,6 +508,7 @@ impl ExtensionReadRel {
 
         let output_count = columns.len();
         let rel = ExtensionReadRel(ReadRel {
+            common: Some(direct_common()),
             base_schema: Some(build_named_struct(columns)),
             read_type: Some(read_rel::ReadType::ExtensionTable(
                 read_rel::ExtensionTable {
@@ -1479,7 +1489,7 @@ mod tests {
             .unwrap()
             .types;
         assert_eq!(columns.len(), 2);
-        assert!(read.common.is_none());
+        assert_eq!(read.common, Some(direct_common()));
     }
 
     #[test]

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -379,10 +379,11 @@ impl<'a> Relation<'a> {
             Some(ReadType::NamedTable(table)) => {
                 let table_name = Value::TableName(table.names.iter().map(|n| Name(n)).collect());
                 // XXX: For `ReadRel`s, we use `=>` unless there is a remap to
-                // show, in which case we use `+> … |>`. `Direct` and an absent `common` render the same. 
-                // However, we ignore the `OutputOptions::show_emit` option, and
-                // we haven't yet supported other operators; at some point, we
-                // should figure out our policy here and clean this up.
+                // show, in which case we use `+> … |>`. `Direct` and an absent
+                // `common` render the same. However, we ignore the
+                // `OutputOptions::show_emit` option, and we haven't yet
+                // supported other operators; at some point, we should figure
+                // out our policy here and clean this up.
                 let output_syntax = match emit {
                     Some(EmitKind::Emit(_)) => OutputSyntax::Explicit,
                     Some(EmitKind::Direct(_)) | None => OutputSyntax::Implicit,

--- a/src/textify/rels.rs
+++ b/src/textify/rels.rs
@@ -378,16 +378,14 @@ impl<'a> Relation<'a> {
         match &rel.read_type {
             Some(ReadType::NamedTable(table)) => {
                 let table_name = Value::TableName(table.names.iter().map(|n| Name(n)).collect());
-                // XXX: For `ReadRel`s, we use `=>` if emit is None, `+>` if
-                // `emit` is `Some(Direct)`, and `+> … |>` if emit is
-                // `Some(Remap(…))`. However, we ignore the
-                // `OutputOptions::show_emit` option, and we haven't yet
-                // supported other operators; at some point, we should figure
-                // out our policy here and clean this up.
-                let output_syntax = if emit.is_some() {
-                    OutputSyntax::Explicit
-                } else {
-                    OutputSyntax::Implicit
+                // XXX: For `ReadRel`s, we use `=>` unless there is a remap to
+                // show, in which case we use `+> … |>`. `Direct` and an absent `common` render the same. 
+                // However, we ignore the `OutputOptions::show_emit` option, and
+                // we haven't yet supported other operators; at some point, we
+                // should figure out our policy here and clean this up.
+                let output_syntax = match emit {
+                    Some(EmitKind::Emit(_)) => OutputSyntax::Explicit,
+                    Some(EmitKind::Direct(_)) | None => OutputSyntax::Implicit,
                 };
                 Relation {
                     name: Cow::Borrowed("Read"),

--- a/tests/json_parsing/plan_pbjson.json
+++ b/tests/json_parsing/plan_pbjson.json
@@ -4,6 +4,9 @@
       "root": {
         "input": {
           "extensionLeaf": {
+            "common": {
+              "direct": {}
+            },
             "detail": {
               "typeUrl": "type.googleapis.com/example.ParquetScanConfig",
               "value": "ChJkYXRhL3NhbGVzLnBhcnF1ZXQQgBA="

--- a/tests/plan_roundtrip.rs
+++ b/tests/plan_roundtrip.rs
@@ -21,13 +21,18 @@ Root[c, d]
     roundtrip_plan(plan);
 }
 
+/// `=>` and a `+>` with no remap both mean a `Direct` emit, so they produce the
+/// same plan and print as `=>`.
 #[test]
 fn test_read_explicit_direct_roundtrip() {
-    let plan = r#"=== Plan
+    let canonical = r#"=== Plan
+Root[a, b]
+  Read[my.table => a:i32, b:string?]"#;
+    let equivalent = r#"=== Plan
 Root[a, b]
   Read[my.table +> a:i32, b:string?]"#;
 
-    roundtrip_plan(plan);
+    assert_roundtrip_canonical(canonical, equivalent);
 }
 
 #[test]


### PR DESCRIPTION
## Description

Every relation `substrait-explain` produces now carries an explicit `RelCommon.emit_kind`, rather than leaving `common` unset when the emit is a plain pass-through.

`emit_kind` is a protobuf `oneof`, so an unset one has no default value on the wire. Unlike a scalar enum, absence doesn't decode to a zero value, so a consumer reading a relation without it has to infer/guess that the relation passes its columns through unchanged, and writing `direct: {}` eliminates any risk out of the plan.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Example update
- [ ] Other (please describe)

## Testing

- [x] Added tests for new functionality
- [x] All existing tests pass
- [x] Ran examples to verify behavior

## Checklist

- [x] Code follows Rust conventions
- [x] Documentation updated if needed
- [ ] No breaking changes (or breaking changes documented)
- [x] Pre-commit hooks pass
