### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0](https://github.com/DataDog/substrait-explain/compare/v0.8.0...v0.9.0) - 2026-08-17
+
+### Features
+
+- *(extensions)* support homogeneous tuple arguments ([#208](https://github.com/DataDog/substrait-explain/pull/208))
+- Support expressions inside Sort relations
+- interval day to second support ([#183](https://github.com/DataDog/substrait-explain/pull/183))
+- *(extensions)* [**breaking**] improve argument handling ([#203](https://github.com/DataDog/substrait-explain/pull/203))
+- added support for setting common defaults explicitly ([#207](https://github.com/DataDog/substrait-explain/pull/207))
+
+### Refactoring
+
+- *(extensions)* [**breaking**] centralize argument extraction ([#205](https://github.com/DataDog/substrait-explain/pull/205))
+- *(parser)* extract shared components ([#187](https://github.com/DataDog/substrait-explain/pull/187))
+
 ## [0.8.0](https://github.com/DataDog/substrait-explain/compare/v0.7.0...v0.8.0) - 2026-08-10
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "substrait-explain"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrait-explain"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 authors = [
     "Wendell Smith <wendell.smith@datadoghq.com>",


### PR DESCRIPTION



## 🤖 New release

* `substrait-explain`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)



<details><summary><h3>Changelog</h3></summary><p>

<blockquote>

## [0.9.0](https://github.com/DataDog/substrait-explain/compare/v0.8.0...v0.9.0) - 2026-08-17

### Features

- *(extensions)* support homogeneous tuple arguments ([#208](https://github.com/DataDog/substrait-explain/pull/208))
- Support expressions inside Sort relations
- interval day to second support ([#183](https://github.com/DataDog/substrait-explain/pull/183))
- *(extensions)* [**breaking**] improve argument handling ([#203](https://github.com/DataDog/substrait-explain/pull/203))
- added support for setting common defaults explicitly ([#207](https://github.com/DataDog/substrait-explain/pull/207))

### Refactoring

- *(extensions)* [**breaking**] centralize argument extraction ([#205](https://github.com/DataDog/substrait-explain/pull/205))
- *(parser)* extract shared components ([#187](https://github.com/DataDog/substrait-explain/pull/187))
</blockquote>


</p></details>


<details><summary><h3>⚠ <code>breaking changes report</h3></summary><p>

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant ExtensionValueKind::Reference 4 -> 6 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpC2bqtg/release-pr.rehZo2/src/extensions/args.rs:433
  variant ExtensionValueKind::Enum 5 -> 7 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpC2bqtg/release-pr.rehZo2/src/extensions/args.rs:434
  variant ExtensionValueKind::Tuple 6 -> 8 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpC2bqtg/release-pr.rehZo2/src/extensions/args.rs:435
  variant ExtensionValueKind::Expression 7 -> 9 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpC2bqtg/release-pr.rehZo2/src/extensions/args.rs:436
  variant ExtensionValueKind::Reference 4 -> 6 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpC2bqtg/release-pr.rehZo2/src/extensions/args.rs:433
  variant ExtensionValueKind::Enum 5 -> 7 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpC2bqtg/release-pr.rehZo2/src/extensions/args.rs:434
  variant ExtensionValueKind::Tuple 6 -> 8 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpC2bqtg/release-pr.rehZo2/src/extensions/args.rs:435
  variant ExtensionValueKind::Expression 7 -> 9 in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpC2bqtg/release-pr.rehZo2/src/extensions/args.rs:436

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_variant_added.ron

Failed in:
  variant ExtensionValue:Null in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpC2bqtg/release-pr.rehZo2/src/extensions/args.rs:405
  variant ExtensionValue:Error in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpC2bqtg/release-pr.rehZo2/src/extensions/args.rs:407
  variant ExtensionValue:Null in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpC2bqtg/release-pr.rehZo2/src/extensions/args.rs:405
  variant ExtensionValue:Error in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpC2bqtg/release-pr.rehZo2/src/extensions/args.rs:407
  variant ExtensionValueKind:Null in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpC2bqtg/release-pr.rehZo2/src/extensions/args.rs:431
  variant ExtensionValueKind:Error in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpC2bqtg/release-pr.rehZo2/src/extensions/args.rs:432
  variant ExtensionValueKind:Null in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpC2bqtg/release-pr.rehZo2/src/extensions/args.rs:431
  variant ExtensionValueKind:Error in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpC2bqtg/release-pr.rehZo2/src/extensions/args.rs:432
  variant ExtensionError:NamedArgumentConversion in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpC2bqtg/release-pr.rehZo2/src/extensions/registry.rs:180
  variant ExtensionError:ArgumentConversion in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpC2bqtg/release-pr.rehZo2/src/extensions/registry.rs:188
  variant ExtensionError:NamedArgumentConversion in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpC2bqtg/release-pr.rehZo2/src/extensions/registry.rs:180
  variant ExtensionError:ArgumentConversion in /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpC2bqtg/release-pr.rehZo2/src/extensions/registry.rs:188

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/inherent_method_missing.ron

Failed in:
  ExtensionArgs::extractor, previously in file /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpxxGIlY/substrait-explain/src/extensions/args.rs:648
  ExtensionArgs::extractor, previously in file /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpxxGIlY/substrait-explain/src/extensions/args.rs:648

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/struct_missing.ron

Failed in:
  struct substrait_explain::extensions::args::ArgsExtractor, previously in file /private/var/folders/sw/bffqcbxd0qqdl1ft5synkq3r0000gp/T/.tmpxxGIlY/substrait-explain/src/extensions/args.rs:208
```

</details>
---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).