### PR TITLE
chore(release): improve release PR descriptions

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -7,6 +7,62 @@
 git_tag_enable = false
 git_release_enable = false
 pr_labels = ["release"]
+# Put the changelog first and keep cargo-semver-checks output collapsed below it.
+pr_body = """
+{% set changes %}
+
+{%- for release in releases %}
+
+{%- if release.title and release.changelog %}{% if releases | length > 1 %}
+
+## `{{ release.package }}`
+
+{% endif %}
+
+<blockquote>
+
+## {{ release.title }}
+
+{{ release.changelog }}
+
+</blockquote>{% endif %}
+
+{% endfor %}
+
+{% endset %}
+
+## 🤖 New release
+
+{% for release in releases %}
+
+* `{{ release.package }}`: {% if release.previous_version and release.previous_version != release.next_version %}{{ release.previous_version }} -> {% endif %}{{ release.next_version }}{% if release.semver_check == "incompatible" %} (⚠ API breaking changes){% elif release.semver_check == "compatible" %} (✓ API compatible changes){% endif %}
+
+{%- endfor %}
+
+{% if changes %}
+
+<details><summary><h3>Changelog</h3></summary><p>
+
+{{ changes }}
+
+</p></details>
+
+{% endif %}
+
+{%- for release in releases %}{% if release.breaking_changes %}
+
+<details><summary><h3>⚠ breaking changes report</h3></summary><p>
+
+```text
+{{ release.breaking_changes }}
+```
+
+</p></details>
+{% endif %}{% endfor %}
+
+---
+This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).
+"""
 
 [[package]]
 name = "substrait-explain"


### PR DESCRIPTION
## Description

This PR customizes the release-plz PR body based on the edited version of #211. Generated release PRs now put the changelog before the cargo-semver-checks report instead of leading with raw compatibility diagnostics.

## Changes

- Keep the package version and API compatibility summary at the top.
- Show the changelog first in a collapsed section.
- Keep the full breaking-changes report available in a separate collapsed section when release-plz detects incompatible changes.
- Retain the release-plz attribution footer.
